### PR TITLE
[ocean][crates] Avoid dynamic mapping for features field which has hundrends of different keys

### DIFF
--- a/grimoire_elk/ocean/crates.py
+++ b/grimoire_elk/ocean/crates.py
@@ -24,12 +24,53 @@
 #
 
 from .elastic import ElasticOcean
+from ..elastic_mapping import Mapping as BaseMapping
+
+
+class Mapping(BaseMapping):
+
+    @staticmethod
+    def get_elastic_mappings(es_major):
+        """Get Elasticsearch mapping.
+
+        Non dynamic discovery of type for:
+            * data.versions_data.versions.features
+
+        :param es_major: major version of Elasticsearch, as string
+        :returns:        dictionary with a key, 'items', with the mapping
+        """
+
+        mapping = '''
+         {
+            "dynamic":true,
+                "properties": {
+                    "data": {
+                        "properties": {
+                            "versions_data": {
+                                "properties": {
+                                    "versions": {
+                                        "properties": {
+                                            "features": {
+                                                "dynamic":false,
+                                                "properties": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+        }
+        '''
+
+        return {"items": mapping}
 
 
 class CratesOcean(ElasticOcean):
     """Confluence Ocean feeder"""
 
-    pass
+    mapping = Mapping
 
     @classmethod
     def get_perceval_params_from_url(cls, url):


### PR DESCRIPTION
This fixes the error

`2018-02-08 16:36:53,032 - grimoire_elk.elk.elastic - ERROR - Failed to insert data to ES: {'reason': 'Limit of total fields [1000] in index [crates_mozilla_171205_1] has been exceeded', 'type': 'illegal_argument_exception'}
`