### PR TITLE
[ocean] Fix mappings to index BugzillaRest data

### DIFF
--- a/grimoire_elk/elk/bugzillarest.py
+++ b/grimoire_elk/elk/bugzillarest.py
@@ -30,6 +30,7 @@ from datetime import datetime
 from dateutil import parser
 
 from .enrich import Enrich, metadata, DEFAULT_PROJECT
+from ..elastic_mapping import Mapping as BaseMapping
 
 from .utils import get_time_diff_days
 
@@ -37,7 +38,37 @@ from .utils import get_time_diff_days
 logger = logging.getLogger(__name__)
 
 
+class Mapping(BaseMapping):
+
+    @staticmethod
+    def get_elastic_mappings(es_major):
+        """Get Elasticsearch mapping.
+
+        :param es_major: major version of Elasticsearch, as string
+        :returns:        dictionary with a key, 'items', with the mapping
+        """
+
+        mapping = """
+        {
+            "properties": {
+               "summary": {
+                   "type": "text",
+                   "index": false
+               },
+               "main_description": {
+                   "type": "text",
+                   "index": false
+               }
+            }
+        }
+        """
+
+        return {"items": mapping}
+
+
 class BugzillaRESTEnrich(Enrich):
+
+    mapping = Mapping
 
     roles = ['assigned_to_detail', 'qa_contact_detail', 'creator_detail']
 

--- a/grimoire_elk/ocean/bugzillarest.py
+++ b/grimoire_elk/ocean/bugzillarest.py
@@ -35,9 +35,6 @@ class Mapping(BaseMapping):
     def get_elastic_mappings(es_major):
         """Get Elasticsearch mapping.
 
-        Non dynamic discovery of type for:
-            * data.comments.text
-
         :param es_major: major version of Elasticsearch, as string
         :returns:        dictionary with a key, 'items', with the mapping
         """
@@ -50,7 +47,32 @@ class Mapping(BaseMapping):
                         "properties": {
                             "comments": {
                                 "dynamic":false,
-                                "properties": {}
+                                "properties": {
+                                    "raw_text": {
+                                        "type": "text",
+                                        "index": false
+                                    },
+                                    "text": {
+                                        "type": "text",
+                                        "index": false
+                                    }
+                                }
+                            },
+                            "attachments": {
+                                "properties": {
+                                    "description" : {
+                                        "type": "text",
+                                        "index": false
+                                    },
+                                    "summary" : {
+                                        "type": "text",
+                                        "index": false
+                                    }
+                                }
+                            },
+                            "summary": {
+                                "type": "text",
+                                "index": false
                             }
                         }
                     }

--- a/tests/data/bugzillarest.json
+++ b/tests/data/bugzillarest.json
@@ -13,15 +13,3780 @@
         },
         "attachments": [
             {
-                "attacher": "bugzilla@factorware.com",
-                "bug_id": 1273442,
-                "content_type": "application/x-zip-compressed",
-                "creation_time": "2014-05-01T06:16:04Z",
-                "creator": "bugzilla@factorware.com",
-                "description": "sample.zip",
-                "file_name": "sample.zip",
+                "attacher": "shuang",
+                "bug_id": 1267941,
+                "content_type": "text/plain",
+                "creation_time": "2016-05-04T13:24:06Z",
+                "creator": "shuang",
+                "description": "Implement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate()",
+                "file_name": "bug1267941.patch",
                 "flags": [],
-                "id": 8415766,
+                "id": 8748628,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-05-04T13:51:16Z",
+                "size": 12263,
+                "summary": "Implement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage"
+            },
+            {
+                "attacher": "shuang",
+                "bug_id": 1267941,
+                "content_type": "text/plain",
+                "creation_time": "2016-06-02T08:03:35Z",
+                "creator": "shuang",
+                "description": "bug1267941.patch",
+                "file_name": "bug1267941.patch",
+                "flags": [],
+                "id": 8759067,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-06-02T08:03:51Z",
+                "size": 22554,
+                "summary": "bug1267941.patch"
+            },
+            {
+                "attacher": "shuang",
+                "bug_id": 1267941,
+                "content_type": "text/plain",
+                "creation_time": "2016-06-03T10:55:31Z",
+                "creator": "shuang",
+                "description": "bug1267941.patch (WIP)",
+                "file_name": "bug1267941.patch",
+                "flags": [],
+                "id": 8759609,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-06-06T09:32:36Z",
+                "size": 18134,
+                "summary": "bug1267941.patch (WIP)"
+            },
+            {
+                "attacher": "shuang",
+                "bug_id": 1267941,
+                "content_type": "text/plain",
+                "creation_time": "2016-06-06T09:33:01Z",
+                "creator": "shuang",
+                "description": "bug1267941.patch (WIP)",
+                "file_name": "bug1267941.patch",
+                "flags": [],
+                "id": 8760181,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-06-08T09:12:46Z",
+                "size": 16190,
+                "summary": "bug1267941.patch (WIP)"
+            },
+            {
+                "attacher": "shuang",
+                "bug_id": 1267941,
+                "content_type": "text/plain",
+                "creation_time": "2016-06-08T09:12:27Z",
+                "creator": "shuang",
+                "description": "bug1267941.patch (WIP)",
+                "file_name": "bug1267941.patch",
+                "flags": [],
+                "id": 8761103,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-06-14T13:13:42Z",
+                "size": 20879,
+                "summary": "bug1267941.patch (WIP)"
+            },
+            {
+                "attacher": "shuang",
+                "bug_id": 1267941,
+                "content_type": "text/plain",
+                "creation_time": "2016-06-08T10:19:41Z",
+                "creator": "shuang",
+                "description": "bug1267941.patch (WIP) worker-test",
+                "file_name": "bug1267941.patch",
+                "flags": [],
+                "id": 8761135,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-06-14T16:46:10Z",
+                "size": 20746,
+                "summary": "bug1267941.patch (WIP) worker-test"
+            },
+            {
+                "attacher": "shuang",
+                "bug_id": 1267941,
+                "content_type": "text/plain",
+                "creation_time": "2016-06-14T16:46:58Z",
+                "creator": "shuang",
+                "description": "bug-1267941.patch (WIP)",
+                "file_name": "bug-1267941.patch",
+                "flags": [],
+                "id": 8762723,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-06-16T12:57:24Z",
+                "size": 35365,
+                "summary": "bug-1267941.patch (WIP)"
+            },
+            {
+                "attacher": "shuang",
+                "bug_id": 1267941,
+                "content_type": "text/plain",
+                "creation_time": "2016-06-16T12:58:01Z",
+                "creator": "shuang",
+                "description": "bug-1267941.patch (WIP) worker-test",
+                "file_name": "bug-1267941.patch",
+                "flags": [],
+                "id": 8763074,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-06-17T10:00:39Z",
+                "size": 36158,
+                "summary": "bug-1267941.patch (WIP) worker-test"
+            },
+            {
+                "attacher": "shuang",
+                "bug_id": 1267941,
+                "content_type": "text/plain",
+                "creation_time": "2016-06-17T10:05:52Z",
+                "creator": "shuang",
+                "description": "bug-1267941.patch (WIP) worker-test",
+                "file_name": "bug-1267941.patch",
+                "flags": [],
+                "id": 8763198,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-06-29T11:30:48Z",
+                "size": 36256,
+                "summary": "bug-1267941.patch (WIP) worker-test"
+            },
+            {
+                "attacher": "shuang",
+                "bug_id": 1267941,
+                "content_type": "text/plain",
+                "creation_time": "2016-06-29T11:32:27Z",
+                "creator": "shuang",
+                "description": "bug-1267941.patch",
+                "file_name": "bug-1267941.patch",
+                "flags": [],
+                "id": 8766267,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-06-29T11:40:25Z",
+                "size": 26432,
+                "summary": "bug-1267941.patch"
+            },
+            {
+                "attacher": "shuang",
+                "bug_id": 1267941,
+                "content_type": "text/plain",
+                "creation_time": "2016-06-29T11:40:45Z",
+                "creator": "shuang",
+                "description": "bug-1267941.patch",
+                "file_name": "bug-1267941.patch",
+                "flags": [],
+                "id": 8766269,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-07-01T09:52:49Z",
+                "size": 26436,
+                "summary": "bug-1267941.patch"
+            },
+            {
+                "attacher": "shuang",
+                "bug_id": 1267941,
+                "content_type": "text/plain",
+                "creation_time": "2016-07-01T09:54:34Z",
+                "creator": "shuang",
+                "description": "bug-1267941.patch",
+                "file_name": "bug-1267941.patch",
+                "flags": [],
+                "id": 8767112,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-07-04T10:45:23Z",
+                "size": 28651,
+                "summary": "bug-1267941.patch"
+            },
+            {
+                "attacher": "shuang",
+                "bug_id": 1267941,
+                "content_type": "text/plain",
+                "creation_time": "2016-07-04T10:45:41Z",
+                "creator": "shuang",
+                "description": "bug-1267941.patch",
+                "file_name": "bug-1267941.patch",
+                "flags": [],
+                "id": 8767638,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-07-11T10:29:42Z",
+                "size": 28869,
+                "summary": "bug-1267941.patch"
+            },
+            {
+                "attacher": "shuang",
+                "bug_id": 1267941,
+                "content_type": "text/plain",
+                "creation_time": "2016-07-11T10:30:21Z",
+                "creator": "shuang",
+                "description": "bug-1267941.patch",
+                "file_name": "bug-1267941.patch",
+                "flags": [],
+                "id": 8769629,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-07-12T10:59:32Z",
+                "size": 28842,
+                "summary": "bug-1267941.patch"
+            },
+            {
+                "attacher": "shuang",
+                "bug_id": 1267941,
+                "content_type": "text/plain",
+                "creation_time": "2016-07-12T10:59:46Z",
+                "creator": "shuang",
+                "description": "bug-1267941.patch",
+                "file_name": "bug-1267941.patch",
+                "flags": [],
+                "id": 8770088,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-07-12T11:06:02Z",
+                "size": 29606,
+                "summary": "bug-1267941.patch"
+            },
+            {
+                "attacher": "shuang",
+                "bug_id": 1267941,
+                "content_type": "text/plain",
+                "creation_time": "2016-07-12T11:09:01Z",
+                "creator": "shuang",
+                "description": "bug-1267941.patch",
+                "file_name": "bug-1267941.patch",
+                "flags": [],
+                "id": 8770090,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-07-18T06:13:21Z",
+                "size": 29374,
+                "summary": "bug-1267941.patch"
+            },
+            {
+                "attacher": "shuang",
+                "bug_id": 1267941,
+                "content_type": "text/plain",
+                "creation_time": "2016-07-18T06:15:58Z",
+                "creator": "shuang",
+                "description": "bug-1267941.patch",
+                "file_name": "bug-1267941.patch",
+                "flags": [],
+                "id": 8771871,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-07-21T10:00:09Z",
+                "size": 29418,
+                "summary": "bug-1267941.patch"
+            },
+            {
+                "attacher": "shuang",
+                "bug_id": 1267941,
+                "content_type": "text/plain",
+                "creation_time": "2016-07-20T10:49:37Z",
+                "creator": "shuang",
+                "description": "interdiff.txt",
+                "file_name": "interdiff.txt",
+                "flags": [],
+                "id": 8772800,
+                "is_obsolete": 1,
+                "is_patch": 0,
+                "is_private": 0,
+                "last_change_time": "2016-07-21T08:48:27Z",
+                "size": 9279,
+                "summary": "interdiff.txt"
+            },
+            {
+                "attacher": "shuang",
+                "bug_id": 1267941,
+                "content_type": "text/plain",
+                "creation_time": "2016-07-21T10:01:10Z",
+                "creator": "shuang",
+                "description": "bug-1267941.patch",
+                "file_name": "bug-1267941.patch",
+                "flags": [],
+                "id": 8773210,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-07-25T09:18:00Z",
+                "size": 28813,
+                "summary": "bug-1267941.patch"
+            },
+            {
+                "attacher": "shuang",
+                "bug_id": 1267941,
+                "content_type": "text/plain",
+                "creation_time": "2016-07-25T09:18:39Z",
+                "creator": "shuang",
+                "description": "bug-1267941.patch",
+                "file_name": "bug-1267941.patch",
+                "flags": [],
+                "id": 8774265,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-07-25T09:44:10Z",
+                "size": 33146,
+                "summary": "bug-1267941.patch"
+            },
+            {
+                "attacher": "shuang",
+                "bug_id": 1267941,
+                "content_type": "text/plain",
+                "creation_time": "2016-07-25T09:46:19Z",
+                "creator": "shuang",
+                "description": "Bug 1267941 - Implement Storage API estimate() feature",
+                "file_name": "bug-1267941.patch",
+                "flags": [],
+                "id": 8774281,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-07-26T07:39:08Z",
+                "size": 33174,
+                "summary": "Bug 1267941 - Implement Storage API estimate() feature"
+            },
+            {
+                "attacher": "shuang",
+                "bug_id": 1267941,
+                "content_type": "text/plain",
+                "creation_time": "2016-07-26T07:40:46Z",
+                "creator": "shuang",
+                "description": "Bug 1267941 - Implement Storage API estimate() feature",
+                "file_name": "bug-1267941.patch",
+                "flags": [],
+                "id": 8774626,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-07-26T12:30:27Z",
+                "size": 36451,
+                "summary": "Bug 1267941 - Implement Storage API estimate() feature"
+            },
+            {
+                "attacher": "shuang",
+                "bug_id": 1267941,
+                "content_type": "text/plain",
+                "creation_time": "2016-07-26T12:33:56Z",
+                "creator": "shuang",
+                "description": "Bug 1267941 - Implement Storage API estimate() feature",
+                "file_name": "bug-1267941.patch",
+                "flags": [],
+                "id": 8774714,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-07-27T07:29:03Z",
+                "size": 41172,
+                "summary": "Bug 1267941 - Implement Storage API estimate() feature"
+            },
+            {
+                "attacher": "shuang",
+                "bug_id": 1267941,
+                "content_type": "text/plain",
+                "creation_time": "2016-07-27T07:29:33Z",
+                "creator": "shuang",
+                "description": "Bug 1267941 - Implement Storage API estimate() feature",
+                "file_name": "bug-1267941.patch",
+                "flags": [],
+                "id": 8775042,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-07-27T07:32:49Z",
+                "size": 37777,
+                "summary": "Bug 1267941 - Implement Storage API estimate() feature"
+            },
+            {
+                "attacher": "shuang",
+                "bug_id": 1267941,
+                "content_type": "text/plain",
+                "creation_time": "2016-07-27T07:35:45Z",
+                "creator": "shuang",
+                "description": "Bug 1267941 - Implement Storage API estimate() feature",
+                "file_name": "bug-1267941.patch",
+                "flags": [],
+                "id": 8775044,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-07-27T10:00:46Z",
+                "size": 37013,
+                "summary": "Bug 1267941 - Implement Storage API estimate() feature"
+            }
+        ],
+        "blocks": [
+            1254428,
+            1286717,
+            1287701
+        ],
+        "cc": [
+            "annevk",
+            "btian",
+            "bugmail",
+            "echen",
+            "htsai",
+            "jvarga",
+            "ttung"
+        ],
+        "cc_detail": [
+            {
+                "email": "annevk",
+                "id": 102998,
+                "name": "annevk",
+                "real_name": "Anne (:annevk)"
+            },
+            {
+                "email": "btian",
+                "id": 464639,
+                "name": "btian",
+                "real_name": "Ben Tian [:btian]"
+            },
+            {
+                "email": "bugmail",
+                "id": 151407,
+                "name": "bugmail",
+                "real_name": "Andrew Sutherland [:asuth]"
+            },
+            {
+                "email": "echen",
+                "id": 455480,
+                "name": "echen",
+                "real_name": "Edgar Chen [:edgar][:echen]"
+            },
+            {
+                "email": "htsai",
+                "id": 434964,
+                "name": "htsai",
+                "real_name": "Hsin-Yi Tsai [:hsinyi]"
+            },
+            {
+                "email": "jvarga",
+                "id": 8340,
+                "name": "jvarga",
+                "real_name": "Jan Varga [:janv]"
+            },
+            {
+                "email": "ttung",
+                "id": 552411,
+                "name": "ttung",
+                "real_name": "Tom Tung [:tt]"
+            }
+        ],
+        "cf_blocking_b2g": "---",
+        "cf_blocking_fennec": "---",
+        "cf_blocking_fx": "---",
+        "cf_crash_signature": "",
+        "cf_feature_b2g": "---",
+        "cf_fx_iteration": "---",
+        "cf_fx_points": "---",
+        "cf_has_regression_range": "---",
+        "cf_has_str": "---",
+        "cf_last_resolved": null,
+        "cf_platform_rel": "---",
+        "cf_qa_whiteboard": "",
+        "cf_rank": null,
+        "cf_status_b2g_2_6": "---",
+        "cf_status_firefox47": "---",
+        "cf_status_firefox48": "---",
+        "cf_status_firefox49": "---",
+        "cf_status_firefox50": "---",
+        "cf_status_firefox_esr45": "---",
+        "cf_status_thunderbird_esr38": "---",
+        "cf_status_thunderbird_esr45": "---",
+        "cf_tracking_b2g": "---",
+        "cf_tracking_e10s": "---",
+        "cf_tracking_firefox47": "---",
+        "cf_tracking_firefox48": "---",
+        "cf_tracking_firefox49": "---",
+        "cf_tracking_firefox50": "---",
+        "cf_tracking_firefox_esr45": "---",
+        "cf_tracking_firefox_relnote": "---",
+        "cf_tracking_thunderbird_esr38": "---",
+        "cf_tracking_thunderbird_esr45": "---",
+        "cf_user_story": "",
+        "classification": "Components",
+        "comments": [
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-04-27T07:36:19Z",
+                "creator": "shuang",
+                "id": 11360126,
+                "is_private": false,
+                "raw_text": "Implement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() feature",
+                "tags": [],
+                "text": "Implement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureeeeeeeeeeee",
+                "time": "2016-04-27T07:36:19Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-05-04T12:49:32Z",
+                "creator": "shuang",
+                "id": 11381059,
+                "is_private": false,
+                "raw_text": "Shall we put StorageManager related code under dom/quota? Do you suggest we shall create an another folder?",
+                "tags": [],
+                "text": "Shall we put StorageManager related code under dom/quota? Do you suggest we shall create an another folder?",
+                "time": "2016-05-04T12:49:32Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "jvarga",
+                "bug_id": 1267941,
+                "creation_time": "2016-05-04T13:08:07Z",
+                "creator": "jvarga",
+                "id": 11381122,
+                "is_private": false,
+                "raw_text": "I don't think we need a new directory, but I need to see how new files are named before saying my final word.",
+                "tags": [],
+                "text": "I don't think we need a new directory, but I need to see how new files are named before saying my final word.",
+                "time": "2016-05-04T13:08:07Z"
+            },
+            {
+                "attachment_id": 8748628,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-05-04T13:24:06Z",
+                "creator": "shuang",
+                "id": 11381163,
+                "is_private": false,
+                "raw_text": "",
+                "tags": [],
+                "text": "Created attachment 8748628\nWIP patch",
+                "time": "2016-05-04T13:24:06Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-05-04T13:31:42Z",
+                "creator": "shuang",
+                "id": 11381179,
+                "is_private": false,
+                "raw_text": "(In reply to Jan Varga [:janv] from comment #2)\n> I don't think we need a new directory, but I need to see how new files are\n> named before saying my final word.\n\nI will name it something like StorageManager.",
+                "tags": [],
+                "text": "(In reply to Jan Varga [:janv] from comment #2)\n> I don't think we need a new directory, but I need to see how new files are\n> named before saying my final word.\n\nI will name it something like StorageManager.",
+                "time": "2016-05-04T13:31:42Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "jvarga",
+                "bug_id": 1267941,
+                "creation_time": "2016-05-04T13:33:27Z",
+                "creator": "jvarga",
+                "id": 11381181,
+                "is_private": false,
+                "raw_text": "Yeah, yeah, but I'd like to see actual files .h .cpp before saying it can live together with the original dom/quota",
+                "tags": [],
+                "text": "Yeah, yeah, but I'd like to see actual files .h .cpp before saying it can live together with the original dom/quota",
+                "time": "2016-05-04T13:33:27Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "ttung",
+                "bug_id": 1267941,
+                "creation_time": "2016-05-09T09:33:39Z",
+                "creator": "ttung",
+                "id": 11392396,
+                "is_private": false,
+                "raw_text": "Record the discussion about the implementation on IRC [1]-[2] to keep ourselves remembering that.\n\n09:37\tshawnjohnjr\tjanv:why do we have 'group limit' instead of quota for each origin? is there any special reason?\n09:52\tjanv\tshawnjohnjr: that's the eTLD+1 grouping\n10:10\ttt\tjanv: But why don't we have a quota limit for a origin?\n10:11\tjanv\ttt: that would be a problem for some sites, like wikipedia.org\n10:11\tjanv\terr\n10:11\tjanv\tnever mind\n10:12\tjanv\ttt: once you enable the limit just for origins, then one can create multiple subdomains and fill entire storage area\n10:13\tjanv\ttt: http://www.filldisk.com/\n10:19\ttt\tjanv:Yes, but having multiple limitations(origin limit, group limit and global limit together) can avoid that?\n10:25\tjanv\ttt: group limit and the global limit works just fine\n10:25\tjanv\ttt: we are immune to the filldisk hack\n10:26\ttt\tjanv: OK, I see.\n10:26\ttt\tjanv: thanks\n10:26\tjanv\tsure\n10:30\tshawnjohnjr\tjanv: the reason i asked is because storage api specification said \"site storage unit\" ties to a origin. so i wonder the quota we return should be limit just for origins.\n10:30\tshawnjohnjr\tjanv: \"The site storage quota of an origin origin is a conserviate estimate of the amount of bytes available to origin\u00e2\u0080\u0099s site storage unit.\"\n10:31\tshawnjohnjr\thttps://storage.spec.whatwg.org/#site-storage-unit\n10:31\tjanv\tshawnjohnjr: I guess it should return how many bytes can be used until a quota exceeded is returned\n10:32\tshawnjohnjr\tjanv: oh, i see.\n10:32\tjanv\tshawnjohnjr: and the global limit actually doesn't apply usually\n10:33\tjanv\twhen we reach the global limit we try to delete some unused origins\n10:33\tshawnjohnjr\tjanv: i see\n10:34\tjanv\tshawnjohnjr: not sure how we should account the global limit\n10:35\tjanv\testimate should probably only check the group limit\n10:53\tshawnjohnjr\tjanv:if we only return group limit as quota, then I guess one single origin won't reflect the true quota per a origin. ex: www1.mozilla.org gets group limit 2GB, www1 current usage per origin is 1GB, www2.mozilla.org also gets group limit 2GB, www2 current usage per origin is 500MB. Both origins consider they can consume total 2GB quota. But actually they\n10:53\tshawnjohnjr\tcan't. If I understand the specification correctly.\n10:59\tshawnjohnjr\tannevk: is it ok to return group limit as a quota value\n11:00\tshawnjohnjr\tannevk: if we enable quota per a origin, we will have problem that janv just mentioned\n11:03\tjanv\tshawnjohnjr: yeah, discuss with annevk please\n11:03\tshawnjohnjr\tjanv: thanks for pointing out the problem\n11:04\tjanv\tshawnjohnjr: anyway, they call it \"estimate\" by a reason, since the value is dynamic\n11:04\tjanv\tthere can be multiple workers writing to databases even of the same origin\n11:04\tshawnjohnjr\tjanv: you're right\n13:01\tannevk\tshawnjohnjr: it would be better if we did away with groups I think\n13:01\tannevk\tshawnjohnjr: walking around today though so not working\n13:05\tshawnjohnjr\tannevk: so you think we should get rid of group limit?\n13:08\tshawnjohnjr\tannevk: we still need to consider diskfill hack.\n13:10\tannevk\tshawnjohnjr: yeah, but that is rather easy anyway\n13:11\tannevk\tshawnjohnjr: maybe somewhat more expensive today\u00e2\u0080\u00a6\n13:12\tannevk\tshawnjohnjr: I think basing things around origins and thinking of more general protections to abuse will serve us better\n13:13\tshawnjohnjr\tannevk: okay\n13:16\tannevk\tshawnjohnjr: I believe Chrome plans to experiment with having close to no limit\n13:16\tannevk\tJust let a site use as much as it needs\n13:16\tannevk\tAnd then kick it out when the user switches\n13:21\tshawnjohnjr\tannevk: site means 'origin', right?\n13:22\tshawnjohnjr\tNot eTLD+1 here\n13:24\tannevk\tshawnjohnjr: yeah, I think only we do eTLD+1 \n\n[1] http://logs.glob.uno/?c=mozilla%23content&s=6+May+2016&e=6+May+2016#c372742\n[2] http://logs.glob.uno/?c=mozilla%23content&s=6+May+2016&e=6+May+2016#c372788",
+                "tags": [],
+                "text": "Record the discussion about the implementation on IRC [1]-[2] to keep ourselves remembering that.\n\n09:37\tshawnjohnjr\tjanv:why do we have 'group limit' instead of quota for each origin? is there any special reason?\n09:52\tjanv\tshawnjohnjr: that's the eTLD+1 grouping\n10:10\ttt\tjanv: But why don't we have a quota limit for a origin?\n10:11\tjanv\ttt: that would be a problem for some sites, like wikipedia.org\n10:11\tjanv\terr\n10:11\tjanv\tnever mind\n10:12\tjanv\ttt: once you enable the limit just for origins, then one can create multiple subdomains and fill entire storage area\n10:13\tjanv\ttt: http://www.filldisk.com/\n10:19\ttt\tjanv:Yes, but having multiple limitations(origin limit, group limit and global limit together) can avoid that?\n10:25\tjanv\ttt: group limit and the global limit works just fine\n10:25\tjanv\ttt: we are immune to the filldisk hack\n10:26\ttt\tjanv: OK, I see.\n10:26\ttt\tjanv: thanks\n10:26\tjanv\tsure\n10:30\tshawnjohnjr\tjanv: the reason i asked is because storage api specification said \"site storage unit\" ties to a origin. so i wonder the quota we return should be limit just for origins.\n10:30\tshawnjohnjr\tjanv: \"The site storage quota of an origin origin is a conserviate estimate of the amount of bytes available to origin\u00e2\u0080\u0099s site storage unit.\"\n10:31\tshawnjohnjr\thttps://storage.spec.whatwg.org/#site-storage-unit\n10:31\tjanv\tshawnjohnjr: I guess it should return how many bytes can be used until a quota exceeded is returned\n10:32\tshawnjohnjr\tjanv: oh, i see.\n10:32\tjanv\tshawnjohnjr: and the global limit actually doesn't apply usually\n10:33\tjanv\twhen we reach the global limit we try to delete some unused origins\n10:33\tshawnjohnjr\tjanv: i see\n10:34\tjanv\tshawnjohnjr: not sure how we should account the global limit\n10:35\tjanv\testimate should probably only check the group limit\n10:53\tshawnjohnjr\tjanv:if we only return group limit as quota, then I guess one single origin won't reflect the true quota per a origin. ex: www1.mozilla.org gets group limit 2GB, www1 current usage per origin is 1GB, www2.mozilla.org also gets group limit 2GB, www2 current usage per origin is 500MB. Both origins consider they can consume total 2GB quota. But actually they\n10:53\tshawnjohnjr\tcan't. If I understand the specification correctly.\n10:59\tshawnjohnjr\tannevk: is it ok to return group limit as a quota value\n11:00\tshawnjohnjr\tannevk: if we enable quota per a origin, we will have problem that janv just mentioned\n11:03\tjanv\tshawnjohnjr: yeah, discuss with annevk please\n11:03\tshawnjohnjr\tjanv: thanks for pointing out the problem\n11:04\tjanv\tshawnjohnjr: anyway, they call it \"estimate\" by a reason, since the value is dynamic\n11:04\tjanv\tthere can be multiple workers writing to databases even of the same origin\n11:04\tshawnjohnjr\tjanv: you're right\n13:01\tannevk\tshawnjohnjr: it would be better if we did away with groups I think\n13:01\tannevk\tshawnjohnjr: walking around today though so not working\n13:05\tshawnjohnjr\tannevk: so you think we should get rid of group limit?\n13:08\tshawnjohnjr\tannevk: we still need to consider diskfill hack.\n13:10\tannevk\tshawnjohnjr: yeah, but that is rather easy anyway\n13:11\tannevk\tshawnjohnjr: maybe somewhat more expensive today\u00e2\u0080\u00a6\n13:12\tannevk\tshawnjohnjr: I think basing things around origins and thinking of more general protections to abuse will serve us better\n13:13\tshawnjohnjr\tannevk: okay\n13:16\tannevk\tshawnjohnjr: I believe Chrome plans to experiment with having close to no limit\n13:16\tannevk\tJust let a site use as much as it needs\n13:16\tannevk\tAnd then kick it out when the user switches\n13:21\tshawnjohnjr\tannevk: site means 'origin', right?\n13:22\tshawnjohnjr\tNot eTLD+1 here\n13:24\tannevk\tshawnjohnjr: yeah, I think only we do eTLD+1 \n\n[1] http://logs.glob.uno/?c=mozilla%23content&s=6+May+2016&e=6+May+2016#c372742\n[2] http://logs.glob.uno/?c=mozilla%23content&s=6+May+2016&e=6+May+2016#c372788",
+                "time": "2016-05-09T09:33:39Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-01T08:00:51Z",
+                "creator": "shuang",
+                "id": 11453782,
+                "is_private": false,
+                "raw_text": "Hi Janv,\nI have some doubts on the ipc architecture for Storage API.\nI'm wondering what kind of architecture is correct for Storage API case.\n\n(1) in content process, implement one StorageManagerChild actor just like QuotaChild in QuotaManagerService, directly send IPC messages to PQuotaParent to call |GetUsageForPrincipal|. Ignore existing XPCOM QuotaManagerService interface. The benefit we only need to do IPC once but we probably may have redundant code in StorageManager. \n\nor \n(2) in content process, implement StorageManagerChild/StorageManagerParent actor and StorageManagerChild sends IPC messages to StorageManagerParent in webapi code, StorageManagerParent call QuotaManagerService::GetUsageForPrincipal via XPCOM interface in chrome process. The benefit is to leverage existing XPCOM service in chrome process but we need to do things in PBackground twice.",
+                "tags": [],
+                "text": "Hi Janv,\nI have some doubts on the ipc architecture for Storage API.\nI'm wondering what kind of architecture is correct for Storage API case.\n\n(1) in content process, implement one StorageManagerChild actor just like QuotaChild in QuotaManagerService, directly send IPC messages to PQuotaParent to call |GetUsageForPrincipal|. Ignore existing XPCOM QuotaManagerService interface. The benefit we only need to do IPC once but we probably may have redundant code in StorageManager. \n\nor \n(2) in content process, implement StorageManagerChild/StorageManagerParent actor and StorageManagerChild sends IPC messages to StorageManagerParent in webapi code, StorageManagerParent call QuotaManagerService::GetUsageForPrincipal via XPCOM interface in chrome process. The benefit is to leverage existing XPCOM service in chrome process but we need to do things in PBackground twice.",
+                "time": "2016-06-01T08:00:51Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "jvarga",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-01T08:18:29Z",
+                "creator": "jvarga",
+                "id": 11453809,
+                "is_private": false,
+                "raw_text": "I hoped we could just call QuotaManagerService methods in content process. QuotaManagerService is a client for PQuotaParent. If we need to change QuotaManagerService methods or add new ones, I think that's fine.",
+                "tags": [],
+                "text": "I hoped we could just call QuotaManagerService methods in content process. QuotaManagerService is a client for PQuotaParent. If we need to change QuotaManagerService methods or add new ones, I think that's fine.",
+                "time": "2016-06-01T08:18:29Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "ttung",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-01T11:22:21Z",
+                "creator": "ttung",
+                "id": 11454206,
+                "is_private": false,
+                "raw_text": "Hi Jan,\n\nJust make sure I understand. We need to create another client for PQuotaParent (communicate with QuotaManager directly rather than through QuotaManagerService) or change functions in QuotaManagerService and make it can be called in content process? Thanks!",
+                "tags": [],
+                "text": "Hi Jan,\n\nJust make sure I understand. We need to create another client for PQuotaParent (communicate with QuotaManager directly rather than through QuotaManagerService) or change functions in QuotaManagerService and make it can be called in content process? Thanks!",
+                "time": "2016-06-01T11:22:21Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "jvarga",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-01T12:15:04Z",
+                "creator": "jvarga",
+                "id": 11454298,
+                "is_private": false,
+                "raw_text": "(In reply to Tom Tung [:tt] from comment #9)\n> Hi Jan,\n> \n> Just make sure I understand. We need to create another client for\n> PQuotaParent (communicate with QuotaManager directly rather than through\n> QuotaManagerService) or change functions in QuotaManagerService and make it\n> can be called in content process? Thanks!\n\nThe latter, QuotaManagerService is already available in content processes.",
+                "tags": [],
+                "text": "(In reply to Tom Tung [:tt] from comment #9)\n> Hi Jan,\n> \n> Just make sure I understand. We need to create another client for\n> PQuotaParent (communicate with QuotaManager directly rather than through\n> QuotaManagerService) or change functions in QuotaManagerService and make it\n> can be called in content process? Thanks!\n\nThe latter, QuotaManagerService is already available in content processes.",
+                "time": "2016-06-01T12:15:04Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-02T03:07:03Z",
+                "creator": "shuang",
+                "id": 11456890,
+                "is_private": false,
+                "raw_text": "(In reply to Jan Varga [:janv] from comment #10)\n> (In reply to Tom Tung [:tt] from comment #9)\n> > Hi Jan,\n> > \n> > Just make sure I understand. We need to create another client for\n> > PQuotaParent (communicate with QuotaManager directly rather than through\n> > QuotaManagerService) or change functions in QuotaManagerService and make it\n> > can be called in content process? Thanks!\n> \n> The latter, QuotaManagerService is already available in content processes.\n\nThanks, Jan. Then I will stop working on adding PBackgroundChild and try to modify QuotaManagerService.",
+                "tags": [],
+                "text": "(In reply to Jan Varga [:janv] from comment #10)\n> (In reply to Tom Tung [:tt] from comment #9)\n> > Hi Jan,\n> > \n> > Just make sure I understand. We need to create another client for\n> > PQuotaParent (communicate with QuotaManager directly rather than through\n> > QuotaManagerService) or change functions in QuotaManagerService and make it\n> > can be called in content process? Thanks!\n> \n> The latter, QuotaManagerService is already available in content processes.\n\nThanks, Jan. Then I will stop working on adding PBackgroundChild and try to modify QuotaManagerService.",
+                "time": "2016-06-02T03:07:03Z"
+            },
+            {
+                "attachment_id": 8759067,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-02T08:03:35Z",
+                "creator": "shuang",
+                "id": 11457271,
+                "is_private": false,
+                "raw_text": "",
+                "tags": [],
+                "text": "Created attachment 8759067\nbug1267941.patch",
+                "time": "2016-06-02T08:03:35Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "jvarga",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-02T08:53:03Z",
+                "creator": "jvarga",
+                "id": 11457408,
+                "is_private": false,
+                "raw_text": "(In reply to Shawn Huang [:shawnjohnjr] from comment #12)\n> Created attachment 8759067\n> bug1267941.patch\n\nYeah, I believe it doesn't make sense to create a separate parent/child for this.",
+                "tags": [],
+                "text": "(In reply to Shawn Huang [:shawnjohnjr] from comment #12)\n> Created attachment 8759067\n> bug1267941.patch\n\nYeah, I believe it doesn't make sense to create a separate parent/child for this.",
+                "time": "2016-06-02T08:53:03Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-02T09:46:23Z",
+                "creator": "shuang",
+                "id": 11457537,
+                "is_private": false,
+                "raw_text": "(In reply to Jan Varga [:janv] from comment #10)\n> (In reply to Tom Tung [:tt] from comment #9)\n> > Hi Jan,\n> > \n> > Just make sure I understand. We need to create another client for\n> > PQuotaParent (communicate with QuotaManager directly rather than through\n> > QuotaManagerService) or change functions in QuotaManagerService and make it\n> > can be called in content process? Thanks!\n> \n> The latter, QuotaManagerService is already available in content processes.\nhttps://dxr.mozilla.org/mozilla-central/source/dom/quota/QuotaManagerService.cpp#505\nhttps://dxr.mozilla.org/mozilla-central/source/dom/quota/QuotaManagerService.cpp#566\n\nI thought QuotaManagerService is for Chrome process only because of the assertion. It looks like I was wrong.",
+                "tags": [],
+                "text": "(In reply to Jan Varga [:janv] from comment #10)\n> (In reply to Tom Tung [:tt] from comment #9)\n> > Hi Jan,\n> > \n> > Just make sure I understand. We need to create another client for\n> > PQuotaParent (communicate with QuotaManager directly rather than through\n> > QuotaManagerService) or change functions in QuotaManagerService and make it\n> > can be called in content process? Thanks!\n> \n> The latter, QuotaManagerService is already available in content processes.\nhttps://dxr.mozilla.org/mozilla-central/source/dom/quota/QuotaManagerService.cpp#505\nhttps://dxr.mozilla.org/mozilla-central/source/dom/quota/QuotaManagerService.cpp#566\n\nI thought QuotaManagerService is for Chrome process only because of the assertion. It looks like I was wrong.",
+                "time": "2016-06-02T09:46:23Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "jvarga",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-02T12:33:57Z",
+                "creator": "jvarga",
+                "id": 11457963,
+                "is_private": false,
+                "raw_text": "(In reply to Shawn Huang [:shawnjohnjr] from comment #14)\n> (In reply to Jan Varga [:janv] from comment #10)\n> > (In reply to Tom Tung [:tt] from comment #9)\n> > > Hi Jan,\n> > > \n> > > Just make sure I understand. We need to create another client for\n> > > PQuotaParent (communicate with QuotaManager directly rather than through\n> > > QuotaManagerService) or change functions in QuotaManagerService and make it\n> > > can be called in content process? Thanks!\n> > \n> > The latter, QuotaManagerService is already available in content processes.\n> https://dxr.mozilla.org/mozilla-central/source/dom/quota/QuotaManagerService.\n> cpp#505\n> https://dxr.mozilla.org/mozilla-central/source/dom/quota/QuotaManagerService.\n> cpp#566\n> \n> I thought QuotaManagerService is for Chrome process only because of the\n> assertion. It looks like I was wrong.\n\nChrome process and caller chrome is not the same. The service is definitely used in content processes.\nIt was actually created for this purpose.",
+                "tags": [],
+                "text": "(In reply to Shawn Huang [:shawnjohnjr] from comment #14)\n> (In reply to Jan Varga [:janv] from comment #10)\n> > (In reply to Tom Tung [:tt] from comment #9)\n> > > Hi Jan,\n> > > \n> > > Just make sure I understand. We need to create another client for\n> > > PQuotaParent (communicate with QuotaManager directly rather than through\n> > > QuotaManagerService) or change functions in QuotaManagerService and make it\n> > > can be called in content process? Thanks!\n> > \n> > The latter, QuotaManagerService is already available in content processes.\n> https://dxr.mozilla.org/mozilla-central/source/dom/quota/QuotaManagerService.\n> cpp#505\n> https://dxr.mozilla.org/mozilla-central/source/dom/quota/QuotaManagerService.\n> cpp#566\n> \n> I thought QuotaManagerService is for Chrome process only because of the\n> assertion. It looks like I was wrong.\n\nChrome process and caller chrome is not the same. The service is definitely used in content processes.\nIt was actually created for this purpose.",
+                "time": "2016-06-02T12:33:57Z"
+            },
+            {
+                "attachment_id": 8759609,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-03T10:55:31Z",
+                "creator": "shuang",
+                "id": 11461121,
+                "is_private": false,
+                "raw_text": "Adding estimate() for querying usage only, still need to handle web worker.",
+                "tags": [],
+                "text": "Created attachment 8759609\nbug1267941.patch (WIP)\n\nAdding estimate() for querying usage only, still need to handle web worker.",
+                "time": "2016-06-03T10:55:31Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-03T11:00:22Z",
+                "creator": "shuang",
+                "id": 11461124,
+                "is_private": false,
+                "raw_text": "(In reply to Jan Varga [:janv] from comment #15)\n> (In reply to Shawn Huang [:shawnjohnjr] from comment #14)\n> > (In reply to Jan Varga [:janv] from comment #10)\n> > > (In reply to Tom Tung [:tt] from comment #9)\n> > > > Hi Jan,\n> > > > \n> > > > Just make sure I understand. We need to create another client for\n> > > > PQuotaParent (communicate with QuotaManager directly rather than through\n> > > > QuotaManagerService) or change functions in QuotaManagerService and make it\n> > > > can be called in content process? Thanks!\n> > > \n> > > The latter, QuotaManagerService is already available in content processes.\n> > https://dxr.mozilla.org/mozilla-central/source/dom/quota/QuotaManagerService.\n> > cpp#505\n> > https://dxr.mozilla.org/mozilla-central/source/dom/quota/QuotaManagerService.\n> > cpp#566\n> > \n> > I thought QuotaManagerService is for Chrome process only because of the\n> > assertion. It looks like I was wrong.\n> \n> Chrome process and caller chrome is not the same. The service is definitely\n> used in content processes.\n> It was actually created for this purpose.\n\nI always hit the assertion from webapi, so I just wonder if we can remove the assertion. When running mochitest to test estimate() method, webapi calls GetUsageForPrincipal(), i think caller is content window not from chrome, right?",
+                "tags": [],
+                "text": "(In reply to Jan Varga [:janv] from comment #15)\n> (In reply to Shawn Huang [:shawnjohnjr] from comment #14)\n> > (In reply to Jan Varga [:janv] from comment #10)\n> > > (In reply to Tom Tung [:tt] from comment #9)\n> > > > Hi Jan,\n> > > > \n> > > > Just make sure I understand. We need to create another client for\n> > > > PQuotaParent (communicate with QuotaManager directly rather than through\n> > > > QuotaManagerService) or change functions in QuotaManagerService and make it\n> > > > can be called in content process? Thanks!\n> > > \n> > > The latter, QuotaManagerService is already available in content processes.\n> > https://dxr.mozilla.org/mozilla-central/source/dom/quota/QuotaManagerService.\n> > cpp#505\n> > https://dxr.mozilla.org/mozilla-central/source/dom/quota/QuotaManagerService.\n> > cpp#566\n> > \n> > I thought QuotaManagerService is for Chrome process only because of the\n> > assertion. It looks like I was wrong.\n> \n> Chrome process and caller chrome is not the same. The service is definitely\n> used in content processes.\n> It was actually created for this purpose.\n\nI always hit the assertion from webapi, so I just wonder if we can remove the assertion. When running mochitest to test estimate() method, webapi calls GetUsageForPrincipal(), i think caller is content window not from chrome, right?",
+                "time": "2016-06-03T11:00:22Z"
+            },
+            {
+                "attachment_id": 8759609,
+                "author": "jvarga",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-03T12:50:08Z",
+                "creator": "jvarga",
+                "id": 11461311,
+                "is_private": false,
+                "raw_text": "Review of attachment 8759609:\n-----------------------------------------------------------------\n\nThis just a quick feedback, I think you are going in the right direction now.\n\n::: dom/quota/EstimateUsageCallback.cpp\n@@ +17,5 @@\n> +NS_IMPL_ISUPPORTS(EstimateUsageCallback, nsIQuotaUsageCallback)\n> +\n> +NS_IMETHODIMP EstimateUsageCallback::OnUsageResult(nsIQuotaUsageRequest *aRequest)\n> +{\n> +  UsageRequest* r = static_cast<UsageRequest*> (aRequest);\n\nWhy do you need a static_cast ?\n\n::: dom/quota/QuotaManagerService.cpp\n@@ +501,5 @@\n>  {\n>    MOZ_ASSERT(NS_IsMainThread());\n>    MOZ_ASSERT(aPrincipal);\n>    MOZ_ASSERT(aCallback);\n> +//  MOZ_ASSERT(nsContentUtils::IsCallerChrome());\n\nYes, I think this can now go away.\n\n::: dom/quota/StorageManager.cpp\n@@ +62,5 @@\n> +    return nullptr;\n> +  }\n> +\n> +  nsCOMPtr<nsIQuotaManagerService> qms =\n> +        do_GetService(QUOTAMANAGER_SERVICE_CONTRACTID);\n\nYou don't have to go through the service manager here, just call QuotaManagerService::GetOrCreate()\nHowever, that can only be done on the main thread. Worker implementation will have to dispatch a runnable to the main thread ...\n\n::: dom/quota/moz.build\n@@ +14,5 @@\n>  \n>  EXPORTS.mozilla.dom.quota += [\n>      'ActorsParent.h',\n>      'Client.h',\n> +    'EstimateUsageCallback.h',\n\nWhy does this need to be exported ?\n\nActually, why do we need a separate .h/.cpp pair for this ?\nIt can just live in StorageManager.cpp, no ?",
+                "tags": [],
+                "text": "Comment on attachment 8759609\nbug1267941.patch (WIP)\n\nReview of attachment 8759609:\n-----------------------------------------------------------------\n\nThis just a quick feedback, I think you are going in the right direction now.\n\n::: dom/quota/EstimateUsageCallback.cpp\n@@ +17,5 @@\n> +NS_IMPL_ISUPPORTS(EstimateUsageCallback, nsIQuotaUsageCallback)\n> +\n> +NS_IMETHODIMP EstimateUsageCallback::OnUsageResult(nsIQuotaUsageRequest *aRequest)\n> +{\n> +  UsageRequest* r = static_cast<UsageRequest*> (aRequest);\n\nWhy do you need a static_cast ?\n\n::: dom/quota/QuotaManagerService.cpp\n@@ +501,5 @@\n>  {\n>    MOZ_ASSERT(NS_IsMainThread());\n>    MOZ_ASSERT(aPrincipal);\n>    MOZ_ASSERT(aCallback);\n> +//  MOZ_ASSERT(nsContentUtils::IsCallerChrome());\n\nYes, I think this can now go away.\n\n::: dom/quota/StorageManager.cpp\n@@ +62,5 @@\n> +    return nullptr;\n> +  }\n> +\n> +  nsCOMPtr<nsIQuotaManagerService> qms =\n> +        do_GetService(QUOTAMANAGER_SERVICE_CONTRACTID);\n\nYou don't have to go through the service manager here, just call QuotaManagerService::GetOrCreate()\nHowever, that can only be done on the main thread. Worker implementation will have to dispatch a runnable to the main thread ...\n\n::: dom/quota/moz.build\n@@ +14,5 @@\n>  \n>  EXPORTS.mozilla.dom.quota += [\n>      'ActorsParent.h',\n>      'Client.h',\n> +    'EstimateUsageCallback.h',\n\nWhy does this need to be exported ?\n\nActually, why do we need a separate .h/.cpp pair for this ?\nIt can just live in StorageManager.cpp, no ?",
+                "time": "2016-06-03T12:50:08Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-06T06:06:33Z",
+                "creator": "shuang",
+                "id": 11464974,
+                "is_private": false,
+                "raw_text": "(In reply to Jan Varga [:janv] from comment #18)\n> Comment on attachment 8759609\n> bug1267941.patch (WIP)\n> \n> Review of attachment 8759609:\n> -----------------------------------------------------------------\n> \n> This just a quick feedback, I think you are going in the right direction now.\nThanks! It's a good starting point.\n> \n> ::: dom/quota/EstimateUsageCallback.cpp\n> @@ +17,5 @@\n> > +NS_IMPL_ISUPPORTS(EstimateUsageCallback, nsIQuotaUsageCallback)\n> > +\n> > +NS_IMETHODIMP EstimateUsageCallback::OnUsageResult(nsIQuotaUsageRequest *aRequest)\n> > +{\n> > +  UsageRequest* r = static_cast<UsageRequest*> (aRequest);\n> \n> Why do you need a static_cast ?\nHmm... I shouldn't do it.\n> \n> ::: dom/quota/QuotaManagerService.cpp\n> @@ +501,5 @@\n> >  {\n> >    MOZ_ASSERT(NS_IsMainThread());\n> >    MOZ_ASSERT(aPrincipal);\n> >    MOZ_ASSERT(aCallback);\n> > +//  MOZ_ASSERT(nsContentUtils::IsCallerChrome());\n> \n> Yes, I think this can now go away.\nGreat!\n> \n> ::: dom/quota/StorageManager.cpp\n> @@ +62,5 @@\n> > +    return nullptr;\n> > +  }\n> > +\n> > +  nsCOMPtr<nsIQuotaManagerService> qms =\n> > +        do_GetService(QUOTAMANAGER_SERVICE_CONTRACTID);\n> \n> You don't have to go through the service manager here, just call\n> QuotaManagerService::GetOrCreate()\n> However, that can only be done on the main thread. Worker implementation\n> will have to dispatch a runnable to the main thread ...\nI see, I will change it in later revision.\n> \n> ::: dom/quota/moz.build\n> @@ +14,5 @@\n> >  \n> >  EXPORTS.mozilla.dom.quota += [\n> >      'ActorsParent.h',\n> >      'Client.h',\n> > +    'EstimateUsageCallback.h',\n> \n> Why does this need to be exported ?\nIt's not necessary, I will remove it.\n> \n> Actually, why do we need a separate .h/.cpp pair for this ?\n> It can just live in StorageManager.cpp, no ?\nYeah, I will merge callback into StorageManager.",
+                "tags": [],
+                "text": "(In reply to Jan Varga [:janv] from comment #18)\n> Comment on attachment 8759609\n> bug1267941.patch (WIP)\n> \n> Review of attachment 8759609:\n> -----------------------------------------------------------------\n> \n> This just a quick feedback, I think you are going in the right direction now.\nThanks! It's a good starting point.\n> \n> ::: dom/quota/EstimateUsageCallback.cpp\n> @@ +17,5 @@\n> > +NS_IMPL_ISUPPORTS(EstimateUsageCallback, nsIQuotaUsageCallback)\n> > +\n> > +NS_IMETHODIMP EstimateUsageCallback::OnUsageResult(nsIQuotaUsageRequest *aRequest)\n> > +{\n> > +  UsageRequest* r = static_cast<UsageRequest*> (aRequest);\n> \n> Why do you need a static_cast ?\nHmm... I shouldn't do it.\n> \n> ::: dom/quota/QuotaManagerService.cpp\n> @@ +501,5 @@\n> >  {\n> >    MOZ_ASSERT(NS_IsMainThread());\n> >    MOZ_ASSERT(aPrincipal);\n> >    MOZ_ASSERT(aCallback);\n> > +//  MOZ_ASSERT(nsContentUtils::IsCallerChrome());\n> \n> Yes, I think this can now go away.\nGreat!\n> \n> ::: dom/quota/StorageManager.cpp\n> @@ +62,5 @@\n> > +    return nullptr;\n> > +  }\n> > +\n> > +  nsCOMPtr<nsIQuotaManagerService> qms =\n> > +        do_GetService(QUOTAMANAGER_SERVICE_CONTRACTID);\n> \n> You don't have to go through the service manager here, just call\n> QuotaManagerService::GetOrCreate()\n> However, that can only be done on the main thread. Worker implementation\n> will have to dispatch a runnable to the main thread ...\nI see, I will change it in later revision.\n> \n> ::: dom/quota/moz.build\n> @@ +14,5 @@\n> >  \n> >  EXPORTS.mozilla.dom.quota += [\n> >      'ActorsParent.h',\n> >      'Client.h',\n> > +    'EstimateUsageCallback.h',\n> \n> Why does this need to be exported ?\nIt's not necessary, I will remove it.\n> \n> Actually, why do we need a separate .h/.cpp pair for this ?\n> It can just live in StorageManager.cpp, no ?\nYeah, I will merge callback into StorageManager.",
+                "time": "2016-06-06T06:06:33Z"
+            },
+            {
+                "attachment_id": 8760181,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-06T09:33:01Z",
+                "creator": "shuang",
+                "id": 11465368,
+                "is_private": false,
+                "raw_text": "",
+                "tags": [],
+                "text": "Created attachment 8760181\nbug1267941.patch (WIP)",
+                "time": "2016-06-06T09:33:01Z"
+            },
+            {
+                "attachment_id": 8761103,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-08T09:12:27Z",
+                "creator": "shuang",
+                "id": 11471692,
+                "is_private": false,
+                "raw_text": "",
+                "tags": [],
+                "text": "Created attachment 8761103\nbug1267941.patch (WIP)",
+                "time": "2016-06-08T09:12:27Z"
+            },
+            {
+                "attachment_id": 8761135,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-08T10:19:41Z",
+                "creator": "shuang",
+                "id": 11471909,
+                "is_private": false,
+                "raw_text": "",
+                "tags": [],
+                "text": "Created attachment 8761135\nbug1267941.patch (WIP) worker-test",
+                "time": "2016-06-08T10:19:41Z"
+            },
+            {
+                "attachment_id": 8762723,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-14T16:46:58Z",
+                "creator": "shuang",
+                "id": 11483470,
+                "is_private": false,
+                "raw_text": "Adding estimate() function",
+                "tags": [],
+                "text": "Created attachment 8762723\nbug-1267941.patch (WIP)\n\nAdding estimate() function",
+                "time": "2016-06-14T16:46:58Z"
+            },
+            {
+                "attachment_id": 8763074,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-16T12:58:01Z",
+                "creator": "shuang",
+                "id": 11486334,
+                "is_private": false,
+                "raw_text": "",
+                "tags": [],
+                "text": "Created attachment 8763074\nbug-1267941.patch (WIP) worker-test",
+                "time": "2016-06-16T12:58:01Z"
+            },
+            {
+                "attachment_id": 8763198,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-17T10:05:52Z",
+                "creator": "shuang",
+                "id": 11487487,
+                "is_private": false,
+                "raw_text": "",
+                "tags": [],
+                "text": "Created attachment 8763198\nbug-1267941.patch (WIP) worker-test",
+                "time": "2016-06-17T10:05:52Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-17T10:10:10Z",
+                "creator": "shuang",
+                "id": 11487493,
+                "is_private": false,
+                "raw_text": "So right now, we can expose StorageManager to WorkerNavigator and call estimate(). Next step is to add more test cases.",
+                "tags": [],
+                "text": "So right now, we can expose StorageManager to WorkerNavigator and call estimate(). Next step is to add more test cases.",
+                "time": "2016-06-17T10:10:10Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "jvarga",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-17T10:20:16Z",
+                "creator": "jvarga",
+                "id": 11487513,
+                "is_private": false,
+                "raw_text": "So the goal (according to the spec) is to be able to do this:\n\nnavigator.storage.estimate().then(info => {\n  if(info.quota - info.usage > metroidPrimeLevel.size)\n    return fetch(metroidPrimeLevel.url)\n  throw new Error(\"no space\")\n}).then( /* \u2026 */ )\n\nYour patch currently returns *origin* usage and *group* quota, but our quota checking compares *group* usage and *group* quota. So the code above won't be checking right numbers and may try to fetch data when there's not enough space. Either you return group usage and group quota or origin usage and origin quota.\nSince our quota handling heavily depends on having group quota (there's no such thing as origin quota), I recommend to return *group* usage and *group* quota.",
+                "tags": [],
+                "text": "So the goal (according to the spec) is to be able to do this:\n\nnavigator.storage.estimate().then(info => {\n  if(info.quota - info.usage > metroidPrimeLevel.size)\n    return fetch(metroidPrimeLevel.url)\n  throw new Error(\"no space\")\n}).then( /* \u2026 */ )\n\nYour patch currently returns *origin* usage and *group* quota, but our quota checking compares *group* usage and *group* quota. So the code above won't be checking right numbers and may try to fetch data when there's not enough space. Either you return group usage and group quota or origin usage and origin quota.\nSince our quota handling heavily depends on having group quota (there's no such thing as origin quota), I recommend to return *group* usage and *group* quota.",
+                "time": "2016-06-17T10:20:16Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-17T10:34:53Z",
+                "creator": "shuang",
+                "id": 11487545,
+                "is_private": false,
+                "raw_text": "(In reply to Jan Varga [:janv] from comment #27)\n> So the goal (according to the spec) is to be able to do this:\n> \n> navigator.storage.estimate().then(info => {\n>   if(info.quota - info.usage > metroidPrimeLevel.size)\n>     return fetch(metroidPrimeLevel.url)\n>   throw new Error(\"no space\")\n> }).then( /* \u2026 */ )\n> \n> Your patch currently returns *origin* usage and *group* quota, but our quota\n> checking compares *group* usage and *group* quota. So the code above won't\n> be checking right numbers and may try to fetch data when there's not enough\n> space. Either you return group usage and group quota or origin usage and\n> origin quota.\n> Since our quota handling heavily depends on having group quota (there's no\n> such thing as origin quota), I recommend to return *group* usage and *group*\n> quota.\n\nYes, we're working on adding group usage for QuotaManagerService.",
+                "tags": [],
+                "text": "(In reply to Jan Varga [:janv] from comment #27)\n> So the goal (according to the spec) is to be able to do this:\n> \n> navigator.storage.estimate().then(info => {\n>   if(info.quota - info.usage > metroidPrimeLevel.size)\n>     return fetch(metroidPrimeLevel.url)\n>   throw new Error(\"no space\")\n> }).then( /* \u2026 */ )\n> \n> Your patch currently returns *origin* usage and *group* quota, but our quota\n> checking compares *group* usage and *group* quota. So the code above won't\n> be checking right numbers and may try to fetch data when there's not enough\n> space. Either you return group usage and group quota or origin usage and\n> origin quota.\n> Since our quota handling heavily depends on having group quota (there's no\n> such thing as origin quota), I recommend to return *group* usage and *group*\n> quota.\n\nYes, we're working on adding group usage for QuotaManagerService.",
+                "time": "2016-06-17T10:34:53Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-21T07:41:12Z",
+                "creator": "shuang",
+                "id": 11491748,
+                "is_private": false,
+                "raw_text": "Per discussion in AllHands2016 Storage meeting, we will implement estimate method based on per site usage/quota. Bug 1281103 will implement |GetUsageForGroup|.",
+                "tags": [],
+                "text": "Per discussion in AllHands2016 Storage meeting, we will implement estimate method based on per site usage/quota. Bug 1281103 will implement |GetUsageForGroup|.",
+                "time": "2016-06-21T07:41:12Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-21T07:46:42Z",
+                "creator": "shuang",
+                "id": 11491754,
+                "is_private": false,
+                "raw_text": "(In reply to Shawn Huang [:shawnjohnjr] from comment #29)\n> Per discussion in AllHands2016 Storage meeting, we will implement estimate\n> method based on per site usage/quota. Bug 1281103 will implement\n> |GetUsageForGroup|.\n\nAs Tom suggests to name it |GetGroupUsageForPrincipal|.",
+                "tags": [],
+                "text": "(In reply to Shawn Huang [:shawnjohnjr] from comment #29)\n> Per discussion in AllHands2016 Storage meeting, we will implement estimate\n> method based on per site usage/quota. Bug 1281103 will implement\n> |GetUsageForGroup|.\n\nAs Tom suggests to name it |GetGroupUsageForPrincipal|.",
+                "time": "2016-06-21T07:46:42Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-21T08:07:38Z",
+                "creator": "shuang",
+                "id": 11491775,
+                "is_private": false,
+                "raw_text": "(In reply to Shawn Huang [:shawnjohnjr] from comment #30)\n> (In reply to Shawn Huang [:shawnjohnjr] from comment #29)\n> > Per discussion in AllHands2016 Storage meeting, we will implement estimate\n> > method based on per site usage/quota. Bug 1281103 will implement\n> > |GetUsageForGroup|.\n> \n> As Tom suggests to name it |GetGroupUsageForPrincipal|.\n\nMaybe GetGroupUsageQuotaForPrincipal?",
+                "tags": [],
+                "text": "(In reply to Shawn Huang [:shawnjohnjr] from comment #30)\n> (In reply to Shawn Huang [:shawnjohnjr] from comment #29)\n> > Per discussion in AllHands2016 Storage meeting, we will implement estimate\n> > method based on per site usage/quota. Bug 1281103 will implement\n> > |GetUsageForGroup|.\n> \n> As Tom suggests to name it |GetGroupUsageForPrincipal|.\n\nMaybe GetGroupUsageQuotaForPrincipal?",
+                "time": "2016-06-21T08:07:38Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "jvarga",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-21T09:10:11Z",
+                "creator": "jvarga",
+                "id": 11491876,
+                "is_private": false,
+                "raw_text": "Also note that current getUsageForPrincipal() counts usage for all storage types (default, temporary, persistent), but for estimates() to work correctly we need to only count default and temporary.\n\nInformation about all default and temporary storage origins is cached in GroupInfoPair/GroupInfo/OriginInfo objects, so in theory we don't have to touch the disk and just get usage/quota from these objects.\n\nIt's also questionable what should estimate() return when an origin in default storage gets persisted via navigator.persist(). I see basically two options:\n1. actual usage and quota as some big number\n2. zero usage and zero quota\n\nThe latter (2) would be easier to implement with regard to our current internal implementation (persisted origins are not quota tracked)\n\nYou might want to ask anne what he thinks about it.",
+                "tags": [],
+                "text": "Also note that current getUsageForPrincipal() counts usage for all storage types (default, temporary, persistent), but for estimates() to work correctly we need to only count default and temporary.\n\nInformation about all default and temporary storage origins is cached in GroupInfoPair/GroupInfo/OriginInfo objects, so in theory we don't have to touch the disk and just get usage/quota from these objects.\n\nIt's also questionable what should estimate() return when an origin in default storage gets persisted via navigator.persist(). I see basically two options:\n1. actual usage and quota as some big number\n2. zero usage and zero quota\n\nThe latter (2) would be easier to implement with regard to our current internal implementation (persisted origins are not quota tracked)\n\nYou might want to ask anne what he thinks about it.",
+                "time": "2016-06-21T09:10:11Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-21T11:31:39Z",
+                "creator": "shuang",
+                "id": 11492158,
+                "is_private": false,
+                "raw_text": "(In reply to Jan Varga [:janv] from comment #32)\n> Also note that current getUsageForPrincipal() counts usage for all storage\n> types (default, temporary, persistent), but for estimates() to work\n> correctly we need to only count default and temporary.\nHi Janv,\nThanks for all the hints.\nJust want to confirm I understand things correctly. I remember the discussion: https://github.com/whatwg/storage/issues/25#issuecomment-215400984\n\nSo eventually 'default' internal storage type contains both temporary and persistent storage data, and site storage unit shall store data in the 'default' directory. If clients call navigator.storage.persist(), we update metadata for 'default' internal storage type. We can ignore internal storage type 'persistent', because most site storage units won't store things in our internal 'persistent' storage folder. Is it correct? Or we should consider internal 'persistent' storage type currently? Currently can sites stored data in persistent folder?\n\n> \n> Information about all default and temporary storage origins is cached in\n> GroupInfoPair/GroupInfo/OriginInfo objects, so in theory we don't have to\n> touch the disk and just get usage/quota from these objects.\nOK, I also saw these cached info object.\n> \n> It's also questionable what should estimate() return when an origin in\n> default storage gets persisted via navigator.persist(). I see basically two\nYou mean navigator.storage.persist()?\n> options:\n> 1. actual usage and quota as some big number\nDo you mean returning 'actual' internal storage type \"default + temporary + persistent\"?\n> 2. zero usage and zero quota\nI don't understand why we return zero quota?",
+                "tags": [],
+                "text": "(In reply to Jan Varga [:janv] from comment #32)\n> Also note that current getUsageForPrincipal() counts usage for all storage\n> types (default, temporary, persistent), but for estimates() to work\n> correctly we need to only count default and temporary.\nHi Janv,\nThanks for all the hints.\nJust want to confirm I understand things correctly. I remember the discussion: https://github.com/whatwg/storage/issues/25#issuecomment-215400984\n\nSo eventually 'default' internal storage type contains both temporary and persistent storage data, and site storage unit shall store data in the 'default' directory. If clients call navigator.storage.persist(), we update metadata for 'default' internal storage type. We can ignore internal storage type 'persistent', because most site storage units won't store things in our internal 'persistent' storage folder. Is it correct? Or we should consider internal 'persistent' storage type currently? Currently can sites stored data in persistent folder?\n\n> \n> Information about all default and temporary storage origins is cached in\n> GroupInfoPair/GroupInfo/OriginInfo objects, so in theory we don't have to\n> touch the disk and just get usage/quota from these objects.\nOK, I also saw these cached info object.\n> \n> It's also questionable what should estimate() return when an origin in\n> default storage gets persisted via navigator.persist(). I see basically two\nYou mean navigator.storage.persist()?\n> options:\n> 1. actual usage and quota as some big number\nDo you mean returning 'actual' internal storage type \"default + temporary + persistent\"?\n> 2. zero usage and zero quota\nI don't understand why we return zero quota?",
+                "time": "2016-06-21T11:31:39Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "jvarga",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-21T12:36:51Z",
+                "creator": "jvarga",
+                "id": 11492269,
+                "is_private": false,
+                "raw_text": "(In reply to Shawn Huang [:shawnjohnjr] from comment #33)\n> (In reply to Jan Varga [:janv] from comment #32)\n> > Also note that current getUsageForPrincipal() counts usage for all storage\n> > types (default, temporary, persistent), but for estimates() to work\n> > correctly we need to only count default and temporary.\n> Hi Janv,\n> Thanks for all the hints.\n> Just want to confirm I understand things correctly. I remember the\n> discussion:\n> https://github.com/whatwg/storage/issues/25#issuecomment-215400984\n> \n> So eventually 'default' internal storage type contains both temporary and\n> persistent storage data, and site storage unit shall store data in the\n> 'default' directory. If clients call navigator.storage.persist(), we update\n> metadata for 'default' internal storage type. We can ignore internal storage\n> type 'persistent', because most site storage units won't store things in our\n> internal 'persistent' storage folder. Is it correct? Or we should consider\n> internal 'persistent' storage type currently? Currently can sites stored\n> data in persistent folder?\n\nI mean that current getUsageForPrincipal() also includes *explicit* persistent storage.\nI'm not talking about persistent origins in default storage.\n\n> \n> > \n> > Information about all default and temporary storage origins is cached in\n> > GroupInfoPair/GroupInfo/OriginInfo objects, so in theory we don't have to\n> > touch the disk and just get usage/quota from these objects.\n> OK, I also saw these cached info object.\n> > \n> > It's also questionable what should estimate() return when an origin in\n> > default storage gets persisted via navigator.persist(). I see basically two\n> You mean navigator.storage.persist()?\n\nYes\n\n> > options:\n> > 1. actual usage and quota as some big number\n> Do you mean returning 'actual' internal storage type \"default + temporary +\n> persistent\"?\n\nI mean we would calculate usage normally, that is, for example get it from OriginInfo, etc.\n\n\n> > 2. zero usage and zero quota\n> I don't understand why we return zero quota?\n\nWhen a box/origin is persisted using navigator.storage.persist(), it becomes persistent, so\nthere's no quota anymore, right ?\nSo either we return some big number or zero or maybe -1\nIt's quite convenient to return 0, because it's easy to detect it.",
+                "tags": [],
+                "text": "(In reply to Shawn Huang [:shawnjohnjr] from comment #33)\n> (In reply to Jan Varga [:janv] from comment #32)\n> > Also note that current getUsageForPrincipal() counts usage for all storage\n> > types (default, temporary, persistent), but for estimates() to work\n> > correctly we need to only count default and temporary.\n> Hi Janv,\n> Thanks for all the hints.\n> Just want to confirm I understand things correctly. I remember the\n> discussion:\n> https://github.com/whatwg/storage/issues/25#issuecomment-215400984\n> \n> So eventually 'default' internal storage type contains both temporary and\n> persistent storage data, and site storage unit shall store data in the\n> 'default' directory. If clients call navigator.storage.persist(), we update\n> metadata for 'default' internal storage type. We can ignore internal storage\n> type 'persistent', because most site storage units won't store things in our\n> internal 'persistent' storage folder. Is it correct? Or we should consider\n> internal 'persistent' storage type currently? Currently can sites stored\n> data in persistent folder?\n\nI mean that current getUsageForPrincipal() also includes *explicit* persistent storage.\nI'm not talking about persistent origins in default storage.\n\n> \n> > \n> > Information about all default and temporary storage origins is cached in\n> > GroupInfoPair/GroupInfo/OriginInfo objects, so in theory we don't have to\n> > touch the disk and just get usage/quota from these objects.\n> OK, I also saw these cached info object.\n> > \n> > It's also questionable what should estimate() return when an origin in\n> > default storage gets persisted via navigator.persist(). I see basically two\n> You mean navigator.storage.persist()?\n\nYes\n\n> > options:\n> > 1. actual usage and quota as some big number\n> Do you mean returning 'actual' internal storage type \"default + temporary +\n> persistent\"?\n\nI mean we would calculate usage normally, that is, for example get it from OriginInfo, etc.\n\n\n> > 2. zero usage and zero quota\n> I don't understand why we return zero quota?\n\nWhen a box/origin is persisted using navigator.storage.persist(), it becomes persistent, so\nthere's no quota anymore, right ?\nSo either we return some big number or zero or maybe -1\nIt's quite convenient to return 0, because it's easy to detect it.",
+                "time": "2016-06-21T12:36:51Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-22T07:11:05Z",
+                "creator": "shuang",
+                "id": 11494334,
+                "is_private": false,
+                "raw_text": "(In reply to Jan Varga [:janv] from comment #34)\n> (In reply to Shawn Huang [:shawnjohnjr] from comment #33)\n> > (In reply to Jan Varga [:janv] from comment #32)\n> \n> > > 2. zero usage and zero quota\n> > I don't understand why we return zero quota?\n> \n> When a box/origin is persisted using navigator.storage.persist(), it becomes\n> persistent, so\n> there's no quota anymore, right ?\n> So either we return some big number or zero or maybe -1\n> It's quite convenient to return 0, because it's easy to detect it.\n\nHi Anne,\nIs it true once box/origin is persisted, there's no quota anymore like janv said? From the specification, I can only see estimate() returns site storage unit usage/quota.",
+                "tags": [],
+                "text": "(In reply to Jan Varga [:janv] from comment #34)\n> (In reply to Shawn Huang [:shawnjohnjr] from comment #33)\n> > (In reply to Jan Varga [:janv] from comment #32)\n> \n> > > 2. zero usage and zero quota\n> > I don't understand why we return zero quota?\n> \n> When a box/origin is persisted using navigator.storage.persist(), it becomes\n> persistent, so\n> there's no quota anymore, right ?\n> So either we return some big number or zero or maybe -1\n> It's quite convenient to return 0, because it's easy to detect it.\n\nHi Anne,\nIs it true once box/origin is persisted, there's no quota anymore like janv said? From the specification, I can only see estimate() returns site storage unit usage/quota.",
+                "time": "2016-06-22T07:11:05Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "annevk",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-22T10:04:24Z",
+                "creator": "annevk",
+                "id": 11494572,
+                "is_private": false,
+                "raw_text": "I had imagined we would return large numbers. You can still run out of space after all and it is still useful to know how much you are using. Basically, the persistent grant might enlarge the amount of quota you get.",
+                "tags": [],
+                "text": "I had imagined we would return large numbers. You can still run out of space after all and it is still useful to know how much you are using. Basically, the persistent grant might enlarge the amount of quota you get.",
+                "time": "2016-06-22T10:04:24Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "jvarga",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-22T10:09:06Z",
+                "creator": "jvarga",
+                "id": 11494585,
+                "is_private": false,
+                "raw_text": "Yeah, that's the option 1.",
+                "tags": [],
+                "text": "Yeah, that's the option 1.",
+                "time": "2016-06-22T10:09:06Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-22T10:33:53Z",
+                "creator": "shuang",
+                "id": 11494625,
+                "is_private": false,
+                "raw_text": "(In reply to Anne (:annevk) from comment #36)\n> I had imagined we would return large numbers. You can still run out of space\n> after all and it is still useful to know how much you are using. Basically,\n> the persistent grant might enlarge the amount of quota you get.\n\nI don't understand 'the persistent grant might enlarge the amount of quota you get', can you explain it?",
+                "tags": [],
+                "text": "(In reply to Anne (:annevk) from comment #36)\n> I had imagined we would return large numbers. You can still run out of space\n> after all and it is still useful to know how much you are using. Basically,\n> the persistent grant might enlarge the amount of quota you get.\n\nI don't understand 'the persistent grant might enlarge the amount of quota you get', can you explain it?",
+                "time": "2016-06-22T10:33:53Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "annevk",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-22T10:45:20Z",
+                "creator": "annevk",
+                "id": 11494651,
+                "is_private": false,
+                "raw_text": "Say your current quota is X. You then ask the user for persistent storage permission? User agrees. The new current quota will then be X + Y (both positive integers) and the storage will be persistent.\n\nI think our strategy for now will be that X + Y equals most of the available space. Other browsers might do things a little different. See also bug 1281416 about figuring out a better minimum and maximum.",
+                "tags": [],
+                "text": "Say your current quota is X. You then ask the user for persistent storage permission? User agrees. The new current quota will then be X + Y (both positive integers) and the storage will be persistent.\n\nI think our strategy for now will be that X + Y equals most of the available space. Other browsers might do things a little different. See also bug 1281416 about figuring out a better minimum and maximum.",
+                "time": "2016-06-22T10:45:20Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "jvarga",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-22T11:14:54Z",
+                "creator": "jvarga",
+                "id": 11494703,
+                "is_private": false,
+                "raw_text": "Yeah, so estimate() will be useful even for persisted sites. The quota for it will be calculated using a get free disk space function (multiplied by say 0.8-0.9).",
+                "tags": [],
+                "text": "Yeah, so estimate() will be useful even for persisted sites. The quota for it will be calculated using a get free disk space function (multiplied by say 0.8-0.9).",
+                "time": "2016-06-22T11:14:54Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-27T10:58:49Z",
+                "creator": "shuang",
+                "id": 11503851,
+                "is_private": false,
+                "raw_text": "The patch will be revised after bug 1281103 finished.",
+                "tags": [],
+                "text": "The patch will be revised after bug 1281103 finished.",
+                "time": "2016-06-27T10:58:49Z"
+            },
+            {
+                "attachment_id": 8766267,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-29T11:32:27Z",
+                "creator": "shuang",
+                "id": 11510502,
+                "is_private": false,
+                "raw_text": "Re-base code again based on bug 1281103.",
+                "tags": [],
+                "text": "Created attachment 8766267\nbug-1267941.patch\n\nRe-base code again based on bug 1281103.",
+                "time": "2016-06-29T11:32:27Z"
+            },
+            {
+                "attachment_id": 8766269,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-06-29T11:40:45Z",
+                "creator": "shuang",
+                "id": 11510513,
+                "is_private": false,
+                "raw_text": "",
+                "tags": [],
+                "text": "Created attachment 8766269\nbug-1267941.patch",
+                "time": "2016-06-29T11:40:45Z"
+            },
+            {
+                "attachment_id": 8767112,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-01T09:54:34Z",
+                "creator": "shuang",
+                "id": 11516772,
+                "is_private": false,
+                "raw_text": "Add test cases for worker. Looking into issues after running estimate() in worker thread.",
+                "tags": [],
+                "text": "Created attachment 8767112\nbug-1267941.patch\n\nAdd test cases for worker. Looking into issues after running estimate() in worker thread.",
+                "time": "2016-07-01T09:54:34Z"
+            },
+            {
+                "attachment_id": 8767638,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-04T10:45:41Z",
+                "creator": "shuang",
+                "id": 11520772,
+                "is_private": false,
+                "raw_text": "",
+                "tags": [],
+                "text": "Created attachment 8767638\nbug-1267941.patch",
+                "time": "2016-07-04T10:45:41Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-11T08:39:48Z",
+                "creator": "shuang",
+                "id": 11537753,
+                "is_private": false,
+                "raw_text": "I found leakage during running test cases. I'm looking into it.",
+                "tags": [],
+                "text": "I found leakage during running test cases. I'm looking into it.",
+                "time": "2016-07-11T08:39:48Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-11T09:59:24Z",
+                "creator": "shuang",
+                "id": 11537964,
+                "is_private": false,
+                "raw_text": "Opps! I found the leakage happens after calling new UsageRequest.                                  \n    nsIQuotaUsageRequest* request = new UsageRequest(principal, callback);",
+                "tags": [],
+                "text": "Opps! I found the leakage happens after calling new UsageRequest.                                  \n    nsIQuotaUsageRequest* request = new UsageRequest(principal, callback);",
+                "time": "2016-07-11T09:59:24Z"
+            },
+            {
+                "attachment_id": 8769629,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-11T10:30:21Z",
+                "creator": "shuang",
+                "id": 11538006,
+                "is_private": false,
+                "raw_text": "Fix leakage issues.",
+                "tags": [],
+                "text": "Created attachment 8769629\nbug-1267941.patch\n\nFix leakage issues.",
+                "time": "2016-07-11T10:30:21Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-12T09:34:06Z",
+                "creator": "shuang",
+                "id": 11541070,
+                "is_private": false,
+                "raw_text": "I found the cache test case is wrong, I will fix it in the next revision.",
+                "tags": [],
+                "text": "I found the cache test case is wrong, I will fix it in the next revision.",
+                "time": "2016-07-12T09:34:06Z"
+            },
+            {
+                "attachment_id": 8770088,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-12T10:59:46Z",
+                "creator": "shuang",
+                "id": 11541238,
+                "is_private": false,
+                "raw_text": "",
+                "tags": [],
+                "text": "Created attachment 8770088\nbug-1267941.patch",
+                "time": "2016-07-12T10:59:46Z"
+            },
+            {
+                "attachment_id": 8770090,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-12T11:09:01Z",
+                "creator": "shuang",
+                "id": 11541253,
+                "is_private": false,
+                "raw_text": "",
+                "tags": [],
+                "text": "Created attachment 8770090\nbug-1267941.patch",
+                "time": "2016-07-12T11:09:01Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-13T08:17:17Z",
+                "creator": "shuang",
+                "id": 11544304,
+                "is_private": false,
+                "raw_text": "",
+                "tags": [],
+                "text": "*** Bug 1268804 has been marked as a duplicate of this bug. ***",
+                "time": "2016-07-13T08:17:17Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-13T10:03:52Z",
+                "creator": "shuang",
+                "id": 11544507,
+                "is_private": false,
+                "raw_text": "Hi bz,\nI added SecureContext annotation in Navigator.webidl based on https://storage.spec.whatwg.org/#api.\n\n[SecureContext, NoInterfaceObject, Exposed=(Window,Worker)]                     \ninterface NavigatorStorage {                                                    \n  readonly attribute StorageManager storage;                                    \n};\n\n\nWebIDL.WebIDLError: error: Interface with no interface object is exposed conditionally, /home/shawnjohnjr/code/mozilla-inbound/obj-x86_64-pc-linux-gnu/dom/bindings/Navigator.webidl line 91:0\ninterface NavigatorStorage {\n^\n\nIn WebIDL.py, comment says \"Conditional exposure makes no sense for interfaces with no           interface object, unless they're navigator properties.\"\n                \n        if (self.isExposedConditionally() and                                   \n            not self.hasInterfaceObject() and                                   \n            not self.isNavigatorProperty()):                                    \n            raise WebIDLError(\"Interface with no interface object is \"          \n                              \"exposed conditionally\",                          \n                              [self.location]) \n\nDoes that mean the Storage API specification is wrong?",
+                "tags": [],
+                "text": "Hi bz,\nI added SecureContext annotation in Navigator.webidl based on https://storage.spec.whatwg.org/#api.\n\n[SecureContext, NoInterfaceObject, Exposed=(Window,Worker)]                     \ninterface NavigatorStorage {                                                    \n  readonly attribute StorageManager storage;                                    \n};\n\n\nWebIDL.WebIDLError: error: Interface with no interface object is exposed conditionally, /home/shawnjohnjr/code/mozilla-inbound/obj-x86_64-pc-linux-gnu/dom/bindings/Navigator.webidl line 91:0\ninterface NavigatorStorage {\n^\n\nIn WebIDL.py, comment says \"Conditional exposure makes no sense for interfaces with no           interface object, unless they're navigator properties.\"\n                \n        if (self.isExposedConditionally() and                                   \n            not self.hasInterfaceObject() and                                   \n            not self.isNavigatorProperty()):                                    \n            raise WebIDLError(\"Interface with no interface object is \"          \n                              \"exposed conditionally\",                          \n                              [self.location]) \n\nDoes that mean the Storage API specification is wrong?",
+                "time": "2016-07-13T10:03:52Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "bzbarsky@mit.edu",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-13T13:31:27Z",
+                "creator": "bzbarsky@mit.edu",
+                "id": 11544978,
+                "is_private": false,
+                "raw_text": "No, it means that [SecureContext] does two jobs: conditional exposure of the interface _and_ conditional exposure of the interface members.  The former job makes no sense for [NoInterfaceObject] things, but the latter does.\n\nWhat we should probably do is add an optional argument to isExposedConditionally to not return true just because \"SecureContext\" is set and use that here along with a comment explaining that [SecureContext] is a sensible thing to do even on [NoInterfaceObject] interfaces.",
+                "tags": [],
+                "text": "No, it means that [SecureContext] does two jobs: conditional exposure of the interface _and_ conditional exposure of the interface members.  The former job makes no sense for [NoInterfaceObject] things, but the latter does.\n\nWhat we should probably do is add an optional argument to isExposedConditionally to not return true just because \"SecureContext\" is set and use that here along with a comment explaining that [SecureContext] is a sensible thing to do even on [NoInterfaceObject] interfaces.",
+                "time": "2016-07-13T13:31:27Z"
+            },
+            {
+                "attachment_id": 8771871,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-18T06:15:58Z",
+                "creator": "shuang",
+                "id": 11554148,
+                "is_private": false,
+                "raw_text": "After adding an annotation \"SecureContext\", storage api is not available for non-secure channel. I will check if we can make some changes to mochitests.\n\nJavaScript error: http://mochi.test:8888/tests/dom/cache/test/mochitest/test_cache_orphaned_body.html, line 48: TypeError: navigator.storage is undefined",
+                "tags": [],
+                "text": "Created attachment 8771871\nbug-1267941.patch\n\nAfter adding an annotation \"SecureContext\", storage api is not available for non-secure channel. I will check if we can make some changes to mochitests.\n\nJavaScript error: http://mochi.test:8888/tests/dom/cache/test/mochitest/test_cache_orphaned_body.html, line 48: TypeError: navigator.storage is undefined",
+                "time": "2016-07-18T06:15:58Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-18T08:05:52Z",
+                "creator": "shuang",
+                "id": 11554284,
+                "is_private": false,
+                "raw_text": "Marking blocked on Bug 1274315.\nBug 1274315 - Mochitest cannot be used to test [SecureContext] API",
+                "tags": [],
+                "text": "Marking blocked on Bug 1274315.\nBug 1274315 - Mochitest cannot be used to test [SecureContext] API",
+                "time": "2016-07-18T08:05:52Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-18T09:59:15Z",
+                "creator": "shuang",
+                "id": 11554510,
+                "is_private": false,
+                "raw_text": "Following https://bugzilla.mozilla.org/show_bug.cgi?id=1274315#c1, I guess we can open a new tab to load the test.",
+                "tags": [],
+                "text": "Following https://bugzilla.mozilla.org/show_bug.cgi?id=1274315#c1, I guess we can open a new tab to load the test.",
+                "time": "2016-07-18T09:59:15Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-19T06:45:23Z",
+                "creator": "shuang",
+                "id": 11557614,
+                "is_private": false,
+                "raw_text": "See also: https://bugzilla.mozilla.org/show_bug.cgi?id=1269052",
+                "tags": [],
+                "text": "See also: https://bugzilla.mozilla.org/show_bug.cgi?id=1269052",
+                "time": "2016-07-19T06:45:23Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-20T10:08:08Z",
+                "creator": "shuang",
+                "id": 11561374,
+                "is_private": false,
+                "raw_text": "Regarding 'SecureContext' issue added for Storage API, I followed bug 1274315 comment 1, I added dummy test and try to do 'window.open(\"https://example.com/tests/dom/cache/test/mochitest/file_cache_orphaned_body_storage.html\")'.\n\nBut now I still got 'TypeError: navigator.storage is undefined'.\n\n\n0 INFO SimpleTest START\n1 INFO TEST-START | dom/cache/test/mochitest/test_cache_storage.html\nJavaScript error: https://example.com/tests/dom/cache/test/mochitest/file_cache_orphaned_body_storage.html, line 50: TypeError: navigator.storage is undefined\n\nI'm not sure is there anything I missed.",
+                "tags": [],
+                "text": "Regarding 'SecureContext' issue added for Storage API, I followed bug 1274315 comment 1, I added dummy test and try to do 'window.open(\"https://example.com/tests/dom/cache/test/mochitest/file_cache_orphaned_body_storage.html\")'.\n\nBut now I still got 'TypeError: navigator.storage is undefined'.\n\n\n0 INFO SimpleTest START\n1 INFO TEST-START | dom/cache/test/mochitest/test_cache_storage.html\nJavaScript error: https://example.com/tests/dom/cache/test/mochitest/file_cache_orphaned_body_storage.html, line 50: TypeError: navigator.storage is undefined\n\nI'm not sure is there anything I missed.",
+                "time": "2016-07-20T10:08:08Z"
+            },
+            {
+                "attachment_id": 8772800,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-20T10:49:37Z",
+                "creator": "shuang",
+                "id": 11561450,
+                "is_private": false,
+                "raw_text": "Hi Ted,\nI followed your bug 1274315 Comment 1, I open a new tab by adding 'window.open(\"https://example.com/tests/dom/cache/test/mochitest/file_cache_orphaned_body_storage.html\")', but still cannot access navigator.storage. Do you have any idea?",
+                "tags": [],
+                "text": "Created attachment 8772800\ninterdiff.txt\n\nHi Ted,\nI followed your bug 1274315 Comment 1, I open a new tab by adding 'window.open(\"https://example.com/tests/dom/cache/test/mochitest/file_cache_orphaned_body_storage.html\")', but still cannot access navigator.storage. Do you have any idea?",
+                "time": "2016-07-20T10:49:37Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "bzbarsky@mit.edu",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-20T14:46:37Z",
+                "creator": "bzbarsky@mit.edu",
+                "id": 11562009,
+                "is_private": false,
+                "raw_text": "If you have an insecure context open a popup to an https url, that popup is still an insecure context per spec.",
+                "tags": [],
+                "text": "If you have an insecure context open a popup to an https url, that popup is still an insecure context per spec.",
+                "time": "2016-07-20T14:46:37Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "ted@mielczarek.org",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-20T17:38:05Z",
+                "creator": "ted@mielczarek.org",
+                "id": 11562560,
+                "is_private": false,
+                "raw_text": "Right, my suggestion from that comment was to use the Marionette API somehow, but I don't think that fits very well with how Mochitest is written currently.\n\nI think we need to get bug 1274315 sorted out, possibly by way of bug 1286312.",
+                "tags": [],
+                "text": "Right, my suggestion from that comment was to use the Marionette API somehow, but I don't think that fits very well with how Mochitest is written currently.\n\nI think we need to get bug 1274315 sorted out, possibly by way of bug 1286312.",
+                "time": "2016-07-20T17:38:05Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-21T06:56:59Z",
+                "creator": "shuang",
+                "id": 11564319,
+                "is_private": false,
+                "raw_text": "(In reply to Boris Zbarsky [:bz] from comment #61)\n> If you have an insecure context open a popup to an https url, that popup is\n> still an insecure context per spec.",
+                "tags": [],
+                "text": "(In reply to Boris Zbarsky [:bz] from comment #61)\n> If you have an insecure context open a popup to an https url, that popup is\n> still an insecure context per spec.",
+                "time": "2016-07-21T06:56:59Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-21T08:23:07Z",
+                "creator": "shuang",
+                "id": 11564430,
+                "is_private": false,
+                "raw_text": "(In reply to Ted Mielczarek [:ted.mielczarek] from comment #62)\n> Right, my suggestion from that comment was to use the Marionette API\n> somehow, but I don't think that fits very well with how Mochitest is written\n> currently.\n> \n> I think we need to get bug 1274315 sorted out, possibly by way of bug\n> 1286312.\nSo in bug 1286312, we're going to add '--use-https' option, but how do we specify the specific test case to run with https option? I guess we have to add argument '--user-https' in manifest.ini parser?",
+                "tags": [],
+                "text": "(In reply to Ted Mielczarek [:ted.mielczarek] from comment #62)\n> Right, my suggestion from that comment was to use the Marionette API\n> somehow, but I don't think that fits very well with how Mochitest is written\n> currently.\n> \n> I think we need to get bug 1274315 sorted out, possibly by way of bug\n> 1286312.\nSo in bug 1286312, we're going to add '--use-https' option, but how do we specify the specific test case to run with https option? I guess we have to add argument '--user-https' in manifest.ini parser?",
+                "time": "2016-07-21T08:23:07Z"
+            },
+            {
+                "attachment_id": 8773210,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-21T10:01:10Z",
+                "creator": "shuang",
+                "id": 11564596,
+                "is_private": false,
+                "raw_text": "Rebase again",
+                "tags": [],
+                "text": "Created attachment 8773210\nbug-1267941.patch\n\nRebase again",
+                "time": "2016-07-21T10:01:10Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "ted@mielczarek.org",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-21T19:03:49Z",
+                "creator": "ted@mielczarek.org",
+                "id": 11566267,
+                "is_private": false,
+                "raw_text": "I proposed in that bug that we just try loading the top-level page from https and see if anything breaks. If nothing does, we can just do that. If something does we'll have to add a manifest annotation to load specific tests from specific hosts.",
+                "tags": [],
+                "text": "I proposed in that bug that we just try loading the top-level page from https and see if anything breaks. If nothing does, we can just do that. If something does we'll have to add a manifest annotation to load specific tests from specific hosts.",
+                "time": "2016-07-21T19:03:49Z"
+            },
+            {
+                "attachment_id": 8774265,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-25T09:18:39Z",
+                "creator": "shuang",
+                "id": 11571893,
+                "is_private": false,
+                "raw_text": "Add Indexeddb test case for StorageManager estimate method.",
+                "tags": [],
+                "text": "Created attachment 8774265\nbug-1267941.patch\n\nAdd Indexeddb test case for StorageManager estimate method.",
+                "time": "2016-07-25T09:18:39Z"
+            },
+            {
+                "attachment_id": 8774281,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-25T09:46:19Z",
+                "creator": "shuang",
+                "id": 11571968,
+                "is_private": false,
+                "raw_text": "",
+                "tags": [],
+                "text": "Created attachment 8774281\nBug 1267941 - Implement Storage API estimate() feature",
+                "time": "2016-07-25T09:46:19Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-25T09:50:01Z",
+                "creator": "shuang",
+                "id": 11571974,
+                "is_private": false,
+                "raw_text": "https://treeherder.mozilla.org/#/jobs?repo=try&revision=2e73cda202c9",
+                "tags": [],
+                "text": "https://treeherder.mozilla.org/#/jobs?repo=try&revision=2e73cda202c9",
+                "time": "2016-07-25T09:50:01Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-25T10:17:12Z",
+                "creator": "shuang",
+                "id": 11572032,
+                "is_private": false,
+                "raw_text": "Based on Comment 66, I think it's better to enable SecureContext in bug 1268804.",
+                "tags": [],
+                "text": "Based on Comment 66, I think it's better to enable SecureContext in bug 1268804.",
+                "time": "2016-07-25T10:17:12Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-26T03:57:38Z",
+                "creator": "shuang",
+                "id": 11574400,
+                "is_private": false,
+                "raw_text": "(In reply to Shawn Huang [:shawnjohnjr] from comment #69)\n> https://treeherder.mozilla.org/#/jobs?repo=try&revision=2e73cda202c9\nI should be careful :(\n* dom/quota/StorageManager.cpp:115:3: error: bad implicit conversion constructor for 'MainThreadStorageRunnable\n* dom/workers/test/serviceworkers/test_serviceworker_interfaces.html\n* dom/tests/mochitest/general/test_interfaces.html",
+                "tags": [],
+                "text": "(In reply to Shawn Huang [:shawnjohnjr] from comment #69)\n> https://treeherder.mozilla.org/#/jobs?repo=try&revision=2e73cda202c9\nI should be careful :(\n* dom/quota/StorageManager.cpp:115:3: error: bad implicit conversion constructor for 'MainThreadStorageRunnable\n* dom/workers/test/serviceworkers/test_serviceworker_interfaces.html\n* dom/tests/mochitest/general/test_interfaces.html",
+                "time": "2016-07-26T03:57:38Z"
+            },
+            {
+                "attachment_id": 8774626,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-26T07:40:46Z",
+                "creator": "shuang",
+                "id": 11574634,
+                "is_private": false,
+                "raw_text": "Fixed test errors and build failure on the specific target\ntry: https://treeherder.mozilla.org/#/jobs?repo=try&revision=07bec679c779",
+                "tags": [],
+                "text": "Created attachment 8774626\nBug 1267941 - Implement Storage API estimate() feature\n\nFixed test errors and build failure on the specific target\ntry: https://treeherder.mozilla.org/#/jobs?repo=try&revision=07bec679c779",
+                "time": "2016-07-26T07:40:46Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-26T08:59:04Z",
+                "creator": "shuang",
+                "id": 11574770,
+                "is_private": false,
+                "raw_text": "(In reply to Shawn Huang [:shawnjohnjr] from comment #72)\n> Created attachment 8774626\n> Bug 1267941 - Implement Storage API estimate() feature\n> \n> Fixed test errors and build failure on the specific target\n> try: https://treeherder.mozilla.org/#/jobs?repo=try&revision=07bec679c779\n* dom/workers/test/test_navigator.html \n* dom/workers/test/test_worker_interfaces.html",
+                "tags": [],
+                "text": "(In reply to Shawn Huang [:shawnjohnjr] from comment #72)\n> Created attachment 8774626\n> Bug 1267941 - Implement Storage API estimate() feature\n> \n> Fixed test errors and build failure on the specific target\n> try: https://treeherder.mozilla.org/#/jobs?repo=try&revision=07bec679c779\n* dom/workers/test/test_navigator.html \n* dom/workers/test/test_worker_interfaces.html",
+                "time": "2016-07-26T08:59:04Z"
+            },
+            {
+                "attachment_id": 8774714,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-26T12:33:56Z",
+                "creator": "shuang",
+                "id": 11575254,
+                "is_private": false,
+                "raw_text": "Fixed test_navigator.html failure.\nBut still failed test_worker_interfaces.html.\n\n13 INFO TEST-UNEXPECTED-FAIL | dom/workers/test/test_worker_interfaces.html | uncaught exception - DataCloneError: The object could not be cloned. at workerTestExec/worker.onmessage@http://mochi.test:8888/tests/dom/workers/test/worker_driver.js:73:7\nEventHandlerNonNull*workerTestExec@http://mochi.test:8888/tests/dom/workers/test/worker_driver.js:32:3\n@http://mochi.test:8888/tests/dom/workers/test/test_worker_interfaces.html:13:1",
+                "tags": [],
+                "text": "Created attachment 8774714\nBug 1267941 - Implement Storage API estimate() feature\n\nFixed test_navigator.html failure.\nBut still failed test_worker_interfaces.html.\n\n13 INFO TEST-UNEXPECTED-FAIL | dom/workers/test/test_worker_interfaces.html | uncaught exception - DataCloneError: The object could not be cloned. at workerTestExec/worker.onmessage@http://mochi.test:8888/tests/dom/workers/test/worker_driver.js:73:7\nEventHandlerNonNull*workerTestExec@http://mochi.test:8888/tests/dom/workers/test/worker_driver.js:32:3\n@http://mochi.test:8888/tests/dom/workers/test/test_worker_interfaces.html:13:1",
+                "time": "2016-07-26T12:33:56Z"
+            },
+            {
+                "attachment_id": 8775042,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-27T07:29:33Z",
+                "creator": "shuang",
+                "id": 11577918,
+                "is_private": false,
+                "raw_text": "",
+                "tags": [],
+                "text": "Created attachment 8775042\nBug 1267941 - Implement Storage API estimate() feature",
+                "time": "2016-07-27T07:29:33Z"
+            },
+            {
+                "attachment_id": 8775044,
+                "author": "shuang",
+                "bug_id": 1267941,
+                "creation_time": "2016-07-27T07:35:45Z",
+                "creator": "shuang",
+                "id": 11577925,
+                "is_private": false,
+                "raw_text": "https://treeherder.mozilla.org/#/jobs?repo=try&revision=09dc51eaf4f0",
+                "tags": [],
+                "text": "Created attachment 8775044\nBug 1267941 - Implement Storage API estimate() feature\n\nhttps://treeherder.mozilla.org/#/jobs?repo=try&revision=09dc51eaf4f0",
+                "time": "2016-07-27T07:35:45Z"
+            }
+        ],
+        "component": "DOM",
+        "creation_time": "2016-04-27T07:36:19Z",
+        "creator": "shuang",
+        "creator_detail": {
+            "email": "shuang",
+            "id": 458181,
+            "name": "shuang",
+            "real_name": "Shawn Huang [:shawnjohnjr]"
+        },
+        "depends_on": [
+            1268804,
+            1274315,
+            1286312,
+            1281103,
+            1286548
+        ],
+        "dupe_of": null,
+        "flags": [],
+        "groups": [],
+        "history": [
+            {
+                "changes": [
+                    {
+                        "added": "1254428",
+                        "field_name": "blocks",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-04-27T07:38:03Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "htsai",
+                        "field_name": "cc",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-04-28T09:43:58Z",
+                "who": "htsai"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "btpp-fixlater",
+                        "field_name": "whiteboard",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-04-29T01:26:32Z",
+                "who": "overholt"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "shuang",
+                        "field_name": "assigned_to",
+                        "removed": "nobody@mozilla.org"
+                    }
+                ],
+                "when": "2016-04-29T08:13:26Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1268804",
+                        "field_name": "depends_on",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-04-29T08:14:23Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "btian",
+                        "field_name": "cc",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-05-04T07:25:19Z",
+                "who": "btian"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "jvarga",
+                        "field_name": "cc",
+                        "removed": ""
+                    },
+                    {
+                        "added": "needinfo?(jvarga)",
+                        "field_name": "flagtypes.name",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-05-04T13:06:00Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "",
+                        "field_name": "flagtypes.name",
+                        "removed": "needinfo?(jvarga)"
+                    }
+                ],
+                "when": "2016-05-04T13:08:07Z",
+                "who": "jvarga"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "needinfo?(jvarga)",
+                        "field_name": "flagtypes.name",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-05-04T13:31:42Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "",
+                        "field_name": "flagtypes.name",
+                        "removed": "needinfo?(jvarga)"
+                    }
+                ],
+                "when": "2016-05-04T13:33:27Z",
+                "who": "jvarga"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1",
+                        "attachment_id": 8748628,
+                        "field_name": "attachments.isobsolete",
+                        "removed": "0"
+                    }
+                ],
+                "when": "2016-05-04T13:51:16Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "ttung",
+                        "field_name": "cc",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-05-09T09:33:39Z",
+                "who": "ttung"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "needinfo?(jvarga)",
+                        "field_name": "flagtypes.name",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-06-01T08:00:51Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "",
+                        "field_name": "flagtypes.name",
+                        "removed": "needinfo?(jvarga)"
+                    }
+                ],
+                "when": "2016-06-01T08:18:29Z",
+                "who": "jvarga"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "needinfo?(jvarga)",
+                        "field_name": "flagtypes.name",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-06-01T11:22:21Z",
+                "who": "ttung"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "",
+                        "field_name": "flagtypes.name",
+                        "removed": "needinfo?(jvarga)"
+                    }
+                ],
+                "when": "2016-06-01T12:15:04Z",
+                "who": "jvarga"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1",
+                        "attachment_id": 8759067,
+                        "field_name": "attachments.isobsolete",
+                        "removed": "0"
+                    }
+                ],
+                "when": "2016-06-02T08:03:51Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "btpp-active",
+                        "field_name": "whiteboard",
+                        "removed": "btpp-fixlater"
+                    }
+                ],
+                "when": "2016-06-02T09:50:59Z",
+                "who": "htsai"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "bugmail",
+                        "field_name": "cc",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-06-02T21:43:52Z",
+                "who": "bugmail"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "needinfo?(jvarga)",
+                        "field_name": "flagtypes.name",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-06-03T11:00:45Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "",
+                        "field_name": "flagtypes.name",
+                        "removed": "needinfo?(jvarga)"
+                    }
+                ],
+                "when": "2016-06-06T06:06:44Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1",
+                        "attachment_id": 8759609,
+                        "field_name": "attachments.isobsolete",
+                        "removed": "0"
+                    }
+                ],
+                "when": "2016-06-06T09:32:36Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1",
+                        "attachment_id": 8760181,
+                        "field_name": "attachments.isobsolete",
+                        "removed": "0"
+                    }
+                ],
+                "when": "2016-06-08T09:12:46Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1",
+                        "attachment_id": 8761103,
+                        "field_name": "attachments.isobsolete",
+                        "removed": "0"
+                    }
+                ],
+                "when": "2016-06-14T13:13:42Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1",
+                        "attachment_id": 8761135,
+                        "field_name": "attachments.isobsolete",
+                        "removed": "0"
+                    }
+                ],
+                "when": "2016-06-14T16:46:10Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1",
+                        "attachment_id": 8762723,
+                        "field_name": "attachments.isobsolete",
+                        "removed": "0"
+                    }
+                ],
+                "when": "2016-06-16T12:57:24Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1",
+                        "attachment_id": 8763074,
+                        "field_name": "attachments.isobsolete",
+                        "removed": "0"
+                    }
+                ],
+                "when": "2016-06-17T10:00:39Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1281103",
+                        "field_name": "depends_on",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-06-21T07:38:20Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "needinfo?(jvarga)",
+                        "field_name": "flagtypes.name",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-06-21T11:31:39Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "",
+                        "field_name": "flagtypes.name",
+                        "removed": "needinfo?(jvarga)"
+                    }
+                ],
+                "when": "2016-06-21T12:36:51Z",
+                "who": "jvarga"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "annevk",
+                        "field_name": "cc",
+                        "removed": ""
+                    },
+                    {
+                        "added": "needinfo?(annevk)",
+                        "field_name": "flagtypes.name",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-06-22T07:11:05Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "",
+                        "field_name": "flagtypes.name",
+                        "removed": "needinfo?(annevk)"
+                    }
+                ],
+                "when": "2016-06-22T10:04:24Z",
+                "who": "annevk"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "needinfo?(annevk)",
+                        "field_name": "flagtypes.name",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-06-22T10:33:53Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "",
+                        "field_name": "flagtypes.name",
+                        "removed": "needinfo?(annevk)"
+                    }
+                ],
+                "when": "2016-06-22T10:45:20Z",
+                "who": "annevk"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1",
+                        "attachment_id": 8763198,
+                        "field_name": "attachments.isobsolete",
+                        "removed": "0"
+                    }
+                ],
+                "when": "2016-06-29T11:30:48Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1",
+                        "attachment_id": 8766267,
+                        "field_name": "attachments.isobsolete",
+                        "removed": "0"
+                    }
+                ],
+                "when": "2016-06-29T11:40:25Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1",
+                        "attachment_id": 8766269,
+                        "field_name": "attachments.isobsolete",
+                        "removed": "0"
+                    }
+                ],
+                "when": "2016-07-01T09:52:49Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1",
+                        "attachment_id": 8767112,
+                        "field_name": "attachments.isobsolete",
+                        "removed": "0"
+                    }
+                ],
+                "when": "2016-07-04T10:45:23Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1",
+                        "attachment_id": 8767638,
+                        "field_name": "attachments.isobsolete",
+                        "removed": "0"
+                    }
+                ],
+                "when": "2016-07-11T10:29:42Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1",
+                        "attachment_id": 8769629,
+                        "field_name": "attachments.isobsolete",
+                        "removed": "0"
+                    }
+                ],
+                "when": "2016-07-12T10:59:32Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1",
+                        "attachment_id": 8770088,
+                        "field_name": "attachments.isobsolete",
+                        "removed": "0"
+                    }
+                ],
+                "when": "2016-07-12T11:06:02Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "bzbarsky@mit.edu",
+                        "field_name": "cc",
+                        "removed": ""
+                    },
+                    {
+                        "added": "needinfo?(bzbarsky@mit.edu)",
+                        "field_name": "flagtypes.name",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-07-13T10:03:52Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "echen",
+                        "field_name": "cc",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-07-13T10:25:47Z",
+                "who": "echen"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "",
+                        "field_name": "flagtypes.name",
+                        "removed": "needinfo?(bzbarsky@mit.edu)"
+                    }
+                ],
+                "when": "2016-07-13T13:31:27Z",
+                "who": "bzbarsky@mit.edu"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1286548",
+                        "field_name": "depends_on",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-07-13T14:02:17Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1",
+                        "attachment_id": 8770090,
+                        "field_name": "attachments.isobsolete",
+                        "removed": "0"
+                    }
+                ],
+                "when": "2016-07-18T06:13:21Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1274315",
+                        "field_name": "depends_on",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-07-18T06:47:17Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1286717",
+                        "field_name": "blocks",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-07-18T07:50:28Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1287701",
+                        "field_name": "blocks",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-07-19T07:11:15Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "ted@mielczarek.org",
+                        "field_name": "cc",
+                        "removed": ""
+                    },
+                    {
+                        "added": "needinfo?(ted@mielczarek.org)",
+                        "field_name": "flagtypes.name",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-07-20T10:49:37Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "",
+                        "field_name": "flagtypes.name",
+                        "removed": "needinfo?(ted@mielczarek.org)"
+                    }
+                ],
+                "when": "2016-07-20T17:38:05Z",
+                "who": "ted@mielczarek.org"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1286312",
+                        "field_name": "depends_on",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-07-21T06:56:59Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "needinfo?(ted@mielczarek.org)",
+                        "field_name": "flagtypes.name",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-07-21T08:23:07Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1",
+                        "attachment_id": 8772800,
+                        "field_name": "attachments.isobsolete",
+                        "removed": "0"
+                    }
+                ],
+                "when": "2016-07-21T08:48:27Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1",
+                        "attachment_id": 8771871,
+                        "field_name": "attachments.isobsolete",
+                        "removed": "0"
+                    }
+                ],
+                "when": "2016-07-21T10:00:09Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "",
+                        "field_name": "flagtypes.name",
+                        "removed": "needinfo?(ted@mielczarek.org)"
+                    }
+                ],
+                "when": "2016-07-21T19:03:49Z",
+                "who": "ted@mielczarek.org"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1",
+                        "attachment_id": 8773210,
+                        "field_name": "attachments.isobsolete",
+                        "removed": "0"
+                    }
+                ],
+                "when": "2016-07-25T09:18:00Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1",
+                        "attachment_id": 8774265,
+                        "field_name": "attachments.isobsolete",
+                        "removed": "0"
+                    }
+                ],
+                "when": "2016-07-25T09:44:10Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "",
+                        "field_name": "cc",
+                        "removed": "bzbarsky@mit.edu"
+                    }
+                ],
+                "when": "2016-07-25T13:58:51Z",
+                "who": "bzbarsky@mit.edu"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1",
+                        "attachment_id": 8774281,
+                        "field_name": "attachments.isobsolete",
+                        "removed": "0"
+                    }
+                ],
+                "when": "2016-07-26T07:39:08Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1",
+                        "attachment_id": 8774626,
+                        "field_name": "attachments.isobsolete",
+                        "removed": "0"
+                    }
+                ],
+                "when": "2016-07-26T12:30:27Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "",
+                        "field_name": "cc",
+                        "removed": "ted@mielczarek.org"
+                    }
+                ],
+                "when": "2016-07-26T13:46:32Z",
+                "who": "ted@mielczarek.org"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1",
+                        "attachment_id": 8774714,
+                        "field_name": "attachments.isobsolete",
+                        "removed": "0"
+                    }
+                ],
+                "when": "2016-07-27T07:29:03Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1",
+                        "attachment_id": 8775042,
+                        "field_name": "attachments.isobsolete",
+                        "removed": "0"
+                    }
+                ],
+                "when": "2016-07-27T07:32:49Z",
+                "who": "shuang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1",
+                        "attachment_id": 8775044,
+                        "field_name": "attachments.isobsolete",
+                        "removed": "0"
+                    }
+                ],
+                "when": "2016-07-27T10:00:46Z",
+                "who": "shuang"
+            }
+        ],
+        "id": 1267941,
+        "is_cc_accessible": true,
+        "is_confirmed": true,
+        "is_creator_accessible": true,
+        "is_open": true,
+        "keywords": [],
+        "last_change_time": "2016-07-27T10:00:46Z",
+        "mentors": [],
+        "mentors_detail": [],
+        "op_sys": "Unspecified",
+        "platform": "Unspecified",
+        "priority": "--",
+        "product": "Core",
+        "qa_contact": "",
+        "resolution": "",
+        "see_also": [],
+        "severity": "normal",
+        "status": "NEW",
+        "summary": "Implement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() featureImplement Storage API estimate() feature",
+        "target_milestone": "---",
+        "url": "",
+        "version": "unspecified",
+        "votes": 0,
+        "whiteboard": "btpp-active"
+    },
+    "origin": "https://bugzilla.mozilla.org/",
+    "perceval_version": "0.2.0",
+    "timestamp": 1469613768.249659,
+    "updated_on": 1469613646.0,
+    "uuid": "9b19710bc823a781c8b7614cd24b406678583874"
+},
+{
+    "backend_name": "BugzillaREST",
+    "backend_version": "0.2.0",
+    "data": {
+        "alias": null,
+        "assigned_to": "cam",
+        "assigned_to_detail": {
+            "email": "cam",
+            "id": 54040,
+            "name": "cam",
+            "real_name": "Cameron McCormack (:heycam)"
+        },
+        "attachments": [
+            {
+                "attacher": "cam",
+                "bug_id": 1289710,
+                "content_type": "text/x-review-board-request",
+                "creation_time": "2016-07-27T09:26:24Z",
+                "creator": "cam",
+                "description": "Bug 1289710 - Allow KTableEntry objects to be initialized with enum values of appropriate size.",
+                "file_name": "reviewboard-67400-url.txt",
+                "flags": [
+                    {
+                        "creation_date": "2016-07-27T09:26:24Z",
+                        "id": 1429882,
+                        "modification_date": "2016-07-27T10:00:54Z",
+                        "name": "review",
+                        "setter": "xidorn+moz",
+                        "status": "+",
+                        "type_id": 4
+                    }
+                ],
+                "id": 8775080,
+                "is_obsolete": 0,
+                "is_patch": 0,
+                "is_private": 0,
+                "last_change_time": "2016-07-27T10:00:54Z",
+                "size": 58,
+                "summary": "Bug 1289710 - Allow KTableEntry objects to be initialized with enum values of appropriate size."
+            }
+        ],
+        "blocks": [
+            1277133
+        ],
+        "cc": [
+            "xidorn+moz"
+        ],
+        "cc_detail": [
+            {
+                "email": "xidorn+moz",
+                "id": 373403,
+                "name": "xidorn+moz",
+                "real_name": "Xidorn Quan [:xidorn] (UTC+10)"
+            }
+        ],
+        "cf_blocking_b2g": "---",
+        "cf_blocking_fennec": "---",
+        "cf_blocking_fx": "---",
+        "cf_crash_signature": "",
+        "cf_feature_b2g": "---",
+        "cf_fx_iteration": "---",
+        "cf_fx_points": "---",
+        "cf_has_regression_range": "---",
+        "cf_has_str": "---",
+        "cf_last_resolved": null,
+        "cf_platform_rel": "---",
+        "cf_qa_whiteboard": "",
+        "cf_rank": null,
+        "cf_status_b2g_2_6": "---",
+        "cf_status_firefox47": "---",
+        "cf_status_firefox48": "---",
+        "cf_status_firefox49": "---",
+        "cf_status_firefox50": "---",
+        "cf_status_firefox_esr45": "---",
+        "cf_status_thunderbird_esr38": "---",
+        "cf_status_thunderbird_esr45": "---",
+        "cf_tracking_b2g": "---",
+        "cf_tracking_e10s": "---",
+        "cf_tracking_firefox47": "---",
+        "cf_tracking_firefox48": "---",
+        "cf_tracking_firefox49": "---",
+        "cf_tracking_firefox50": "---",
+        "cf_tracking_firefox_esr45": "---",
+        "cf_tracking_firefox_relnote": "---",
+        "cf_tracking_thunderbird_esr38": "---",
+        "cf_tracking_thunderbird_esr45": "---",
+        "cf_user_story": "",
+        "classification": "Components",
+        "comments": [
+            {
+                "attachment_id": null,
+                "author": "cam",
+                "bug_id": 1289710,
+                "creation_time": "2016-07-27T09:23:40Z",
+                "creator": "cam",
+                "id": 11578131,
+                "is_private": false,
+                "raw_text": "From bug 1277133 comment 3.",
+                "tags": [],
+                "text": "From bug 1277133 comment 3.",
+                "time": "2016-07-27T09:23:40Z"
+            },
+            {
+                "attachment_id": 8775080,
+                "author": "cam",
+                "bug_id": 1289710,
+                "creation_time": "2016-07-27T09:26:24Z",
+                "creator": "cam",
+                "id": 11578139,
+                "is_private": false,
+                "raw_text": "Review commit: https://reviewboard.mozilla.org/r/67400/diff/#index_header\nSee other reviews: https://reviewboard.mozilla.org/r/67400/",
+                "tags": [],
+                "text": "Created attachment 8775080\nBug 1289710 - Allow KTableEntry objects to be initialized with enum values of appropriate size.\n\nReview commit: https://reviewboard.mozilla.org/r/67400/diff/#index_header\nSee other reviews: https://reviewboard.mozilla.org/r/67400/",
+                "time": "2016-07-27T09:26:24Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "cam",
+                "bug_id": 1289710,
+                "creation_time": "2016-07-27T09:28:13Z",
+                "creator": "cam",
+                "id": 11578141,
+                "is_private": false,
+                "raw_text": "Building: https://treeherder.mozilla.org/#/jobs?repo=try&revision=a01ecc81e67b\nFailing when using an inappropriately sized enum: https://treeherder.mozilla.org/#/jobs?repo=try&revision=5f3911de9e6b&selectedJob=24592340",
+                "tags": [],
+                "text": "Building: https://treeherder.mozilla.org/#/jobs?repo=try&revision=a01ecc81e67b\nFailing when using an inappropriately sized enum: https://treeherder.mozilla.org/#/jobs?repo=try&revision=5f3911de9e6b&selectedJob=24592340",
+                "time": "2016-07-27T09:28:13Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "cam",
+                "bug_id": 1289710,
+                "creation_time": "2016-07-27T09:48:57Z",
+                "creator": "cam",
+                "id": 11578192,
+                "is_private": false,
+                "raw_text": "I notice that, for example, nsCSSProps::ValueToKeywordEnum takes an int32_t, even though all valid keywords must fit within an int16_t.  ValueToKeywordEnum then asserts that the value will fit.  Should we do the same for the KTableEntry constructor that takes the integer type?",
+                "tags": [],
+                "text": "I notice that, for example, nsCSSProps::ValueToKeywordEnum takes an int32_t, even though all valid keywords must fit within an int16_t.  ValueToKeywordEnum then asserts that the value will fit.  Should we do the same for the KTableEntry constructor that takes the integer type?",
+                "time": "2016-07-27T09:48:57Z"
+            },
+            {
+                "attachment_id": 8775080,
+                "author": "xidorn+moz",
+                "bug_id": 1289710,
+                "creation_time": "2016-07-27T10:00:54Z",
+                "creator": "xidorn+moz",
+                "id": 11578222,
+                "is_private": false,
+                "raw_text": "https://reviewboard.mozilla.org/r/67400/#review64434\n\nLooks good. Thanks.\n\n::: layout/style/nsCSSProps.h:359\n(Diff revision 1)\n> +struct IsEnumFittingWithin\n> +  : std::conditional<std::is_enum<T>::value,\n> +                     detail::IsEnumFittingWithinHelper<T, Storage>,\n> +                     std::false_type>::type\n\nGiven you call it \"IsEnumFittingWithin\", how about just static_assert that T is an enum, and get rid of the std::conditional wrap and just make this struct inherit IsIntegralFittingWithin directly?",
+                "tags": [],
+                "text": "Comment on attachment 8775080\nBug 1289710 - Allow KTableEntry objects to be initialized with enum values of appropriate size.\n\nhttps://reviewboard.mozilla.org/r/67400/#review64434\n\nLooks good. Thanks.\n\n::: layout/style/nsCSSProps.h:359\n(Diff revision 1)\n> +struct IsEnumFittingWithin\n> +  : std::conditional<std::is_enum<T>::value,\n> +                     detail::IsEnumFittingWithinHelper<T, Storage>,\n> +                     std::false_type>::type\n\nGiven you call it \"IsEnumFittingWithin\", how about just static_assert that T is an enum, and get rid of the std::conditional wrap and just make this struct inherit IsIntegralFittingWithin directly?",
+                "time": "2016-07-27T10:00:54Z"
+            }
+        ],
+        "component": "CSS Parsing and Computation",
+        "creation_time": "2016-07-27T09:23:40Z",
+        "creator": "cam",
+        "creator_detail": {
+            "email": "cam",
+            "id": 54040,
+            "name": "cam",
+            "real_name": "Cameron McCormack (:heycam)"
+        },
+        "depends_on": [],
+        "dupe_of": null,
+        "flags": [],
+        "groups": [],
+        "history": [
+            {
+                "changes": [
+                    {
+                        "added": "review?(xidorn+moz)",
+                        "attachment_id": 8775080,
+                        "field_name": "flagtypes.name",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-07-27T09:26:24Z",
+                "who": "cam"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "review+",
+                        "attachment_id": 8775080,
+                        "field_name": "flagtypes.name",
+                        "removed": "review?(xidorn+moz)"
+                    }
+                ],
+                "when": "2016-07-27T10:00:54Z",
+                "who": "xidorn+moz"
+            }
+        ],
+        "id": 1289710,
+        "is_cc_accessible": true,
+        "is_confirmed": true,
+        "is_creator_accessible": true,
+        "is_open": true,
+        "keywords": [],
+        "last_change_time": "2016-07-27T10:00:54Z",
+        "mentors": [],
+        "mentors_detail": [],
+        "op_sys": "Unspecified",
+        "platform": "Unspecified",
+        "priority": "--",
+        "product": "Core",
+        "qa_contact": "",
+        "resolution": "",
+        "see_also": [],
+        "severity": "normal",
+        "status": "ASSIGNED",
+        "summary": "allow KTableEntry objects to be initialized with enum values",
+        "target_milestone": "---",
+        "url": "",
+        "version": "unspecified",
+        "votes": 0,
+        "whiteboard": ""
+    },
+    "origin": "https://bugzilla.mozilla.org/",
+    "perceval_version": "0.2.0",
+    "timestamp": 1469613768.26616,
+    "updated_on": 1469613654.0,
+    "uuid": "447cf03583c19510423d35b9c9d4dd63f8f16aa8"
+},
+{
+    "backend_name": "BugzillaREST",
+    "backend_version": "0.2.0",
+    "data": {
+        "alias": null,
+        "assigned_to": "gijskruitbosch+bugs",
+        "assigned_to_detail": {
+            "email": "gijskruitbosch+bugs",
+            "id": 159069,
+            "name": "gijskruitbosch+bugs",
+            "real_name": ":Gijs Kruitbosch (Gone July 28 - Aug 11)"
+        },
+        "attachments": [
+            {
+                "attacher": "gijskruitbosch+bugs",
+                "bug_id": 1289436,
+                "content_type": "text/x-review-board-request",
+                "creation_time": "2016-07-26T17:06:53Z",
+                "creator": "gijskruitbosch+bugs",
+                "description": "Bug 1289436 - add telemetry for the length of time we take to import data,",
+                "file_name": "reviewboard-67222-url.txt",
+                "flags": [
+                    {
+                        "creation_date": "2016-07-26T17:06:53Z",
+                        "id": 1429478,
+                        "modification_date": "2016-07-26T17:06:53Z",
+                        "name": "review",
+                        "requestee": "benjamin",
+                        "setter": "gijskruitbosch+bugs",
+                        "status": "?",
+                        "type_id": 748
+                    },
+                    {
+                        "creation_date": "2016-07-26T17:06:53Z",
+                        "id": 1429479,
+                        "modification_date": "2016-07-26T18:46:47Z",
+                        "name": "review",
+                        "setter": "jaws",
+                        "status": "+",
+                        "type_id": 748
+                    }
+                ],
+                "id": 8774811,
+                "is_obsolete": 0,
+                "is_patch": 0,
+                "is_private": 0,
+                "last_change_time": "2016-07-26T18:46:47Z",
+                "size": 58,
+                "summary": "Bug 1289436 - add telemetry for the length of time we take to import data,"
+            }
+        ],
+        "blocks": [
+            1289172
+        ],
+        "cc": [
+            "benjamin",
+            "dolske",
+            "jaws"
+        ],
+        "cc_detail": [
+            {
+                "email": "benjamin",
+                "id": 7044,
+                "name": "benjamin",
+                "real_name": "Benjamin Smedberg AWAY UNTIL 2-AUG-2016 [:bsmedberg]"
+            },
+            {
+                "email": "dolske",
+                "id": 27780,
+                "name": "dolske",
+                "real_name": "Justin Dolske [:Dolske]"
+            },
+            {
+                "email": "jaws",
+                "id": 409754,
+                "name": "jaws",
+                "real_name": "Jared Wein [:jaws] (please needinfo? me)"
+            }
+        ],
+        "cf_crash_signature": "",
+        "cf_fx_iteration": "---",
+        "cf_fx_points": "---",
+        "cf_has_regression_range": "---",
+        "cf_has_str": "---",
+        "cf_last_resolved": null,
+        "cf_platform_rel": "---",
+        "cf_qa_whiteboard": "",
+        "cf_rank": null,
+        "cf_status_firefox47": "---",
+        "cf_status_firefox48": "---",
+        "cf_status_firefox49": "---",
+        "cf_status_firefox50": "affected",
+        "cf_status_firefox_esr45": "---",
+        "cf_tracking_e10s": "---",
+        "cf_tracking_firefox47": "---",
+        "cf_tracking_firefox48": "---",
+        "cf_tracking_firefox49": "---",
+        "cf_tracking_firefox50": "---",
+        "cf_tracking_firefox_esr45": "---",
+        "cf_tracking_firefox_relnote": "---",
+        "cf_user_story": "",
+        "classification": "Client Software",
+        "comments": [
+            {
+                "attachment_id": null,
+                "author": "gijskruitbosch+bugs",
+                "bug_id": 1289436,
+                "creation_time": "2016-07-26T13:57:25Z",
+                "creator": "gijskruitbosch+bugs",
+                "id": 11575439,
+                "is_private": false,
+                "raw_text": "",
+                "tags": [],
+                "text": "",
+                "time": "2016-07-26T13:57:25Z"
+            },
+            {
+                "attachment_id": 8774811,
+                "author": "gijskruitbosch+bugs",
+                "bug_id": 1289436,
+                "creation_time": "2016-07-26T17:06:53Z",
+                "creator": "gijskruitbosch+bugs",
+                "id": 11576076,
+                "is_private": false,
+                "raw_text": "Review commit: https://reviewboard.mozilla.org/r/67222/diff/#index_header\nSee other reviews: https://reviewboard.mozilla.org/r/67222/",
+                "tags": [],
+                "text": "Created attachment 8774811\nBug 1289436 - add telemetry for the length of time we take to import data,\n\nReview commit: https://reviewboard.mozilla.org/r/67222/diff/#index_header\nSee other reviews: https://reviewboard.mozilla.org/r/67222/",
+                "time": "2016-07-26T17:06:53Z"
+            },
+            {
+                "attachment_id": 8774811,
+                "author": "jaws",
+                "bug_id": 1289436,
+                "creation_time": "2016-07-26T18:46:47Z",
+                "creator": "jaws",
+                "id": 11576443,
+                "is_private": false,
+                "raw_text": "https://reviewboard.mozilla.org/r/67222/#review64154\n\n::: browser/components/migration/MigrationUtils.jsm:239\n(Diff revision 1)\n> +    let maybeStartTelemetry = (resourceType, resource) => {\n> +      let histogram = getHistogramForResourceType(resourceType);\n> +      if (histogram) {\n> +        TelemetryStopwatch.startKeyed(histogram, this.getKey(), resource);\n> +      }\n> +    };\n> +    let maybeStopTelemetry = (resourceType, resource) => {\n> +      let histogram = getHistogramForResourceType(resourceType);\n> +      if (histogram) {\n> +        TelemetryStopwatch.finishKeyed(histogram, this.getKey(), resource);\n\nThese function names almost sound like they are starting and stopping the complete Telemetry system.\n\nCan you rename these functions to\nmaybeStartTelemetryStopwatch and maybeStopTelemetryStopwatch? Or maybe you can think of a better name?",
+                "tags": [],
+                "text": "Comment on attachment 8774811\nBug 1289436 - add telemetry for the length of time we take to import data,\n\nhttps://reviewboard.mozilla.org/r/67222/#review64154\n\n::: browser/components/migration/MigrationUtils.jsm:239\n(Diff revision 1)\n> +    let maybeStartTelemetry = (resourceType, resource) => {\n> +      let histogram = getHistogramForResourceType(resourceType);\n> +      if (histogram) {\n> +        TelemetryStopwatch.startKeyed(histogram, this.getKey(), resource);\n> +      }\n> +    };\n> +    let maybeStopTelemetry = (resourceType, resource) => {\n> +      let histogram = getHistogramForResourceType(resourceType);\n> +      if (histogram) {\n> +        TelemetryStopwatch.finishKeyed(histogram, this.getKey(), resource);\n\nThese function names almost sound like they are starting and stopping the complete Telemetry system.\n\nCan you rename these functions to\nmaybeStartTelemetryStopwatch and maybeStopTelemetryStopwatch? Or maybe you can think of a better name?",
+                "time": "2016-07-26T18:46:47Z"
+            },
+            {
+                "attachment_id": 8774811,
+                "author": "gijskruitbosch+bugs",
+                "bug_id": 1289436,
+                "creation_time": "2016-07-27T10:02:00Z",
+                "creator": "gijskruitbosch+bugs",
+                "id": 11578223,
+                "is_private": false,
+                "raw_text": "Review request updated; see interdiff: https://reviewboard.mozilla.org/r/67222/diff/1-2/",
+                "tags": [],
+                "text": "Comment on attachment 8774811\nBug 1289436 - add telemetry for the length of time we take to import data,\n\nReview request updated; see interdiff: https://reviewboard.mozilla.org/r/67222/diff/1-2/",
+                "time": "2016-07-27T10:02:00Z"
+            }
+        ],
+        "component": "Migration",
+        "creation_time": "2016-07-26T13:57:25Z",
+        "creator": "gijskruitbosch+bugs",
+        "creator_detail": {
+            "email": "gijskruitbosch+bugs",
+            "id": 159069,
+            "name": "gijskruitbosch+bugs",
+            "real_name": ":Gijs Kruitbosch (Gone July 28 - Aug 11)"
+        },
+        "depends_on": [],
+        "dupe_of": null,
+        "flags": [],
+        "groups": [],
+        "history": [
+            {
+                "changes": [
+                    {
+                        "added": "review?(benjamin), review?(jaws)",
+                        "attachment_id": 8774811,
+                        "field_name": "flagtypes.name",
+                        "removed": ""
+                    },
+                    {
+                        "added": "benjamin, jaws",
+                        "field_name": "cc",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-07-26T17:06:53Z",
+                "who": "gijskruitbosch+bugs"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "review+",
+                        "attachment_id": 8774811,
+                        "field_name": "flagtypes.name",
+                        "removed": "review?(jaws)"
+                    }
+                ],
+                "when": "2016-07-26T18:46:47Z",
+                "who": "jaws"
+            }
+        ],
+        "id": 1289436,
+        "is_cc_accessible": true,
+        "is_confirmed": true,
+        "is_creator_accessible": true,
+        "is_open": true,
+        "keywords": [],
+        "last_change_time": "2016-07-27T10:02:00Z",
+        "mentors": [],
+        "mentors_detail": [],
+        "op_sys": "Unspecified",
+        "platform": "Unspecified",
+        "priority": "--",
+        "product": "Firefox",
+        "qa_contact": "",
+        "resolution": "",
+        "see_also": [],
+        "severity": "normal",
+        "status": "ASSIGNED",
+        "summary": "Add telemetry for the time it takes to import history, bookmarks and logins",
+        "target_milestone": "---",
+        "url": "",
+        "version": "Trunk",
+        "votes": 0,
+        "whiteboard": ""
+    },
+    "origin": "https://bugzilla.mozilla.org/",
+    "perceval_version": "0.2.0",
+    "timestamp": 1469613768.268261,
+    "updated_on": 1469613720.0,
+    "uuid": "b1e928077f6641f79fb5da84c1c661fa2c1fffe0"
+},
+{
+    "backend_name": "BugzillaREST",
+    "backend_version": "0.2.0",
+    "data": {
+        "alias": null,
+        "assigned_to": "kechang",
+        "assigned_to_detail": {
+            "email": "kechang",
+            "id": 505624,
+            "name": "kechang",
+            "real_name": "Kershaw Chang [:kershaw]"
+        },
+        "attachments": [
+            {
+                "attacher": "kechang",
+                "bug_id": 1197690,
+                "content_type": "text/plain",
+                "creation_time": "2016-07-14T09:37:24Z",
+                "creator": "kechang",
+                "description": "Part1: Support reconnect command",
+                "file_name": "0001-Bug-1197690-Part1-Support-reconnect-command.patch",
+                "flags": [],
+                "id": 8770881,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-07-15T10:55:37Z",
+                "size": 31089,
+                "summary": "Part1: Support reconnect command"
+            },
+            {
+                "attacher": "kechang",
+                "bug_id": 1197690,
+                "content_type": "text/plain",
+                "creation_time": "2016-07-14T09:38:06Z",
+                "creator": "kechang",
+                "description": "Part2: Implement reconnect",
+                "file_name": "0002-Bug-1197690-Part2-Implement-reconnect.patch",
+                "flags": [],
+                "id": 8770882,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-07-20T09:36:49Z",
+                "size": 38254,
+                "summary": "Part2: Implement reconnect"
+            },
+            {
+                "attacher": "kechang",
+                "bug_id": 1197690,
+                "content_type": "text/plain",
+                "creation_time": "2016-07-15T10:55:37Z",
+                "creator": "kechang",
+                "description": "Part1: Support reconnect command - v2",
+                "file_name": "0001-Bug-1197690-Part1-Support-reconnect-command.patch",
+                "flags": [],
+                "id": 8771370,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-07-19T06:48:43Z",
+                "size": 40045,
+                "summary": "Part1: Support reconnect command - v2"
+            },
+            {
+                "attacher": "kechang",
+                "bug_id": 1197690,
+                "content_type": "text/plain",
+                "creation_time": "2016-07-19T06:48:43Z",
+                "creator": "kechang",
+                "description": "Part1: Support reconnect command - v3",
+                "file_name": "0001-Bug-1197690-Part1-Support-reconnect-command.patch",
+                "flags": [
+                    {
+                        "creation_date": "2016-07-19T06:48:43Z",
+                        "id": 1425672,
+                        "modification_date": "2016-07-19T10:03:02Z",
+                        "name": "review",
+                        "setter": "juhsu",
+                        "status": "+",
+                        "type_id": 4
+                    }
+                ],
+                "id": 8772298,
+                "is_obsolete": 0,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-07-19T10:03:02Z",
+                "size": 40750,
+                "summary": "Part1: Support reconnect command - v3"
+            },
+            {
+                "attacher": "kechang",
+                "bug_id": 1197690,
+                "content_type": "text/plain",
+                "creation_time": "2016-07-20T09:36:49Z",
+                "creator": "kechang",
+                "description": "Part2: Implement reconnect - v2",
+                "file_name": "0002-Bug-1197690-Part2-Implement-reconnect.patch",
+                "flags": [
+                    {
+                        "creation_date": "2016-07-20T09:36:49Z",
+                        "id": 1426430,
+                        "modification_date": "2016-07-22T03:30:56Z",
+                        "name": "feedback",
+                        "setter": "schien",
+                        "status": "+",
+                        "type_id": 607
+                    }
+                ],
+                "id": 8772767,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-07-27T03:50:22Z",
+                "size": 58400,
+                "summary": "Part2: Implement reconnect - v2"
+            },
+            {
+                "attacher": "kechang",
+                "bug_id": 1197690,
+                "content_type": "text/plain",
+                "creation_time": "2016-07-27T03:50:22Z",
+                "creator": "kechang",
+                "description": "Part2: Implement reconnect - v3",
+                "file_name": "0002-Bug-1197690-Part2-Implement-reconnect.patch",
+                "flags": [
+                    {
+                        "creation_date": "2016-07-27T03:50:22Z",
+                        "id": 1429800,
+                        "modification_date": "2016-07-27T08:29:06Z",
+                        "name": "feedback",
+                        "setter": "schien",
+                        "status": "+",
+                        "type_id": 607
+                    }
+                ],
+                "id": 8775004,
+                "is_obsolete": 0,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-07-27T08:29:06Z",
+                "size": 88997,
+                "summary": "Part2: Implement reconnect - v3"
+            },
+            {
+                "attacher": "kechang",
+                "bug_id": 1197690,
+                "content_type": "text/plain",
+                "creation_time": "2016-07-27T03:51:18Z",
+                "creator": "kechang",
+                "description": "Interdiff for part2",
+                "file_name": "0001-fixup-Bug-1197690-Part2-Implement-reconnect.patch",
+                "flags": [],
+                "id": 8775005,
+                "is_obsolete": 0,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-07-27T03:51:18Z",
+                "size": 58196,
+                "summary": "Interdiff for part2"
+            },
+            {
+                "attacher": "kechang",
+                "bug_id": 1197690,
+                "content_type": "text/plain",
+                "creation_time": "2016-07-27T03:51:54Z",
+                "creator": "kechang",
+                "description": "Part3: test case",
+                "file_name": "0003-Bug-1197690-Part3-Tests.patch",
+                "flags": [
+                    {
+                        "creation_date": "2016-07-27T03:51:54Z",
+                        "id": 1429801,
+                        "modification_date": "2016-07-27T10:02:14Z",
+                        "name": "feedback",
+                        "setter": "schien",
+                        "status": "+",
+                        "type_id": 607
+                    }
+                ],
+                "id": 8775006,
+                "is_obsolete": 0,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-07-27T10:02:14Z",
+                "size": 32042,
+                "summary": "Part3: test case"
+            }
+        ],
+        "blocks": [
+            1067828,
+            1067862,
+            1184036,
+            1184073
+        ],
+        "cc": [
+            "awu",
+            "jocheng",
+            "juhsu",
+            "schien",
+            "selin"
+        ],
+        "cc_detail": [
+            {
+                "email": "awu",
+                "id": 472477,
+                "name": "awu",
+                "real_name": "Aaron Wu"
+            },
+            {
+                "email": "jocheng",
+                "id": 518231,
+                "name": "jocheng",
+                "real_name": "Josh Cheng [:josh]"
+            },
+            {
+                "email": "juhsu",
+                "id": 501232,
+                "name": "juhsu",
+                "real_name": "Junior [:junior]"
+            },
+            {
+                "email": "schien",
+                "id": 443226,
+                "name": "schien",
+                "real_name": "Shih-Chiang Chien [:schien] (UTC+8) (use ni? plz)"
+            },
+            {
+                "email": "selin",
+                "id": 504223,
+                "name": "selin",
+                "real_name": "Sean Lin [:seanlin] (inactive from Mar 2016)"
+            }
+        ],
+        "cf_blocking_b2g": "2.6+",
+        "cf_blocking_fennec": "---",
+        "cf_blocking_fx": "---",
+        "cf_crash_signature": "",
+        "cf_feature_b2g": "---",
+        "cf_fx_iteration": "---",
+        "cf_fx_points": "---",
+        "cf_has_regression_range": "---",
+        "cf_has_str": "---",
+        "cf_last_resolved": null,
+        "cf_platform_rel": "---",
+        "cf_qa_whiteboard": "",
+        "cf_rank": null,
+        "cf_status_b2g_2_6": "---",
+        "cf_status_firefox47": "---",
+        "cf_status_firefox48": "---",
+        "cf_status_firefox49": "---",
+        "cf_status_firefox50": "---",
+        "cf_status_firefox_esr45": "---",
+        "cf_status_thunderbird_esr38": "---",
+        "cf_status_thunderbird_esr45": "---",
+        "cf_tracking_b2g": "---",
+        "cf_tracking_e10s": "---",
+        "cf_tracking_firefox47": "---",
+        "cf_tracking_firefox48": "---",
+        "cf_tracking_firefox49": "---",
+        "cf_tracking_firefox50": "---",
+        "cf_tracking_firefox_esr45": "---",
+        "cf_tracking_firefox_relnote": "---",
+        "cf_tracking_thunderbird_esr38": "---",
+        "cf_tracking_thunderbird_esr45": "---",
+        "cf_user_story": "",
+        "classification": "Components",
+        "comments": [
+            {
+                "attachment_id": null,
+                "author": "selin",
+                "bug_id": 1197690,
+                "creation_time": "2015-08-24T07:06:55Z",
+                "creator": "selin",
+                "id": 10649196,
+                "is_private": false,
+                "raw_text": "+++ This bug was initially created as a clone of Bug #1195605 +++\n\nSupport resuming a disconnected presentation session.",
+                "tags": [],
+                "text": "+++ This bug was initially created as a clone of Bug #1195605 +++\n\nSupport resuming a disconnected presentation session.",
+                "time": "2015-08-24T07:06:55Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "schien",
+                "bug_id": 1197690,
+                "creation_time": "2015-08-26T14:36:34Z",
+                "creator": "schien",
+                "id": 10660854,
+                "is_private": false,
+                "raw_text": "Corresponding requirement: https://github.com/w3c/presentation-api/blob/gh-pages/uc-req.md#req03-resuming-connection-to-presentation\n\nhttps://github.com/w3c/presentation-api/issues/170 will define the finalized function name.",
+                "tags": [],
+                "text": "Corresponding requirement: https://github.com/w3c/presentation-api/blob/gh-pages/uc-req.md#req03-resuming-connection-to-presentation\n\nhttps://github.com/w3c/presentation-api/issues/170 will define the finalized function name.",
+                "time": "2015-08-26T14:36:34Z"
+            },
+            {
+                "attachment_id": 8770881,
+                "author": "kechang",
+                "bug_id": 1197690,
+                "creation_time": "2016-07-14T09:37:24Z",
+                "creator": "kechang",
+                "id": 11547617,
+                "is_private": false,
+                "raw_text": "WIP",
+                "tags": [],
+                "text": "Created attachment 8770881\nPart1: Support reconnect command\n\nWIP",
+                "time": "2016-07-14T09:37:24Z"
+            },
+            {
+                "attachment_id": 8770882,
+                "author": "kechang",
+                "bug_id": 1197690,
+                "creation_time": "2016-07-14T09:38:06Z",
+                "creator": "kechang",
+                "id": 11547619,
+                "is_private": false,
+                "raw_text": "",
+                "tags": [],
+                "text": "Created attachment 8770882\nPart2: Implement reconnect",
+                "time": "2016-07-14T09:38:06Z"
+            },
+            {
+                "attachment_id": 8770881,
+                "author": "juhsu",
+                "bug_id": 1197690,
+                "creation_time": "2016-07-14T10:11:16Z",
+                "creator": "juhsu",
+                "id": 11547744,
+                "is_private": false,
+                "raw_text": "Review of attachment 8770881:\n-----------------------------------------------------------------\n\nI have a quick scan of this patch, generally good but I'd like to see a rebased version.\nCould we have a test in test_tcp_control_channel.js?\n\n::: dom/presentation/interfaces/nsIPresentationControlService.idl\n@@ +65,5 @@\n> +   */\n> +  void onReconnectRequest(in nsITCPDeviceInfo aDeviceInfo,\n> +                          in DOMString url,\n> +                          in DOMString aPresentationId,\n> +                          in nsIPresentationControlChannel aControlChannel);\n\nPlease consider a well-organized order of APIs with nsIPresentationControlChannel.idl\n\n::: dom/presentation/provider/LegacyPresentationControlService.js\n@@ +238,5 @@\n>    },\n>  \n> +  reconnect: function() {\n> +    // Legacy protocol doesn't support extra reconnect protocol.\n> +    // Simply close the transport channel.\n\nPlease refer to bug 1276378 comment 20\n\n::: dom/presentation/provider/MulticastDNSDeviceProvider.cpp\n@@ +873,5 @@\n>    return NS_OK;\n>  }\n>  \n> +already_AddRefed<MulticastDNSDeviceProvider::Device>\n> +MulticastDNSDeviceProvider::GetOrCreateDevice(nsITCPDeviceInfo* aDeviceInfo)\n\nAnnotate the criterion\n\n@@ +882,5 @@\n>    RefPtr<Device> device;\n>    uint32_t index;\n>    if (FindDeviceByAddress(address, index)) {\n>      device = mDevices[index];\n>    } else {\n\nMake sure that comment changes in bug 1276378 comment 19 is applied.\n\n::: dom/presentation/provider/PresentationControlService.js\n@@ +183,5 @@\n>    },\n>  \n> +  onSessionReconnect: function(aDeviceInfo, aUrl, aPresentationId, aControlChannel) {\n> +    DEBUG && log(\"TCPPresentationServer - onSessionReconnect: \" +\n> +                 aDeviceInfo.address + \":\" + aDeviceInfo.port); //jshint ignore:line\n\nnit: space between \"//\" and jshint\n\n@@ +184,5 @@\n>  \n> +  onSessionReconnect: function(aDeviceInfo, aUrl, aPresentationId, aControlChannel) {\n> +    DEBUG && log(\"TCPPresentationServer - onSessionReconnect: \" +\n> +                 aDeviceInfo.address + \":\" + aDeviceInfo.port); //jshint ignore:line\n> +    this.listener.onReconnectRequest(aDeviceInfo,\n\nBail out if this.listener is null. Please make sure that the control channel is appropriately release to avoid leakage.\n\n@@ +413,5 @@\n>      this._stateMachine.terminate(aPresentationId);\n>    },\n>  \n> +  reconnect: function(aPresentationId, aUrl) {\n> +    if (this._direction != \"sender\") {\n\nClearly annotate the limitation in idl\n\n@@ +603,5 @@\n>      this._listener.notifyOpened();\n>    },\n>  \n> +  _notifyReconnected: function() {\n> +    this._listener.notifyReconnected();\n\nIs there any chance that this._listener is null?\n\n@@ +687,5 @@\n>  \n>    notifyTerminate: function(presentationId) {\n>      this._presentationService.onSessionTerminate(this._deviceInfo,\n>                                                  presentationId,\n>                                                  this);\n\nHere's a nit. I know its not yours.",
+                "tags": [],
+                "text": "Comment on attachment 8770881\nPart1: Support reconnect command\n\nReview of attachment 8770881:\n-----------------------------------------------------------------\n\nI have a quick scan of this patch, generally good but I'd like to see a rebased version.\nCould we have a test in test_tcp_control_channel.js?\n\n::: dom/presentation/interfaces/nsIPresentationControlService.idl\n@@ +65,5 @@\n> +   */\n> +  void onReconnectRequest(in nsITCPDeviceInfo aDeviceInfo,\n> +                          in DOMString url,\n> +                          in DOMString aPresentationId,\n> +                          in nsIPresentationControlChannel aControlChannel);\n\nPlease consider a well-organized order of APIs with nsIPresentationControlChannel.idl\n\n::: dom/presentation/provider/LegacyPresentationControlService.js\n@@ +238,5 @@\n>    },\n>  \n> +  reconnect: function() {\n> +    // Legacy protocol doesn't support extra reconnect protocol.\n> +    // Simply close the transport channel.\n\nPlease refer to bug 1276378 comment 20\n\n::: dom/presentation/provider/MulticastDNSDeviceProvider.cpp\n@@ +873,5 @@\n>    return NS_OK;\n>  }\n>  \n> +already_AddRefed<MulticastDNSDeviceProvider::Device>\n> +MulticastDNSDeviceProvider::GetOrCreateDevice(nsITCPDeviceInfo* aDeviceInfo)\n\nAnnotate the criterion\n\n@@ +882,5 @@\n>    RefPtr<Device> device;\n>    uint32_t index;\n>    if (FindDeviceByAddress(address, index)) {\n>      device = mDevices[index];\n>    } else {\n\nMake sure that comment changes in bug 1276378 comment 19 is applied.\n\n::: dom/presentation/provider/PresentationControlService.js\n@@ +183,5 @@\n>    },\n>  \n> +  onSessionReconnect: function(aDeviceInfo, aUrl, aPresentationId, aControlChannel) {\n> +    DEBUG && log(\"TCPPresentationServer - onSessionReconnect: \" +\n> +                 aDeviceInfo.address + \":\" + aDeviceInfo.port); //jshint ignore:line\n\nnit: space between \"//\" and jshint\n\n@@ +184,5 @@\n>  \n> +  onSessionReconnect: function(aDeviceInfo, aUrl, aPresentationId, aControlChannel) {\n> +    DEBUG && log(\"TCPPresentationServer - onSessionReconnect: \" +\n> +                 aDeviceInfo.address + \":\" + aDeviceInfo.port); //jshint ignore:line\n> +    this.listener.onReconnectRequest(aDeviceInfo,\n\nBail out if this.listener is null. Please make sure that the control channel is appropriately release to avoid leakage.\n\n@@ +413,5 @@\n>      this._stateMachine.terminate(aPresentationId);\n>    },\n>  \n> +  reconnect: function(aPresentationId, aUrl) {\n> +    if (this._direction != \"sender\") {\n\nClearly annotate the limitation in idl\n\n@@ +603,5 @@\n>      this._listener.notifyOpened();\n>    },\n>  \n> +  _notifyReconnected: function() {\n> +    this._listener.notifyReconnected();\n\nIs there any chance that this._listener is null?\n\n@@ +687,5 @@\n>  \n>    notifyTerminate: function(presentationId) {\n>      this._presentationService.onSessionTerminate(this._deviceInfo,\n>                                                  presentationId,\n>                                                  this);\n\nHere's a nit. I know its not yours.",
+                "time": "2016-07-14T10:11:16Z"
+            },
+            {
+                "attachment_id": 8770882,
+                "author": "schien",
+                "bug_id": 1197690,
+                "creation_time": "2016-07-15T07:46:49Z",
+                "creator": "schien",
+                "id": 11550279,
+                "is_private": false,
+                "raw_text": "Review of attachment 8770882:\n-----------------------------------------------------------------\n\nThis patch seems to have many missing part. I only check the reconnect algorithm with W3C spec.\n\n::: dom/presentation/PresentationRequest.cpp\n@@ +141,5 @@\n>  \n>  already_AddRefed<Promise>\n> +PresentationRequest::Reconnect(const nsAString& aPresentationId,\n> +                               ErrorResult& aRv)\n> +{\n\nmissing the security check algorithm listed in spec.\nplease add a comment if you want to delay the implementation along with bug 1254488.\n\n@@ +146,5 @@\n> +  nsCOMPtr<nsIGlobalObject> global = do_QueryInterface(GetOwner());\n> +  if (NS_WARN_IF(!global)) {\n> +    aRv.Throw(NS_ERROR_UNEXPECTED);\n> +    return nullptr;\n> +  }\n\nFirst, need to search if there is any matching PresentationConnection in current browsing context. Need to return the same PresentationConnection object if found.\n\n::: dom/presentation/PresentationService.cpp\n@@ +709,5 @@\n> +  RefPtr<PresentationSessionInfo> info = GetSessionInfo(aSessionId, aRole);\n> +  if (NS_WARN_IF(!info)) {\n> +    return NS_ERROR_NOT_AVAILABLE;\n> +  }\n> +\n\nNeed to check URL and state here as well.\n\n::: dom/presentation/ipc/PresentationIPCService.h\n@@ -68,5 @@\n> -  // to retrieve the correspondent session ID. Besides, also keep the mapping\n> -  // between the responding session ID and the window ID to help look up the\n> -  // window ID.\n> -  nsClassHashtable<nsUint64HashKey, nsString> mRespondingSessionIds;\n> -  nsDataHashtable<nsStringHashKey, uint64_t> mRespondingWindowIds;\n\nThese changes are for DataChannel OOP, any particular reason you need to remove them?",
+                "tags": [],
+                "text": "Comment on attachment 8770882\nPart2: Implement reconnect\n\nReview of attachment 8770882:\n-----------------------------------------------------------------\n\nThis patch seems to have many missing part. I only check the reconnect algorithm with W3C spec.\n\n::: dom/presentation/PresentationRequest.cpp\n@@ +141,5 @@\n>  \n>  already_AddRefed<Promise>\n> +PresentationRequest::Reconnect(const nsAString& aPresentationId,\n> +                               ErrorResult& aRv)\n> +{\n\nmissing the security check algorithm listed in spec.\nplease add a comment if you want to delay the implementation along with bug 1254488.\n\n@@ +146,5 @@\n> +  nsCOMPtr<nsIGlobalObject> global = do_QueryInterface(GetOwner());\n> +  if (NS_WARN_IF(!global)) {\n> +    aRv.Throw(NS_ERROR_UNEXPECTED);\n> +    return nullptr;\n> +  }\n\nFirst, need to search if there is any matching PresentationConnection in current browsing context. Need to return the same PresentationConnection object if found.\n\n::: dom/presentation/PresentationService.cpp\n@@ +709,5 @@\n> +  RefPtr<PresentationSessionInfo> info = GetSessionInfo(aSessionId, aRole);\n> +  if (NS_WARN_IF(!info)) {\n> +    return NS_ERROR_NOT_AVAILABLE;\n> +  }\n> +\n\nNeed to check URL and state here as well.\n\n::: dom/presentation/ipc/PresentationIPCService.h\n@@ -68,5 @@\n> -  // to retrieve the correspondent session ID. Besides, also keep the mapping\n> -  // between the responding session ID and the window ID to help look up the\n> -  // window ID.\n> -  nsClassHashtable<nsUint64HashKey, nsString> mRespondingSessionIds;\n> -  nsDataHashtable<nsStringHashKey, uint64_t> mRespondingWindowIds;\n\nThese changes are for DataChannel OOP, any particular reason you need to remove them?",
+                "time": "2016-07-15T07:46:49Z"
+            },
+            {
+                "attachment_id": 8771370,
+                "author": "kechang",
+                "bug_id": 1197690,
+                "creation_time": "2016-07-15T10:55:37Z",
+                "creator": "kechang",
+                "id": 11550580,
+                "is_private": false,
+                "raw_text": "Rebase and address previous comments.",
+                "tags": [],
+                "text": "Created attachment 8771370\nPart1: Support reconnect command - v2\n\nRebase and address previous comments.",
+                "time": "2016-07-15T10:55:37Z"
+            },
+            {
+                "attachment_id": 8771370,
+                "author": "juhsu",
+                "bug_id": 1197690,
+                "creation_time": "2016-07-18T02:36:19Z",
+                "creator": "juhsu",
+                "id": 11553941,
+                "is_private": false,
+                "raw_text": "Review of attachment 8771370:\n-----------------------------------------------------------------\n\nI'd like to hold the r+ mainly because I'd like to see the test again.\n\n::: dom/presentation/interfaces/nsIPresentationControlChannel.idl\n@@ +133,5 @@\n> +   * Note that only controller is allowed to reconnect a session.\n> +   * @param presentationId The Id for representing this session.\n> +   * @param url The URL requested to open by remote device.\n> +   * @throws NS_ERROR_FAILURE on failure\n> +   */\n\nPlease let me confirm if the parameters are necessary or not. Could we change the presentationId and url in |reconnect| for a control channel?\nIf yes, what does the presenter behave?\nIf no, there's something wrong.\n\n::: dom/presentation/provider/MulticastDNSDeviceProvider.cpp\n@@ +872,5 @@\n>  \n>    return NS_OK;\n>  }\n>  \n> +// Create a new device if can not find one by address.\n\nLack of subject in the \"if\" sentence. Please rephrase.\n\n::: dom/presentation/provider/ReceiverStateMachine.jsm\n@@ +74,5 @@\n> +        stateMachine._sendCommand({\n> +          type: CommandType.RECONNECT_ACK,\n> +          presentationId: command.presentationId\n> +        });\n> +        break;\n\nPlease align with bug 1276378 comment 24\n\n::: dom/presentation/tests/xpcshell/test_tcp_control_channel.js\n@@ +479,5 @@\n> +    },\n> +    QueryInterface: XPCOMUtils.generateQI([Ci.nsIPresentationControlChannelListener]),\n> +  };\n> +}\n> +\n\nThe setup is dup with |loopOfferAnswer|. Any reason to do this? Could we just merge to loopOfferAnswer?",
+                "tags": [],
+                "text": "Comment on attachment 8771370\nPart1: Support reconnect command - v2\n\nReview of attachment 8771370:\n-----------------------------------------------------------------\n\nI'd like to hold the r+ mainly because I'd like to see the test again.\n\n::: dom/presentation/interfaces/nsIPresentationControlChannel.idl\n@@ +133,5 @@\n> +   * Note that only controller is allowed to reconnect a session.\n> +   * @param presentationId The Id for representing this session.\n> +   * @param url The URL requested to open by remote device.\n> +   * @throws NS_ERROR_FAILURE on failure\n> +   */\n\nPlease let me confirm if the parameters are necessary or not. Could we change the presentationId and url in |reconnect| for a control channel?\nIf yes, what does the presenter behave?\nIf no, there's something wrong.\n\n::: dom/presentation/provider/MulticastDNSDeviceProvider.cpp\n@@ +872,5 @@\n>  \n>    return NS_OK;\n>  }\n>  \n> +// Create a new device if can not find one by address.\n\nLack of subject in the \"if\" sentence. Please rephrase.\n\n::: dom/presentation/provider/ReceiverStateMachine.jsm\n@@ +74,5 @@\n> +        stateMachine._sendCommand({\n> +          type: CommandType.RECONNECT_ACK,\n> +          presentationId: command.presentationId\n> +        });\n> +        break;\n\nPlease align with bug 1276378 comment 24\n\n::: dom/presentation/tests/xpcshell/test_tcp_control_channel.js\n@@ +479,5 @@\n> +    },\n> +    QueryInterface: XPCOMUtils.generateQI([Ci.nsIPresentationControlChannelListener]),\n> +  };\n> +}\n> +\n\nThe setup is dup with |loopOfferAnswer|. Any reason to do this? Could we just merge to loopOfferAnswer?",
+                "time": "2016-07-18T02:36:19Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "kechang",
+                "bug_id": 1197690,
+                "creation_time": "2016-07-18T06:43:32Z",
+                "creator": "kechang",
+                "id": 11554172,
+                "is_private": false,
+                "raw_text": "(In reply to Shih-Chiang Chien [:schien] (UTC+8) (use ni? plz) from comment #5)\n> Comment on attachment 8770882\n> Part2: Implement reconnect\n> \n> Review of attachment 8770882:\n> -----------------------------------------------------------------\n> \n> This patch seems to have many missing part. I only check the reconnect\n> algorithm with W3C spec.\n> \n\nYes, this is a not completed patch. My intention is to make sure I am on the right track.\n\n> ::: dom/presentation/PresentationRequest.cpp\n> @@ +141,5 @@\n> >  \n> >  already_AddRefed<Promise>\n> > +PresentationRequest::Reconnect(const nsAString& aPresentationId,\n> > +                               ErrorResult& aRv)\n> > +{\n> \n> missing the security check algorithm listed in spec.\n> please add a comment if you want to delay the implementation along with bug\n> 1254488.\n> \n\nWill add a comment. \n\n> @@ +146,5 @@\n> > +  nsCOMPtr<nsIGlobalObject> global = do_QueryInterface(GetOwner());\n> > +  if (NS_WARN_IF(!global)) {\n> > +    aRv.Throw(NS_ERROR_UNEXPECTED);\n> > +    return nullptr;\n> > +  }\n> \n> First, need to search if there is any matching PresentationConnection in\n> current browsing context. Need to return the same PresentationConnection\n> object if found.\n> \n\nYes, I missed that part. It seems that we don't have a list to save all presentation connections in controller. I will think how to do this. \n\n> ::: dom/presentation/PresentationService.cpp\n> @@ +709,5 @@\n> > +  RefPtr<PresentationSessionInfo> info = GetSessionInfo(aSessionId, aRole);\n> > +  if (NS_WARN_IF(!info)) {\n> > +    return NS_ERROR_NOT_AVAILABLE;\n> > +  }\n> > +\n> \n> Need to check URL and state here as well.\n> \n\nThis function should be only invoked at controller side. I think we can just use the URL in the session info and don't have to check it again.\n\n> ::: dom/presentation/ipc/PresentationIPCService.h\n> @@ -68,5 @@\n> > -  // to retrieve the correspondent session ID. Besides, also keep the mapping\n> > -  // between the responding session ID and the window ID to help look up the\n> > -  // window ID.\n> > -  nsClassHashtable<nsUint64HashKey, nsString> mRespondingSessionIds;\n> > -  nsDataHashtable<nsStringHashKey, uint64_t> mRespondingWindowIds;\n> \n> These changes are for DataChannel OOP, any particular reason you need to\n> remove them?\n\nI just found it seems not used here. I will check again.",
+                "tags": [],
+                "text": "(In reply to Shih-Chiang Chien [:schien] (UTC+8) (use ni? plz) from comment #5)\n> Comment on attachment 8770882\n> Part2: Implement reconnect\n> \n> Review of attachment 8770882:\n> -----------------------------------------------------------------\n> \n> This patch seems to have many missing part. I only check the reconnect\n> algorithm with W3C spec.\n> \n\nYes, this is a not completed patch. My intention is to make sure I am on the right track.\n\n> ::: dom/presentation/PresentationRequest.cpp\n> @@ +141,5 @@\n> >  \n> >  already_AddRefed<Promise>\n> > +PresentationRequest::Reconnect(const nsAString& aPresentationId,\n> > +                               ErrorResult& aRv)\n> > +{\n> \n> missing the security check algorithm listed in spec.\n> please add a comment if you want to delay the implementation along with bug\n> 1254488.\n> \n\nWill add a comment. \n\n> @@ +146,5 @@\n> > +  nsCOMPtr<nsIGlobalObject> global = do_QueryInterface(GetOwner());\n> > +  if (NS_WARN_IF(!global)) {\n> > +    aRv.Throw(NS_ERROR_UNEXPECTED);\n> > +    return nullptr;\n> > +  }\n> \n> First, need to search if there is any matching PresentationConnection in\n> current browsing context. Need to return the same PresentationConnection\n> object if found.\n> \n\nYes, I missed that part. It seems that we don't have a list to save all presentation connections in controller. I will think how to do this. \n\n> ::: dom/presentation/PresentationService.cpp\n> @@ +709,5 @@\n> > +  RefPtr<PresentationSessionInfo> info = GetSessionInfo(aSessionId, aRole);\n> > +  if (NS_WARN_IF(!info)) {\n> > +    return NS_ERROR_NOT_AVAILABLE;\n> > +  }\n> > +\n> \n> Need to check URL and state here as well.\n> \n\nThis function should be only invoked at controller side. I think we can just use the URL in the session info and don't have to check it again.\n\n> ::: dom/presentation/ipc/PresentationIPCService.h\n> @@ -68,5 @@\n> > -  // to retrieve the correspondent session ID. Besides, also keep the mapping\n> > -  // between the responding session ID and the window ID to help look up the\n> > -  // window ID.\n> > -  nsClassHashtable<nsUint64HashKey, nsString> mRespondingSessionIds;\n> > -  nsDataHashtable<nsStringHashKey, uint64_t> mRespondingWindowIds;\n> \n> These changes are for DataChannel OOP, any particular reason you need to\n> remove them?\n\nI just found it seems not used here. I will check again.",
+                "time": "2016-07-18T06:43:32Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "kechang",
+                "bug_id": 1197690,
+                "creation_time": "2016-07-18T06:54:10Z",
+                "creator": "kechang",
+                "id": 11554186,
+                "is_private": false,
+                "raw_text": "(In reply to Junior [:junior] from comment #7)\n> Comment on attachment 8771370\n> Part1: Support reconnect command - v2\n> \n> Review of attachment 8771370:\n> -----------------------------------------------------------------\n> \n> I'd like to hold the r+ mainly because I'd like to see the test again.\n> \n> ::: dom/presentation/interfaces/nsIPresentationControlChannel.idl\n> @@ +133,5 @@\n> > +   * Note that only controller is allowed to reconnect a session.\n> > +   * @param presentationId The Id for representing this session.\n> > +   * @param url The URL requested to open by remote device.\n> > +   * @throws NS_ERROR_FAILURE on failure\n> > +   */\n> \n> Please let me confirm if the parameters are necessary or not. Could we\n> change the presentationId and url in |reconnect| for a control channel?\n> If yes, what does the presenter behave?\n> If no, there's something wrong.\n> \n\nSince we create a new control channel every time we try to reconnect, I think we have to pass the presentationId and url. Receiver will check whether the presentationId and url are matched. If not, the control channel will be closed.\n\n> ::: dom/presentation/provider/MulticastDNSDeviceProvider.cpp\n> @@ +872,5 @@\n> >  \n> >    return NS_OK;\n> >  }\n> >  \n> > +// Create a new device if can not find one by address.\n> \n> Lack of subject in the \"if\" sentence. Please rephrase.\n> \n\nWill do.\n\n> ::: dom/presentation/provider/ReceiverStateMachine.jsm\n> @@ +74,5 @@\n> > +        stateMachine._sendCommand({\n> > +          type: CommandType.RECONNECT_ACK,\n> > +          presentationId: command.presentationId\n> > +        });\n> > +        break;\n> \n> Please align with bug 1276378 comment 24\n> \n\nGot it.\n\n> ::: dom/presentation/tests/xpcshell/test_tcp_control_channel.js\n> @@ +479,5 @@\n> > +    },\n> > +    QueryInterface: XPCOMUtils.generateQI([Ci.nsIPresentationControlChannelListener]),\n> > +  };\n> > +}\n> > +\n> \n> The setup is dup with |loopOfferAnswer|. Any reason to do this? Could we\n> just merge to loopOfferAnswer?\n\nYes, I can merge it.",
+                "tags": [],
+                "text": "(In reply to Junior [:junior] from comment #7)\n> Comment on attachment 8771370\n> Part1: Support reconnect command - v2\n> \n> Review of attachment 8771370:\n> -----------------------------------------------------------------\n> \n> I'd like to hold the r+ mainly because I'd like to see the test again.\n> \n> ::: dom/presentation/interfaces/nsIPresentationControlChannel.idl\n> @@ +133,5 @@\n> > +   * Note that only controller is allowed to reconnect a session.\n> > +   * @param presentationId The Id for representing this session.\n> > +   * @param url The URL requested to open by remote device.\n> > +   * @throws NS_ERROR_FAILURE on failure\n> > +   */\n> \n> Please let me confirm if the parameters are necessary or not. Could we\n> change the presentationId and url in |reconnect| for a control channel?\n> If yes, what does the presenter behave?\n> If no, there's something wrong.\n> \n\nSince we create a new control channel every time we try to reconnect, I think we have to pass the presentationId and url. Receiver will check whether the presentationId and url are matched. If not, the control channel will be closed.\n\n> ::: dom/presentation/provider/MulticastDNSDeviceProvider.cpp\n> @@ +872,5 @@\n> >  \n> >    return NS_OK;\n> >  }\n> >  \n> > +// Create a new device if can not find one by address.\n> \n> Lack of subject in the \"if\" sentence. Please rephrase.\n> \n\nWill do.\n\n> ::: dom/presentation/provider/ReceiverStateMachine.jsm\n> @@ +74,5 @@\n> > +        stateMachine._sendCommand({\n> > +          type: CommandType.RECONNECT_ACK,\n> > +          presentationId: command.presentationId\n> > +        });\n> > +        break;\n> \n> Please align with bug 1276378 comment 24\n> \n\nGot it.\n\n> ::: dom/presentation/tests/xpcshell/test_tcp_control_channel.js\n> @@ +479,5 @@\n> > +    },\n> > +    QueryInterface: XPCOMUtils.generateQI([Ci.nsIPresentationControlChannelListener]),\n> > +  };\n> > +}\n> > +\n> \n> The setup is dup with |loopOfferAnswer|. Any reason to do this? Could we\n> just merge to loopOfferAnswer?\n\nYes, I can merge it.",
+                "time": "2016-07-18T06:54:10Z"
+            },
+            {
+                "attachment_id": 8772298,
+                "author": "kechang",
+                "bug_id": 1197690,
+                "creation_time": "2016-07-19T06:48:43Z",
+                "creator": "kechang",
+                "id": 11557623,
+                "is_private": false,
+                "raw_text": "Address previous comments.",
+                "tags": [],
+                "text": "Created attachment 8772298\nPart1: Support reconnect command - v3\n\nAddress previous comments.",
+                "time": "2016-07-19T06:48:43Z"
+            },
+            {
+                "attachment_id": 8772298,
+                "author": "juhsu",
+                "bug_id": 1197690,
+                "creation_time": "2016-07-19T10:03:02Z",
+                "creator": "juhsu",
+                "id": 11558012,
+                "is_private": false,
+                "raw_text": "Review of attachment 8772298:\n-----------------------------------------------------------------\n\n::: dom/presentation/PresentationDeviceManager.cpp\n@@ +276,5 @@\n> +\n> +  RefPtr<PresentationSessionRequest> request =\n> +    new PresentationSessionRequest(aDevice, aUrl, aPresentationId, aControlChannel);\n> +  obs->NotifyObservers(request,\n> +                       PRESENTATION_RECONNECT_REQUEST_TOPIC,\n\nUpdate the description in PresentationSessionRequest.idl\n\n::: dom/presentation/interfaces/nsIPresentationControlChannel.idl\n@@ +129,5 @@\n>    void disconnect(in nsresult reason);\n> +\n> +  /*\n> +   * Reconnect a presentation on remote endpoint.\n> +   * Note that only controller is allowed to reconnect a session.\n\n|ControlService.connect| and |ControlChannel.disconnect| are about the control channel. However, |ControlChannel.reconnect| is about a presentation session, so does |launch| and |terminate|.\n\nThat's the reason (|re|dis)connect make me confused here, and the bad thing here is the word |reconnect| in the spec.\n\nTo reduce the ambiguity, please find another bug for the naming\n\n::: dom/presentation/provider/MulticastDNSDeviceProvider.cpp\n@@ +872,5 @@\n>  \n>    return NS_OK;\n>  }\n>  \n> +// Create a new device if we were unable to find it with the address.\n\ns/it/one/\n\n::: dom/presentation/provider/PresentationControlService.js\n@@ +194,5 @@\n>    },\n>  \n> +  onSessionReconnect: function(aDeviceInfo, aUrl, aPresentationId, aControlChannel) {\n> +    DEBUG && log(\"TCPPresentationServer - onSessionReconnect: \" +\n> +                 aDeviceInfo.address + \":\" + aDeviceInfo.port); //jshint ignore:line\n\nnit: space after \"//\"\n\n::: dom/presentation/provider/ReceiverStateMachine.jsm\n@@ +121,5 @@\n>      }\n>    },\n>  \n> +  reconnect: function _reconnect() {\n> +    // presentation session can only be reconnected by controlling UA.\n\nDebug message is informative enough.",
+                "tags": [],
+                "text": "Comment on attachment 8772298\nPart1: Support reconnect command - v3\n\nReview of attachment 8772298:\n-----------------------------------------------------------------\n\n::: dom/presentation/PresentationDeviceManager.cpp\n@@ +276,5 @@\n> +\n> +  RefPtr<PresentationSessionRequest> request =\n> +    new PresentationSessionRequest(aDevice, aUrl, aPresentationId, aControlChannel);\n> +  obs->NotifyObservers(request,\n> +                       PRESENTATION_RECONNECT_REQUEST_TOPIC,\n\nUpdate the description in PresentationSessionRequest.idl\n\n::: dom/presentation/interfaces/nsIPresentationControlChannel.idl\n@@ +129,5 @@\n>    void disconnect(in nsresult reason);\n> +\n> +  /*\n> +   * Reconnect a presentation on remote endpoint.\n> +   * Note that only controller is allowed to reconnect a session.\n\n|ControlService.connect| and |ControlChannel.disconnect| are about the control channel. However, |ControlChannel.reconnect| is about a presentation session, so does |launch| and |terminate|.\n\nThat's the reason (|re|dis)connect make me confused here, and the bad thing here is the word |reconnect| in the spec.\n\nTo reduce the ambiguity, please find another bug for the naming\n\n::: dom/presentation/provider/MulticastDNSDeviceProvider.cpp\n@@ +872,5 @@\n>  \n>    return NS_OK;\n>  }\n>  \n> +// Create a new device if we were unable to find it with the address.\n\ns/it/one/\n\n::: dom/presentation/provider/PresentationControlService.js\n@@ +194,5 @@\n>    },\n>  \n> +  onSessionReconnect: function(aDeviceInfo, aUrl, aPresentationId, aControlChannel) {\n> +    DEBUG && log(\"TCPPresentationServer - onSessionReconnect: \" +\n> +                 aDeviceInfo.address + \":\" + aDeviceInfo.port); //jshint ignore:line\n\nnit: space after \"//\"\n\n::: dom/presentation/provider/ReceiverStateMachine.jsm\n@@ +121,5 @@\n>      }\n>    },\n>  \n> +  reconnect: function _reconnect() {\n> +    // presentation session can only be reconnected by controlling UA.\n\nDebug message is informative enough.",
+                "time": "2016-07-19T10:03:02Z"
+            },
+            {
+                "attachment_id": 8772767,
+                "author": "kechang",
+                "bug_id": 1197690,
+                "creation_time": "2016-07-20T09:36:49Z",
+                "creator": "kechang",
+                "id": 11561147,
+                "is_private": false,
+                "raw_text": "",
+                "tags": [],
+                "text": "Created attachment 8772767\nPart2: Implement reconnect - v2",
+                "time": "2016-07-20T09:36:49Z"
+            },
+            {
+                "attachment_id": 8772767,
+                "author": "kechang",
+                "bug_id": 1197690,
+                "creation_time": "2016-07-20T09:42:13Z",
+                "creator": "kechang",
+                "id": 11561270,
+                "is_private": false,
+                "raw_text": "Review of attachment 8772767:\n-----------------------------------------------------------------\n\n::: dom/presentation/PresentationCallbacks.h\n@@ -29,5 @@\n>    NS_DECL_ISUPPORTS\n>    NS_DECL_NSIPRESENTATIONSERVICECALLBACK\n>  \n>    PresentationRequesterCallback(PresentationRequest* aRequest,\n> -                                const nsAString& aUrl,\n\nIt seems that aUrl is not used here, so remove it.\n\n::: dom/presentation/ipc/PresentationIPCService.h\n@@ -68,5 @@\n> -  // to retrieve the correspondent session ID. Besides, also keep the mapping\n> -  // between the responding session ID and the window ID to help look up the\n> -  // window ID.\n> -  nsClassHashtable<nsUint64HashKey, nsString> mRespondingSessionIds;\n> -  nsDataHashtable<nsStringHashKey, uint64_t> mRespondingWindowIds;\n\nRemove these tables since they are already defined in PresentationServiceBase.",
+                "tags": [],
+                "text": "Comment on attachment 8772767\nPart2: Implement reconnect - v2\n\nReview of attachment 8772767:\n-----------------------------------------------------------------\n\n::: dom/presentation/PresentationCallbacks.h\n@@ -29,5 @@\n>    NS_DECL_ISUPPORTS\n>    NS_DECL_NSIPRESENTATIONSERVICECALLBACK\n>  \n>    PresentationRequesterCallback(PresentationRequest* aRequest,\n> -                                const nsAString& aUrl,\n\nIt seems that aUrl is not used here, so remove it.\n\n::: dom/presentation/ipc/PresentationIPCService.h\n@@ -68,5 @@\n> -  // to retrieve the correspondent session ID. Besides, also keep the mapping\n> -  // between the responding session ID and the window ID to help look up the\n> -  // window ID.\n> -  nsClassHashtable<nsUint64HashKey, nsString> mRespondingSessionIds;\n> -  nsDataHashtable<nsStringHashKey, uint64_t> mRespondingWindowIds;\n\nRemove these tables since they are already defined in PresentationServiceBase.",
+                "time": "2016-07-20T09:42:13Z"
+            },
+            {
+                "attachment_id": 8772767,
+                "author": "schien",
+                "bug_id": 1197690,
+                "creation_time": "2016-07-22T03:30:56Z",
+                "creator": "schien",
+                "id": 11567330,
+                "is_private": false,
+                "raw_text": "Review of attachment 8772767:\n-----------------------------------------------------------------\n\nNeed add test for following scenarios:\n1. reconnect a connecting / connected session in the same browser context\n2. reconnect a closed session in other browser context\n3. reconnect a connecting / connected session in other browser context\n4. error handling for NotFoundError\n\n::: dom/presentation/PresentationCallbacks.h\n@@ -29,5 @@\n>    NS_DECL_ISUPPORTS\n>    NS_DECL_NSIPRESENTATIONSERVICECALLBACK\n>  \n>    PresentationRequesterCallback(PresentationRequest* aRequest,\n> -                                const nsAString& aUrl,\n\nI think we are going to use it while implementing multiple URL in one PresentationRequest.\n\n::: dom/presentation/PresentationConnectionCollection.h\n@@ +23,5 @@\n> +{\n> +public:\n> +  static PresentationConnectionCollection* GetSingleton();\n> +\n> +  ~PresentationConnectionCollection();\n\nmake it private and virtual.\n\n@@ +30,5 @@\n> +\n> +  void RemoveConnection(PresentationConnection* aConnection);\n> +\n> +  already_AddRefed<PresentationConnection>\n> +  FindConnection(nsPIDOMWindowInner* aWindow, const nsAString& aId);\n\nwhy not simply pass the windowId?\n\n::: dom/presentation/PresentationRequest.cpp\n@@ +201,5 @@\n> +PresentationRequest::FindOrCreatePresentationConnection(\n> +  const nsAString& aPresentationId,\n> +  Promise* aPromise)\n> +{\n> +  if (NS_WARN_IF(!aPromise)) {\n\nuse MOZ_ASSERT?\n\n@@ +222,5 @@\n> +        aPromise->MaybeResolve(connection);\n> +        break;\n> +      case PresentationConnectionState::Connecting:\n> +      case PresentationConnectionState::Connected:\n> +        aPromise->MaybeResolve(connection);\n\nIn spec step 7.4 it says connection state should be switch to \"connecting\" and then fire the \"onconnect\" event.\n\n@@ +253,5 @@\n> +                              nsIPresentationService::ROLE_CONTROLLER,\n> +                              callback);\n> +  if (rv == NS_ERROR_NOT_AVAILABLE) {\n> +    aPromise->MaybeReject(NS_ERROR_DOM_NOT_FOUND_ERR);\n> +  }\n\nWe should also reject the promise if getting other failure result.\n\n::: dom/presentation/PresentationService.cpp\n@@ +374,5 @@\n>      return NS_OK;\n>    }\n>  #endif\n>  \n>    // Create or reuse session info.\n\nWe should add more description about how we reuse session info.\n\n@@ +723,5 @@\n> +\n> +  if (NS_WARN_IF(!info->GetUrl().Equals(aUrl))) {\n> +    return NS_ERROR_INVALID_ARG;\n> +  }\n> +\n\nWe'll need to update the windowID <-> presentationId mapping as well, otherwise all the following event will be deliver to the old window.\nAlso need to notify IPC service to update the mapping for data channel scenario.\n\n::: dom/presentation/PresentationSessionInfo.cpp\n@@ +1272,5 @@\n>  \n>  NS_IMETHODIMP\n> +PresentationPresentingInfo::NotifyReconnected()\n> +{\n> +  // Do nothing.\n\nMaybe assert here since we are pretty sure it won't happen.\n\n::: dom/webidl/PresentationRequest.webidl\n@@ +36,5 @@\n> +   * The connection state is \"connecting\".\n> +   *\n> +   * The promise may be rejected duo to one of the following reasons:\n> +   * - \"OperationError\": Unexpected error occurs.\n> +   * - \"NotFoundError\":  Can not find a presentation connection with the presentationId.\n\nadd comment for SecurityError as well.",
+                "tags": [],
+                "text": "Comment on attachment 8772767\nPart2: Implement reconnect - v2\n\nReview of attachment 8772767:\n-----------------------------------------------------------------\n\nNeed add test for following scenarios:\n1. reconnect a connecting / connected session in the same browser context\n2. reconnect a closed session in other browser context\n3. reconnect a connecting / connected session in other browser context\n4. error handling for NotFoundError\n\n::: dom/presentation/PresentationCallbacks.h\n@@ -29,5 @@\n>    NS_DECL_ISUPPORTS\n>    NS_DECL_NSIPRESENTATIONSERVICECALLBACK\n>  \n>    PresentationRequesterCallback(PresentationRequest* aRequest,\n> -                                const nsAString& aUrl,\n\nI think we are going to use it while implementing multiple URL in one PresentationRequest.\n\n::: dom/presentation/PresentationConnectionCollection.h\n@@ +23,5 @@\n> +{\n> +public:\n> +  static PresentationConnectionCollection* GetSingleton();\n> +\n> +  ~PresentationConnectionCollection();\n\nmake it private and virtual.\n\n@@ +30,5 @@\n> +\n> +  void RemoveConnection(PresentationConnection* aConnection);\n> +\n> +  already_AddRefed<PresentationConnection>\n> +  FindConnection(nsPIDOMWindowInner* aWindow, const nsAString& aId);\n\nwhy not simply pass the windowId?\n\n::: dom/presentation/PresentationRequest.cpp\n@@ +201,5 @@\n> +PresentationRequest::FindOrCreatePresentationConnection(\n> +  const nsAString& aPresentationId,\n> +  Promise* aPromise)\n> +{\n> +  if (NS_WARN_IF(!aPromise)) {\n\nuse MOZ_ASSERT?\n\n@@ +222,5 @@\n> +        aPromise->MaybeResolve(connection);\n> +        break;\n> +      case PresentationConnectionState::Connecting:\n> +      case PresentationConnectionState::Connected:\n> +        aPromise->MaybeResolve(connection);\n\nIn spec step 7.4 it says connection state should be switch to \"connecting\" and then fire the \"onconnect\" event.\n\n@@ +253,5 @@\n> +                              nsIPresentationService::ROLE_CONTROLLER,\n> +                              callback);\n> +  if (rv == NS_ERROR_NOT_AVAILABLE) {\n> +    aPromise->MaybeReject(NS_ERROR_DOM_NOT_FOUND_ERR);\n> +  }\n\nWe should also reject the promise if getting other failure result.\n\n::: dom/presentation/PresentationService.cpp\n@@ +374,5 @@\n>      return NS_OK;\n>    }\n>  #endif\n>  \n>    // Create or reuse session info.\n\nWe should add more description about how we reuse session info.\n\n@@ +723,5 @@\n> +\n> +  if (NS_WARN_IF(!info->GetUrl().Equals(aUrl))) {\n> +    return NS_ERROR_INVALID_ARG;\n> +  }\n> +\n\nWe'll need to update the windowID <-> presentationId mapping as well, otherwise all the following event will be deliver to the old window.\nAlso need to notify IPC service to update the mapping for data channel scenario.\n\n::: dom/presentation/PresentationSessionInfo.cpp\n@@ +1272,5 @@\n>  \n>  NS_IMETHODIMP\n> +PresentationPresentingInfo::NotifyReconnected()\n> +{\n> +  // Do nothing.\n\nMaybe assert here since we are pretty sure it won't happen.\n\n::: dom/webidl/PresentationRequest.webidl\n@@ +36,5 @@\n> +   * The connection state is \"connecting\".\n> +   *\n> +   * The promise may be rejected duo to one of the following reasons:\n> +   * - \"OperationError\": Unexpected error occurs.\n> +   * - \"NotFoundError\":  Can not find a presentation connection with the presentationId.\n\nadd comment for SecurityError as well.",
+                "time": "2016-07-22T03:30:56Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "kechang",
+                "bug_id": 1197690,
+                "creation_time": "2016-07-22T07:05:04Z",
+                "creator": "kechang",
+                "id": 11567582,
+                "is_private": false,
+                "raw_text": "(In reply to Shih-Chiang Chien [:schien] (UTC+8) (use ni? plz) from comment #14)\n> Comment on attachment 8772767\n> Part2: Implement reconnect - v2\n> \n> Review of attachment 8772767:\n> -----------------------------------------------------------------\n> \n> Need add test for following scenarios:\n> 1. reconnect a connecting / connected session in the same browser context\n> 2. reconnect a closed session in other browser context\n> 3. reconnect a connecting / connected session in other browser context\n> 4. error handling for NotFoundError\n> \n\nSure.\n\n> ::: dom/presentation/PresentationCallbacks.h\n> @@ -29,5 @@\n> >    NS_DECL_ISUPPORTS\n> >    NS_DECL_NSIPRESENTATIONSERVICECALLBACK\n> >  \n> >    PresentationRequesterCallback(PresentationRequest* aRequest,\n> > -                                const nsAString& aUrl,\n> \n> I think we are going to use it while implementing multiple URL in one\n> PresentationRequest.\n> \n\nI'll add it back in next version.\n\n> ::: dom/presentation/PresentationConnectionCollection.h\n> @@ +23,5 @@\n> > +{\n> > +public:\n> > +  static PresentationConnectionCollection* GetSingleton();\n> > +\n> > +  ~PresentationConnectionCollection();\n> \n> make it private and virtual.\n> \n\nOk.\n\n> @@ +30,5 @@\n> > +\n> > +  void RemoveConnection(PresentationConnection* aConnection);\n> > +\n> > +  already_AddRefed<PresentationConnection>\n> > +  FindConnection(nsPIDOMWindowInner* aWindow, const nsAString& aId);\n> \n> why not simply pass the windowId?\n> \n\nYes, it would be simpler. I'll do it.\n\n> ::: dom/presentation/PresentationRequest.cpp\n> @@ +201,5 @@\n> > +PresentationRequest::FindOrCreatePresentationConnection(\n> > +  const nsAString& aPresentationId,\n> > +  Promise* aPromise)\n> > +{\n> > +  if (NS_WARN_IF(!aPromise)) {\n> \n> use MOZ_ASSERT?\n> \n\nOK.\n\n> @@ +222,5 @@\n> > +        aPromise->MaybeResolve(connection);\n> > +        break;\n> > +      case PresentationConnectionState::Connecting:\n> > +      case PresentationConnectionState::Connected:\n> > +        aPromise->MaybeResolve(connection);\n> \n> In spec step 7.4 it says connection state should be switch to \"connecting\"\n> and then fire the \"onconnect\" event.\n> \n\nIn step 7.3, it says we should abort all remaining steps. So, I think this should be fine.\n\n> @@ +253,5 @@\n> > +                              nsIPresentationService::ROLE_CONTROLLER,\n> > +                              callback);\n> > +  if (rv == NS_ERROR_NOT_AVAILABLE) {\n> > +    aPromise->MaybeReject(NS_ERROR_DOM_NOT_FOUND_ERR);\n> > +  }\n> \n> We should also reject the promise if getting other failure result.\n> \n> ::: dom/presentation/PresentationService.cpp\n> @@ +374,5 @@\n> >      return NS_OK;\n> >    }\n> >  #endif\n> >  \n> >    // Create or reuse session info.\n> \n> We should add more description about how we reuse session info.\n> \n\nOK.\n\n> @@ +723,5 @@\n> > +\n> > +  if (NS_WARN_IF(!info->GetUrl().Equals(aUrl))) {\n> > +    return NS_ERROR_INVALID_ARG;\n> > +  }\n> > +\n> \n> We'll need to update the windowID <-> presentationId mapping as well,\n> otherwise all the following event will be deliver to the old window.\n> Also need to notify IPC service to update the mapping for data channel\n> scenario.\n> \n\nGot it.\n\n> ::: dom/presentation/PresentationSessionInfo.cpp\n> @@ +1272,5 @@\n> >  \n> >  NS_IMETHODIMP\n> > +PresentationPresentingInfo::NotifyReconnected()\n> > +{\n> > +  // Do nothing.\n> \n> Maybe assert here since we are pretty sure it won't happen.\n> \n\nOK.\n\n> ::: dom/webidl/PresentationRequest.webidl\n> @@ +36,5 @@\n> > +   * The connection state is \"connecting\".\n> > +   *\n> > +   * The promise may be rejected duo to one of the following reasons:\n> > +   * - \"OperationError\": Unexpected error occurs.\n> > +   * - \"NotFoundError\":  Can not find a presentation connection with the presentationId.\n> \n> add comment for SecurityError as well.\n\nWill do.",
+                "tags": [],
+                "text": "(In reply to Shih-Chiang Chien [:schien] (UTC+8) (use ni? plz) from comment #14)\n> Comment on attachment 8772767\n> Part2: Implement reconnect - v2\n> \n> Review of attachment 8772767:\n> -----------------------------------------------------------------\n> \n> Need add test for following scenarios:\n> 1. reconnect a connecting / connected session in the same browser context\n> 2. reconnect a closed session in other browser context\n> 3. reconnect a connecting / connected session in other browser context\n> 4. error handling for NotFoundError\n> \n\nSure.\n\n> ::: dom/presentation/PresentationCallbacks.h\n> @@ -29,5 @@\n> >    NS_DECL_ISUPPORTS\n> >    NS_DECL_NSIPRESENTATIONSERVICECALLBACK\n> >  \n> >    PresentationRequesterCallback(PresentationRequest* aRequest,\n> > -                                const nsAString& aUrl,\n> \n> I think we are going to use it while implementing multiple URL in one\n> PresentationRequest.\n> \n\nI'll add it back in next version.\n\n> ::: dom/presentation/PresentationConnectionCollection.h\n> @@ +23,5 @@\n> > +{\n> > +public:\n> > +  static PresentationConnectionCollection* GetSingleton();\n> > +\n> > +  ~PresentationConnectionCollection();\n> \n> make it private and virtual.\n> \n\nOk.\n\n> @@ +30,5 @@\n> > +\n> > +  void RemoveConnection(PresentationConnection* aConnection);\n> > +\n> > +  already_AddRefed<PresentationConnection>\n> > +  FindConnection(nsPIDOMWindowInner* aWindow, const nsAString& aId);\n> \n> why not simply pass the windowId?\n> \n\nYes, it would be simpler. I'll do it.\n\n> ::: dom/presentation/PresentationRequest.cpp\n> @@ +201,5 @@\n> > +PresentationRequest::FindOrCreatePresentationConnection(\n> > +  const nsAString& aPresentationId,\n> > +  Promise* aPromise)\n> > +{\n> > +  if (NS_WARN_IF(!aPromise)) {\n> \n> use MOZ_ASSERT?\n> \n\nOK.\n\n> @@ +222,5 @@\n> > +        aPromise->MaybeResolve(connection);\n> > +        break;\n> > +      case PresentationConnectionState::Connecting:\n> > +      case PresentationConnectionState::Connected:\n> > +        aPromise->MaybeResolve(connection);\n> \n> In spec step 7.4 it says connection state should be switch to \"connecting\"\n> and then fire the \"onconnect\" event.\n> \n\nIn step 7.3, it says we should abort all remaining steps. So, I think this should be fine.\n\n> @@ +253,5 @@\n> > +                              nsIPresentationService::ROLE_CONTROLLER,\n> > +                              callback);\n> > +  if (rv == NS_ERROR_NOT_AVAILABLE) {\n> > +    aPromise->MaybeReject(NS_ERROR_DOM_NOT_FOUND_ERR);\n> > +  }\n> \n> We should also reject the promise if getting other failure result.\n> \n> ::: dom/presentation/PresentationService.cpp\n> @@ +374,5 @@\n> >      return NS_OK;\n> >    }\n> >  #endif\n> >  \n> >    // Create or reuse session info.\n> \n> We should add more description about how we reuse session info.\n> \n\nOK.\n\n> @@ +723,5 @@\n> > +\n> > +  if (NS_WARN_IF(!info->GetUrl().Equals(aUrl))) {\n> > +    return NS_ERROR_INVALID_ARG;\n> > +  }\n> > +\n> \n> We'll need to update the windowID <-> presentationId mapping as well,\n> otherwise all the following event will be deliver to the old window.\n> Also need to notify IPC service to update the mapping for data channel\n> scenario.\n> \n\nGot it.\n\n> ::: dom/presentation/PresentationSessionInfo.cpp\n> @@ +1272,5 @@\n> >  \n> >  NS_IMETHODIMP\n> > +PresentationPresentingInfo::NotifyReconnected()\n> > +{\n> > +  // Do nothing.\n> \n> Maybe assert here since we are pretty sure it won't happen.\n> \n\nOK.\n\n> ::: dom/webidl/PresentationRequest.webidl\n> @@ +36,5 @@\n> > +   * The connection state is \"connecting\".\n> > +   *\n> > +   * The promise may be rejected duo to one of the following reasons:\n> > +   * - \"OperationError\": Unexpected error occurs.\n> > +   * - \"NotFoundError\":  Can not find a presentation connection with the presentationId.\n> \n> add comment for SecurityError as well.\n\nWill do.",
+                "time": "2016-07-22T07:05:04Z"
+            },
+            {
+                "attachment_id": null,
+                "author": "schien",
+                "bug_id": 1197690,
+                "creation_time": "2016-07-22T09:39:01Z",
+                "creator": "schien",
+                "id": 11567871,
+                "is_private": false,
+                "raw_text": "(In reply to Kershaw Chang [:kershaw] from comment #15)\n> (In reply to Shih-Chiang Chien [:schien] (UTC+8) (use ni? plz) from comment\n> > @@ +222,5 @@\n> > > +        aPromise->MaybeResolve(connection);\n> > > +        break;\n> > > +      case PresentationConnectionState::Connecting:\n> > > +      case PresentationConnectionState::Connected:\n> > > +        aPromise->MaybeResolve(connection);\n> > \n> > In spec step 7.4 it says connection state should be switch to \"connecting\"\n> > and then fire the \"onconnect\" event.\n> > \n> \n> In step 7.3, it says we should abort all remaining steps. So, I think this\n> should be fine.\n> \n\nI misread the spec, thanks for the correction!",
+                "tags": [],
+                "text": "(In reply to Kershaw Chang [:kershaw] from comment #15)\n> (In reply to Shih-Chiang Chien [:schien] (UTC+8) (use ni? plz) from comment\n> > @@ +222,5 @@\n> > > +        aPromise->MaybeResolve(connection);\n> > > +        break;\n> > > +      case PresentationConnectionState::Connecting:\n> > > +      case PresentationConnectionState::Connected:\n> > > +        aPromise->MaybeResolve(connection);\n> > \n> > In spec step 7.4 it says connection state should be switch to \"connecting\"\n> > and then fire the \"onconnect\" event.\n> > \n> \n> In step 7.3, it says we should abort all remaining steps. So, I think this\n> should be fine.\n> \n\nI misread the spec, thanks for the correction!",
+                "time": "2016-07-22T09:39:01Z"
+            },
+            {
+                "attachment_id": 8775004,
+                "author": "kechang",
+                "bug_id": 1197690,
+                "creation_time": "2016-07-27T03:50:22Z",
+                "creator": "kechang",
+                "id": 11577679,
+                "is_private": false,
+                "raw_text": "1. Address previous comments\n2. Add url in PresentationConnection\n3. Fix some bugs found in test cases",
+                "tags": [],
+                "text": "Created attachment 8775004\nPart2: Implement reconnect - v3\n\n1. Address previous comments\n2. Add url in PresentationConnection\n3. Fix some bugs found in test cases",
+                "time": "2016-07-27T03:50:22Z"
+            },
+            {
+                "attachment_id": 8775005,
+                "author": "kechang",
+                "bug_id": 1197690,
+                "creation_time": "2016-07-27T03:51:18Z",
+                "creator": "kechang",
+                "id": 11577680,
+                "is_private": false,
+                "raw_text": "Interdiff of v2 and v3.",
+                "tags": [],
+                "text": "Created attachment 8775005\nInterdiff for part2\n\nInterdiff of v2 and v3.",
+                "time": "2016-07-27T03:51:18Z"
+            },
+            {
+                "attachment_id": 8775006,
+                "author": "kechang",
+                "bug_id": 1197690,
+                "creation_time": "2016-07-27T03:51:54Z",
+                "creator": "kechang",
+                "id": 11577681,
+                "is_private": false,
+                "raw_text": "Tests.",
+                "tags": [],
+                "text": "Created attachment 8775006\nPart3: test case\n\nTests.",
+                "time": "2016-07-27T03:51:54Z"
+            },
+            {
+                "attachment_id": 8775004,
+                "author": "schien",
+                "bug_id": 1197690,
+                "creation_time": "2016-07-27T08:29:06Z",
+                "creator": "schien",
+                "id": 11578001,
+                "is_private": false,
+                "raw_text": "Review of attachment 8775004:\n-----------------------------------------------------------------\n\n::: dom/presentation/Presentation.cpp\n@@ +53,5 @@\n> +  if (!docShell) {\n> +    return false;\n> +  }\n> +\n> +  nsContentUtils::GetPresentationURL(docShell, mPresentationUrl);\n\nstoring an extra attribute that only for receiver side that only used once seems a waste to me.\n\n::: dom/presentation/PresentationReceiver.cpp\n@@ +31,5 @@\n>  NS_INTERFACE_MAP_END\n>  \n>  /* static */ already_AddRefed<PresentationReceiver>\n> +PresentationReceiver::Create(nsPIDOMWindowInner* aWindow,\n> +                             const nsAString& aUrl)\n\nI'll prefer PresentationReceiver get the presentation URL by itself instead of passing from somewhere.\n\n::: dom/presentation/PresentationRequest.cpp\n@@ +185,5 @@\n> +\n> +  RefPtr<PresentationRequest> self = this;\n> +  nsString presentationId = nsString(aPresentationId);\n> +  nsCOMPtr<nsIRunnable> r =\n> +    NS_NewRunnableFunction([self, presentationId, promise] () -> void {\n\nWe might prefer using NewRunnableMethod since bug 1268313 is landed.\n*reminder: need switch to NS_NewRunnableFunction on tv 2.6 branch.\n\n::: dom/presentation/ipc/PresentationParent.cpp\n@@ +250,5 @@\n>  \n>  NS_IMETHODIMP\n> +PresentationParent::NotifyReplaced(const nsAString& aSessionId)\n> +{\n> +  return NS_OK;\n\nAdd a comment to explain that PresentationConnection replace procedure is done in PresentationIPCService::RegisterSessionListener.",
+                "tags": [],
+                "text": "Comment on attachment 8775004\nPart2: Implement reconnect - v3\n\nReview of attachment 8775004:\n-----------------------------------------------------------------\n\n::: dom/presentation/Presentation.cpp\n@@ +53,5 @@\n> +  if (!docShell) {\n> +    return false;\n> +  }\n> +\n> +  nsContentUtils::GetPresentationURL(docShell, mPresentationUrl);\n\nstoring an extra attribute that only for receiver side that only used once seems a waste to me.\n\n::: dom/presentation/PresentationReceiver.cpp\n@@ +31,5 @@\n>  NS_INTERFACE_MAP_END\n>  \n>  /* static */ already_AddRefed<PresentationReceiver>\n> +PresentationReceiver::Create(nsPIDOMWindowInner* aWindow,\n> +                             const nsAString& aUrl)\n\nI'll prefer PresentationReceiver get the presentation URL by itself instead of passing from somewhere.\n\n::: dom/presentation/PresentationRequest.cpp\n@@ +185,5 @@\n> +\n> +  RefPtr<PresentationRequest> self = this;\n> +  nsString presentationId = nsString(aPresentationId);\n> +  nsCOMPtr<nsIRunnable> r =\n> +    NS_NewRunnableFunction([self, presentationId, promise] () -> void {\n\nWe might prefer using NewRunnableMethod since bug 1268313 is landed.\n*reminder: need switch to NS_NewRunnableFunction on tv 2.6 branch.\n\n::: dom/presentation/ipc/PresentationParent.cpp\n@@ +250,5 @@\n>  \n>  NS_IMETHODIMP\n> +PresentationParent::NotifyReplaced(const nsAString& aSessionId)\n> +{\n> +  return NS_OK;\n\nAdd a comment to explain that PresentationConnection replace procedure is done in PresentationIPCService::RegisterSessionListener.",
+                "time": "2016-07-27T08:29:06Z"
+            },
+            {
+                "attachment_id": 8775006,
+                "author": "schien",
+                "bug_id": 1197690,
+                "creation_time": "2016-07-27T10:02:14Z",
+                "creator": "schien",
+                "id": 11578224,
+                "is_private": false,
+                "raw_text": "Review of attachment 8775006:\n-----------------------------------------------------------------\n\n::: dom/presentation/tests/mochitest/mochitest.ini\n@@ +55,5 @@\n>  skip-if = (e10s || toolkit == 'gonk' || toolkit == 'android')\n>  [test_presentation_sender_on_terminate_request.html]\n>  skip-if = toolkit == 'android'\n>  [test_presentation_sandboxed_presentation.html]\n> +[test_presentation_reconnect_connection.html]\n\nhow about test_presentation_reconnect.html?\n\n::: dom/presentation/tests/mochitest/test_presentation_reconnect_connection.html\n@@ +221,5 @@\n> +    iframe.contentWindow.postMessage(\"startConnection\", \"*\");\n> +    gScript.sendAsyncMessage('save-control-channel-listener');\n> +    addEventListener(\"message\", function listener(event) {\n> +      var message = event.data;\n> +      if (/^COMMAND /.exec(message)) {\n\nYou can simply use a map to store the command handler.\n\n@@ +234,5 @@\n> +\n> +          var request1 = new PresentationRequest(\"http://example1.com\");\n> +          request1.reconnect(command.id).then(\n> +            function(aConnection) {\n> +              is(aConnection.state, \"connecting\", \"The state should be connecting.\");\n\nYou can use Promise.all() to wait both onconnect in this page and onclose in iframe. Also, send a message to make sure we reroute the message correctly.",
+                "tags": [],
+                "text": "Comment on attachment 8775006\nPart3: test case\n\nReview of attachment 8775006:\n-----------------------------------------------------------------\n\n::: dom/presentation/tests/mochitest/mochitest.ini\n@@ +55,5 @@\n>  skip-if = (e10s || toolkit == 'gonk' || toolkit == 'android')\n>  [test_presentation_sender_on_terminate_request.html]\n>  skip-if = toolkit == 'android'\n>  [test_presentation_sandboxed_presentation.html]\n> +[test_presentation_reconnect_connection.html]\n\nhow about test_presentation_reconnect.html?\n\n::: dom/presentation/tests/mochitest/test_presentation_reconnect_connection.html\n@@ +221,5 @@\n> +    iframe.contentWindow.postMessage(\"startConnection\", \"*\");\n> +    gScript.sendAsyncMessage('save-control-channel-listener');\n> +    addEventListener(\"message\", function listener(event) {\n> +      var message = event.data;\n> +      if (/^COMMAND /.exec(message)) {\n\nYou can simply use a map to store the command handler.\n\n@@ +234,5 @@\n> +\n> +          var request1 = new PresentationRequest(\"http://example1.com\");\n> +          request1.reconnect(command.id).then(\n> +            function(aConnection) {\n> +              is(aConnection.state, \"connecting\", \"The state should be connecting.\");\n\nYou can use Promise.all() to wait both onconnect in this page and onclose in iframe. Also, send a message to make sure we reroute the message correctly.",
+                "time": "2016-07-27T10:02:14Z"
+            }
+        ],
+        "component": "DOM",
+        "creation_time": "2015-08-24T07:06:55Z",
+        "creator": "selin",
+        "creator_detail": {
+            "email": "selin",
+            "id": 504223,
+            "name": "selin",
+            "real_name": "Sean Lin [:seanlin] (inactive from Mar 2016)"
+        },
+        "depends_on": [
+            1192101
+        ],
+        "dupe_of": null,
+        "flags": [],
+        "groups": [],
+        "history": [
+            {
+                "changes": [
+                    {
+                        "added": "1184036",
+                        "field_name": "blocks",
+                        "removed": ""
+                    },
+                    {
+                        "added": "",
+                        "field_name": "depends_on",
+                        "removed": "1195605"
+                    },
+                    {
+                        "added": "[Presentation WebAPI] Support resuming a disconnected presentation session",
+                        "field_name": "summary",
+                        "removed": "[Presentation WebAPI] Support many-to-one session"
+                    }
+                ],
+                "when": "2015-08-24T07:08:46Z",
+                "who": "selin"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "2.6?",
+                        "field_name": "cf_blocking_b2g",
+                        "removed": "---"
+                    }
+                ],
+                "when": "2016-04-15T11:47:44Z",
+                "who": "schien"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "awu",
+                        "field_name": "cc",
+                        "removed": ""
+                    },
+                    {
+                        "added": "2.6+",
+                        "field_name": "cf_blocking_b2g",
+                        "removed": "2.6?"
+                    }
+                ],
+                "when": "2016-04-18T02:22:42Z",
+                "who": "awu"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "[ft:conndevices] [ETA 6/30]",
+                        "field_name": "whiteboard",
+                        "removed": "[ft:conndevices]"
+                    }
+                ],
+                "when": "2016-05-04T09:06:51Z",
+                "who": "schien"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "jocheng",
+                        "field_name": "cc",
+                        "removed": ""
+                    },
+                    {
+                        "added": "FxOS-S1 (26Jun)",
+                        "field_name": "target_milestone",
+                        "removed": "---"
+                    }
+                ],
+                "when": "2016-05-31T09:58:21Z",
+                "who": "jocheng"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "[ft:conndevices] [ETA 7/15]",
+                        "field_name": "whiteboard",
+                        "removed": "[ft:conndevices] [ETA 6/30]"
+                    }
+                ],
+                "when": "2016-06-30T02:45:27Z",
+                "who": "awu"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "juhsu",
+                        "field_name": "cc",
+                        "removed": ""
+                    },
+                    {
+                        "added": "kechang",
+                        "field_name": "assigned_to",
+                        "removed": "nobody@mozilla.org"
+                    },
+                    {
+                        "added": "feedback?(juhsu)",
+                        "attachment_id": 8770881,
+                        "field_name": "flagtypes.name",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-07-14T09:37:24Z",
+                "who": "kechang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "feedback?(schien)",
+                        "attachment_id": 8770882,
+                        "field_name": "flagtypes.name",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-07-14T09:38:06Z",
+                "who": "kechang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "",
+                        "attachment_id": 8770881,
+                        "field_name": "flagtypes.name",
+                        "removed": "feedback?(juhsu)"
+                    }
+                ],
+                "when": "2016-07-14T10:11:16Z",
+                "who": "juhsu"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "",
+                        "attachment_id": 8770882,
+                        "field_name": "flagtypes.name",
+                        "removed": "feedback?(schien)"
+                    }
+                ],
+                "when": "2016-07-15T07:46:49Z",
+                "who": "schien"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1",
+                        "attachment_id": 8770881,
+                        "field_name": "attachments.isobsolete",
+                        "removed": "0"
+                    },
+                    {
+                        "added": "review?(juhsu)",
+                        "attachment_id": 8771370,
+                        "field_name": "flagtypes.name",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-07-15T10:55:37Z",
+                "who": "kechang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "",
+                        "attachment_id": 8771370,
+                        "field_name": "flagtypes.name",
+                        "removed": "review?(juhsu)"
+                    }
+                ],
+                "when": "2016-07-18T02:36:19Z",
+                "who": "juhsu"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1",
+                        "attachment_id": 8771370,
+                        "field_name": "attachments.isobsolete",
+                        "removed": "0"
+                    },
+                    {
+                        "added": "review?(juhsu)",
+                        "attachment_id": 8772298,
+                        "field_name": "flagtypes.name",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-07-19T06:48:43Z",
+                "who": "kechang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "review+",
+                        "attachment_id": 8772298,
+                        "field_name": "flagtypes.name",
+                        "removed": "review?(juhsu)"
+                    }
+                ],
+                "when": "2016-07-19T10:03:02Z",
+                "who": "juhsu"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1",
+                        "attachment_id": 8770882,
+                        "field_name": "attachments.isobsolete",
+                        "removed": "0"
+                    },
+                    {
+                        "added": "feedback?(schien)",
+                        "attachment_id": 8772767,
+                        "field_name": "flagtypes.name",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-07-20T09:36:49Z",
+                "who": "kechang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "feedback+",
+                        "attachment_id": 8772767,
+                        "field_name": "flagtypes.name",
+                        "removed": "feedback?(schien)"
+                    }
+                ],
+                "when": "2016-07-22T03:30:56Z",
+                "who": "schien"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "1",
+                        "attachment_id": 8772767,
+                        "field_name": "attachments.isobsolete",
+                        "removed": "0"
+                    },
+                    {
+                        "added": "feedback?(schien)",
+                        "attachment_id": 8775004,
+                        "field_name": "flagtypes.name",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-07-27T03:50:22Z",
+                "who": "kechang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "feedback?(schien)",
+                        "attachment_id": 8775006,
+                        "field_name": "flagtypes.name",
+                        "removed": ""
+                    }
+                ],
+                "when": "2016-07-27T03:51:54Z",
+                "who": "kechang"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "feedback+",
+                        "attachment_id": 8775004,
+                        "field_name": "flagtypes.name",
+                        "removed": "feedback?(schien)"
+                    }
+                ],
+                "when": "2016-07-27T08:29:06Z",
+                "who": "schien"
+            },
+            {
+                "changes": [
+                    {
+                        "added": "feedback+",
+                        "attachment_id": 8775006,
+                        "field_name": "flagtypes.name",
+                        "removed": "feedback?(schien)"
+                    }
+                ],
+                "when": "2016-07-27T10:02:14Z",
+                "who": "schien"
+            }
+        ],
+        "id": 1197690,
+        "is_cc_accessible": true,
+        "is_confirmed": true,
+        "is_creator_accessible": true,
+        "is_open": true,
+        "keywords": [],
+        "last_change_time": "2016-07-27T10:02:14Z",
+        "mentors": [],
+        "mentors_detail": [],
+        "op_sys": "All",
+        "platform": "x86",
+        "priority": "--",
+        "product": "Core",
+        "qa_contact": "",
+        "resolution": "",
+        "see_also": [],
+        "severity": "normal",
+        "status": "NEW",
+        "summary": "[Presentation WebAPI] Support resuming a disconnected presentation session",
+        "target_milestone": "FxOS-S1 (26Jun)",
+        "url": "http://w3c.github.io/presentation-api/",
+        "version": "unspecified",
+        "votes": 0,
+        "whiteboard": "[ft:conndevices] [ETA 7/15]"
+    },
+    "origin": "https://bugzilla.mozilla.org/",
+    "perceval_version": "0.2.0",
+    "timestamp": 1469613768.270315,
+    "updated_on": 1469613734.0,
+    "uuid": "4c80560617ddc0e744aa58d0d81afc024534f98f"
+},
+{
+    "backend_name": "BugzillaREST",
+    "backend_version": "0.2.0",
+    "data": {
+        "alias": "Clearkey_on_Fennec",
+        "assigned_to": "kikuo",
+        "assigned_to_detail": {
+            "email": "kikuo",
+            "id": 505627,
+            "name": "kikuo",
+            "real_name": "Kilik Kuo [:kikuo]"
+        },
+        "attachments": [
+            {
+                "attacher": "jacheng",
+                "bug_id": 1267141,
+                "content_type": "text/plain",
+                "creation_time": "2016-04-25T08:17:25Z",
+                "creator": "jacheng",
+                "description": "Part1 - Enable-EME-API-on-fennec.patch",
+                "file_name": "0001-Bug-1267141-Enable-EME-API-on-fennec.patch",
+                "flags": [],
+                "id": 8744812,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-07-27T09:59:17Z",
+                "size": 1050,
+                "summary": "Part1 - Enable-EME-API-on-fennec.patch"
+            },
+            {
+                "attacher": "kikuo",
+                "bug_id": 1267141,
+                "content_type": "text/plain",
+                "creation_time": "2016-07-03T16:13:47Z",
+                "creator": "kikuo",
+                "description": "Preload clearkey.so for GMPChild process to avoid any nsFile operation in GMPService.",
+                "file_name": "Enable_EME_Clearkey_on_Fennec.patch",
+                "flags": [],
+                "id": 8767487,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-07-27T10:02:22Z",
+                "size": 9442,
+                "summary": "Preload clearkey.so for GMPChild process to avoid any nsFile operation in GMPService."
+            },
+            {
+                "attacher": "kikuo",
+                "bug_id": 1267141,
+                "content_type": "text/plain",
+                "creation_time": "2016-07-14T06:45:53Z",
+                "creator": "kikuo",
+                "description": "[WIP] Handle URI on GMPProvider.jsm & handle nsString path in GMP{Service,Parent,Child}",
+                "file_name": "Bug_1267141_Clearkey_Fennec_ver_URI.patch",
+                "flags": [],
+                "id": 8770840,
+                "is_obsolete": 1,
+                "is_patch": 1,
+                "is_private": 0,
+                "last_change_time": "2016-07-27T09:59:17Z",
+                "size": 27301,
+                "summary": "[WIP] Handle URI on GMPProvider.jsm & handle nsString path in GMP{Service,Parent,Child}"
+            },
+            {
+                "attacher": "kikuo",
+                "bug_id": 1267141,
+                "content_type": "text/plain",
+                "creation_time": "2016-07-27T09:59:17Z",
+                "creator": "kikuo",
+                "description": "Extract clearkey plugin related fliles when needed.",
+                "file_name": "Bug_1267141_Fennec_Clearkey_v3.patch",
+                "flags": [
+                    {
+                        "creation_date": "2016-07-27T09:59:17Z",
+                        "id": 1429897,
+                        "modification_date": "2016-07-27T09:59:17Z",
+                        "name": "feedback",
+                        "requestee": "cpearce",
+                        "setter": "kikuo",
+                        "status": "?",
+                        "type_id": 607
+                    },
+                    {
+                        "creation_date": "2016-07-27T09:59:17Z",
+                        "id": 1429898,
+                        "modification_date": "2016-07-27T09:59:17Z",
+                        "name": "feedback",
+                        "requestee": "",
+                        "setter": "kikuo",
+                        "status": "?",
+                        "type_id": 607
+                    }
+                ],
+                "id": 8775090,
                 "is_obsolete": 0,
                 "is_patch": 0,
                 "is_private": 0,


### PR DESCRIPTION
This patch prevents to index summary issues, the content of comments and their descriptions and summaries of attachments. These fields may contain large text that causes ES to fail during data uploading.