### PR TITLE
[ocean] Enhance mappings to index Crates data

### DIFF
--- a/grimoire_elk/ocean/crates.py
+++ b/grimoire_elk/ocean/crates.py
@@ -24,12 +24,42 @@
 #
 
 from .elastic import ElasticOcean
+from ..elastic_mapping import Mapping as BaseMapping
+
+
+class Mapping(BaseMapping):
+
+    @staticmethod
+    def get_elastic_mappings(es_major):
+        """Get Elasticsearch mapping.
+
+        :param es_major: major version of Elasticsearch, as string
+        :returns:        dictionary with a key, 'items', with the mapping
+        """
+
+        mapping = '''
+         {
+            "dynamic":true,
+                "properties": {
+                    "data": {
+                        "properties": {
+                            "versions_data": {
+                                "dynamic":false,
+                                "properties": {}
+                            }
+                        }
+                    }
+                }
+        }
+        '''
+
+        return {"items": mapping}
 
 
 class CratesOcean(ElasticOcean):
     """Confluence Ocean feeder"""
 
-    pass
+    mapping = Mapping
 
     @classmethod
     def get_perceval_params_from_url(cls, url):

--- a/tests/data/crates.json
+++ b/tests/data/crates.json
@@ -58,10 +58,4288 @@
                     "version": 60891
                 },
                 {
-                    "date": "2017-08-11",
-                    "downloads": 369,
-                    "id": 64781047,
-                    "version": 22300
+                    "date": "2017-10-23",
+                    "downloads": 1,
+                    "id": 105856002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-24",
+                    "downloads": 2,
+                    "id": 106740518,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-26",
+                    "downloads": 9,
+                    "id": 108792009,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-27",
+                    "downloads": 2,
+                    "id": 109442750,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-03",
+                    "downloads": 5,
+                    "id": 113262838,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-06",
+                    "downloads": 1,
+                    "id": 114917921,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-07",
+                    "downloads": 2,
+                    "id": 115286362,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-13",
+                    "downloads": 2,
+                    "id": 119207418,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-16",
+                    "downloads": 1,
+                    "id": 121435888,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-18",
+                    "downloads": 5,
+                    "id": 122311002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-22",
+                    "downloads": 4,
+                    "id": 125076744,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-28",
+                    "downloads": 1,
+                    "id": 128985675,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-02",
+                    "downloads": 1,
+                    "id": 77054560,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-03",
+                    "downloads": 1,
+                    "id": 77291437,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-05",
+                    "downloads": 1,
+                    "id": 78637102,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-14",
+                    "downloads": 2,
+                    "id": 82918836,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-20",
+                    "downloads": 1,
+                    "id": 86305758,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-21",
+                    "downloads": 1,
+                    "id": 86746238,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-22",
+                    "downloads": 3,
+                    "id": 87585489,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-24",
+                    "downloads": 1,
+                    "id": 88334982,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-28",
+                    "downloads": 1,
+                    "id": 90548601,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-10",
+                    "downloads": 1,
+                    "id": 96689421,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-13",
+                    "downloads": 2,
+                    "id": 98323485,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-14",
+                    "downloads": 2,
+                    "id": 99712307,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-21",
+                    "downloads": 3,
+                    "id": 104389898,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-22",
+                    "downloads": 1,
+                    "id": 105416107,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-23",
+                    "downloads": 1,
+                    "id": 105856002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-24",
+                    "downloads": 2,
+                    "id": 106740518,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-26",
+                    "downloads": 9,
+                    "id": 108792009,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-27",
+                    "downloads": 2,
+                    "id": 109442750,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-03",
+                    "downloads": 5,
+                    "id": 113262838,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-06",
+                    "downloads": 1,
+                    "id": 114917921,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-07",
+                    "downloads": 2,
+                    "id": 115286362,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-13",
+                    "downloads": 2,
+                    "id": 119207418,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-16",
+                    "downloads": 1,
+                    "id": 121435888,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-18",
+                    "downloads": 5,
+                    "id": 122311002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-22",
+                    "downloads": 4,
+                    "id": 125076744,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-28",
+                    "downloads": 1,
+                    "id": 128985675,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-02",
+                    "downloads": 1,
+                    "id": 77054560,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-03",
+                    "downloads": 1,
+                    "id": 77291437,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-05",
+                    "downloads": 1,
+                    "id": 78637102,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-14",
+                    "downloads": 2,
+                    "id": 82918836,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-20",
+                    "downloads": 1,
+                    "id": 86305758,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-21",
+                    "downloads": 1,
+                    "id": 86746238,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-22",
+                    "downloads": 3,
+                    "id": 87585489,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-24",
+                    "downloads": 1,
+                    "id": 88334982,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-28",
+                    "downloads": 1,
+                    "id": 90548601,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-10",
+                    "downloads": 1,
+                    "id": 96689421,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-13",
+                    "downloads": 2,
+                    "id": 98323485,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-14",
+                    "downloads": 2,
+                    "id": 99712307,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-21",
+                    "downloads": 3,
+                    "id": 104389898,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-22",
+                    "downloads": 1,
+                    "id": 105416107,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-23",
+                    "downloads": 1,
+                    "id": 105856002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-24",
+                    "downloads": 2,
+                    "id": 106740518,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-26",
+                    "downloads": 9,
+                    "id": 108792009,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-27",
+                    "downloads": 2,
+                    "id": 109442750,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-03",
+                    "downloads": 5,
+                    "id": 113262838,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-06",
+                    "downloads": 1,
+                    "id": 114917921,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-07",
+                    "downloads": 2,
+                    "id": 115286362,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-13",
+                    "downloads": 2,
+                    "id": 119207418,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-16",
+                    "downloads": 1,
+                    "id": 121435888,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-18",
+                    "downloads": 5,
+                    "id": 122311002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-22",
+                    "downloads": 4,
+                    "id": 125076744,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-28",
+                    "downloads": 1,
+                    "id": 128985675,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-02",
+                    "downloads": 1,
+                    "id": 77054560,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-03",
+                    "downloads": 1,
+                    "id": 77291437,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-05",
+                    "downloads": 1,
+                    "id": 78637102,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-14",
+                    "downloads": 2,
+                    "id": 82918836,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-20",
+                    "downloads": 1,
+                    "id": 86305758,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-21",
+                    "downloads": 1,
+                    "id": 86746238,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-22",
+                    "downloads": 3,
+                    "id": 87585489,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-24",
+                    "downloads": 1,
+                    "id": 88334982,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-28",
+                    "downloads": 1,
+                    "id": 90548601,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-10",
+                    "downloads": 1,
+                    "id": 96689421,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-13",
+                    "downloads": 2,
+                    "id": 98323485,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-14",
+                    "downloads": 2,
+                    "id": 99712307,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-21",
+                    "downloads": 3,
+                    "id": 104389898,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-22",
+                    "downloads": 1,
+                    "id": 105416107,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-23",
+                    "downloads": 1,
+                    "id": 105856002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-24",
+                    "downloads": 2,
+                    "id": 106740518,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-26",
+                    "downloads": 9,
+                    "id": 108792009,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-27",
+                    "downloads": 2,
+                    "id": 109442750,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-03",
+                    "downloads": 5,
+                    "id": 113262838,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-06",
+                    "downloads": 1,
+                    "id": 114917921,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-07",
+                    "downloads": 2,
+                    "id": 115286362,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-13",
+                    "downloads": 2,
+                    "id": 119207418,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-16",
+                    "downloads": 1,
+                    "id": 121435888,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-18",
+                    "downloads": 5,
+                    "id": 122311002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-22",
+                    "downloads": 4,
+                    "id": 125076744,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-28",
+                    "downloads": 1,
+                    "id": 128985675,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-02",
+                    "downloads": 1,
+                    "id": 77054560,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-03",
+                    "downloads": 1,
+                    "id": 77291437,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-05",
+                    "downloads": 1,
+                    "id": 78637102,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-14",
+                    "downloads": 2,
+                    "id": 82918836,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-20",
+                    "downloads": 1,
+                    "id": 86305758,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-21",
+                    "downloads": 1,
+                    "id": 86746238,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-22",
+                    "downloads": 3,
+                    "id": 87585489,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-24",
+                    "downloads": 1,
+                    "id": 88334982,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-28",
+                    "downloads": 1,
+                    "id": 90548601,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-10",
+                    "downloads": 1,
+                    "id": 96689421,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-13",
+                    "downloads": 2,
+                    "id": 98323485,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-14",
+                    "downloads": 2,
+                    "id": 99712307,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-21",
+                    "downloads": 3,
+                    "id": 104389898,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-22",
+                    "downloads": 1,
+                    "id": 105416107,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-23",
+                    "downloads": 1,
+                    "id": 105856002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-24",
+                    "downloads": 2,
+                    "id": 106740518,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-26",
+                    "downloads": 9,
+                    "id": 108792009,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-27",
+                    "downloads": 2,
+                    "id": 109442750,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-03",
+                    "downloads": 5,
+                    "id": 113262838,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-06",
+                    "downloads": 1,
+                    "id": 114917921,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-07",
+                    "downloads": 2,
+                    "id": 115286362,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-13",
+                    "downloads": 2,
+                    "id": 119207418,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-16",
+                    "downloads": 1,
+                    "id": 121435888,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-18",
+                    "downloads": 5,
+                    "id": 122311002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-22",
+                    "downloads": 4,
+                    "id": 125076744,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-28",
+                    "downloads": 1,
+                    "id": 128985675,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-02",
+                    "downloads": 1,
+                    "id": 77054560,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-03",
+                    "downloads": 1,
+                    "id": 77291437,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-05",
+                    "downloads": 1,
+                    "id": 78637102,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-14",
+                    "downloads": 2,
+                    "id": 82918836,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-20",
+                    "downloads": 1,
+                    "id": 86305758,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-21",
+                    "downloads": 1,
+                    "id": 86746238,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-22",
+                    "downloads": 3,
+                    "id": 87585489,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-24",
+                    "downloads": 1,
+                    "id": 88334982,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-28",
+                    "downloads": 1,
+                    "id": 90548601,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-10",
+                    "downloads": 1,
+                    "id": 96689421,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-13",
+                    "downloads": 2,
+                    "id": 98323485,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-14",
+                    "downloads": 2,
+                    "id": 99712307,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-21",
+                    "downloads": 3,
+                    "id": 104389898,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-22",
+                    "downloads": 1,
+                    "id": 105416107,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-23",
+                    "downloads": 1,
+                    "id": 105856002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-24",
+                    "downloads": 2,
+                    "id": 106740518,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-26",
+                    "downloads": 9,
+                    "id": 108792009,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-27",
+                    "downloads": 2,
+                    "id": 109442750,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-03",
+                    "downloads": 5,
+                    "id": 113262838,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-06",
+                    "downloads": 1,
+                    "id": 114917921,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-07",
+                    "downloads": 2,
+                    "id": 115286362,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-13",
+                    "downloads": 2,
+                    "id": 119207418,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-16",
+                    "downloads": 1,
+                    "id": 121435888,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-18",
+                    "downloads": 5,
+                    "id": 122311002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-22",
+                    "downloads": 4,
+                    "id": 125076744,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-28",
+                    "downloads": 1,
+                    "id": 128985675,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-02",
+                    "downloads": 1,
+                    "id": 77054560,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-03",
+                    "downloads": 1,
+                    "id": 77291437,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-05",
+                    "downloads": 1,
+                    "id": 78637102,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-14",
+                    "downloads": 2,
+                    "id": 82918836,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-20",
+                    "downloads": 1,
+                    "id": 86305758,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-21",
+                    "downloads": 1,
+                    "id": 86746238,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-22",
+                    "downloads": 3,
+                    "id": 87585489,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-24",
+                    "downloads": 1,
+                    "id": 88334982,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-28",
+                    "downloads": 1,
+                    "id": 90548601,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-10",
+                    "downloads": 1,
+                    "id": 96689421,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-13",
+                    "downloads": 2,
+                    "id": 98323485,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-14",
+                    "downloads": 2,
+                    "id": 99712307,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-21",
+                    "downloads": 3,
+                    "id": 104389898,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-22",
+                    "downloads": 1,
+                    "id": 105416107,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-23",
+                    "downloads": 1,
+                    "id": 105856002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-24",
+                    "downloads": 2,
+                    "id": 106740518,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-26",
+                    "downloads": 9,
+                    "id": 108792009,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-27",
+                    "downloads": 2,
+                    "id": 109442750,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-03",
+                    "downloads": 5,
+                    "id": 113262838,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-06",
+                    "downloads": 1,
+                    "id": 114917921,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-07",
+                    "downloads": 2,
+                    "id": 115286362,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-13",
+                    "downloads": 2,
+                    "id": 119207418,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-16",
+                    "downloads": 1,
+                    "id": 121435888,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-18",
+                    "downloads": 5,
+                    "id": 122311002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-22",
+                    "downloads": 4,
+                    "id": 125076744,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-28",
+                    "downloads": 1,
+                    "id": 128985675,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-02",
+                    "downloads": 1,
+                    "id": 77054560,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-03",
+                    "downloads": 1,
+                    "id": 77291437,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-05",
+                    "downloads": 1,
+                    "id": 78637102,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-14",
+                    "downloads": 2,
+                    "id": 82918836,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-20",
+                    "downloads": 1,
+                    "id": 86305758,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-21",
+                    "downloads": 1,
+                    "id": 86746238,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-22",
+                    "downloads": 3,
+                    "id": 87585489,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-24",
+                    "downloads": 1,
+                    "id": 88334982,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-28",
+                    "downloads": 1,
+                    "id": 90548601,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-10",
+                    "downloads": 1,
+                    "id": 96689421,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-13",
+                    "downloads": 2,
+                    "id": 98323485,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-14",
+                    "downloads": 2,
+                    "id": 99712307,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-21",
+                    "downloads": 3,
+                    "id": 104389898,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-22",
+                    "downloads": 1,
+                    "id": 105416107,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-23",
+                    "downloads": 1,
+                    "id": 105856002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-24",
+                    "downloads": 2,
+                    "id": 106740518,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-26",
+                    "downloads": 9,
+                    "id": 108792009,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-27",
+                    "downloads": 2,
+                    "id": 109442750,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-03",
+                    "downloads": 5,
+                    "id": 113262838,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-06",
+                    "downloads": 1,
+                    "id": 114917921,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-07",
+                    "downloads": 2,
+                    "id": 115286362,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-13",
+                    "downloads": 2,
+                    "id": 119207418,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-16",
+                    "downloads": 1,
+                    "id": 121435888,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-18",
+                    "downloads": 5,
+                    "id": 122311002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-22",
+                    "downloads": 4,
+                    "id": 125076744,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-28",
+                    "downloads": 1,
+                    "id": 128985675,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-02",
+                    "downloads": 1,
+                    "id": 77054560,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-03",
+                    "downloads": 1,
+                    "id": 77291437,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-05",
+                    "downloads": 1,
+                    "id": 78637102,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-14",
+                    "downloads": 2,
+                    "id": 82918836,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-20",
+                    "downloads": 1,
+                    "id": 86305758,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-21",
+                    "downloads": 1,
+                    "id": 86746238,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-22",
+                    "downloads": 3,
+                    "id": 87585489,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-24",
+                    "downloads": 1,
+                    "id": 88334982,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-28",
+                    "downloads": 1,
+                    "id": 90548601,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-10",
+                    "downloads": 1,
+                    "id": 96689421,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-13",
+                    "downloads": 2,
+                    "id": 98323485,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-14",
+                    "downloads": 2,
+                    "id": 99712307,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-21",
+                    "downloads": 3,
+                    "id": 104389898,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-22",
+                    "downloads": 1,
+                    "id": 105416107,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-23",
+                    "downloads": 1,
+                    "id": 105856002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-24",
+                    "downloads": 2,
+                    "id": 106740518,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-26",
+                    "downloads": 9,
+                    "id": 108792009,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-27",
+                    "downloads": 2,
+                    "id": 109442750,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-03",
+                    "downloads": 5,
+                    "id": 113262838,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-06",
+                    "downloads": 1,
+                    "id": 114917921,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-07",
+                    "downloads": 2,
+                    "id": 115286362,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-13",
+                    "downloads": 2,
+                    "id": 119207418,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-16",
+                    "downloads": 1,
+                    "id": 121435888,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-18",
+                    "downloads": 5,
+                    "id": 122311002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-22",
+                    "downloads": 4,
+                    "id": 125076744,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-28",
+                    "downloads": 1,
+                    "id": 128985675,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-02",
+                    "downloads": 1,
+                    "id": 77054560,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-03",
+                    "downloads": 1,
+                    "id": 77291437,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-05",
+                    "downloads": 1,
+                    "id": 78637102,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-14",
+                    "downloads": 2,
+                    "id": 82918836,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-20",
+                    "downloads": 1,
+                    "id": 86305758,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-21",
+                    "downloads": 1,
+                    "id": 86746238,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-22",
+                    "downloads": 3,
+                    "id": 87585489,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-24",
+                    "downloads": 1,
+                    "id": 88334982,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-28",
+                    "downloads": 1,
+                    "id": 90548601,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-10",
+                    "downloads": 1,
+                    "id": 96689421,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-13",
+                    "downloads": 2,
+                    "id": 98323485,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-14",
+                    "downloads": 2,
+                    "id": 99712307,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-21",
+                    "downloads": 3,
+                    "id": 104389898,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-22",
+                    "downloads": 1,
+                    "id": 105416107,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-23",
+                    "downloads": 1,
+                    "id": 105856002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-24",
+                    "downloads": 2,
+                    "id": 106740518,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-26",
+                    "downloads": 9,
+                    "id": 108792009,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-27",
+                    "downloads": 2,
+                    "id": 109442750,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-03",
+                    "downloads": 5,
+                    "id": 113262838,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-06",
+                    "downloads": 1,
+                    "id": 114917921,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-07",
+                    "downloads": 2,
+                    "id": 115286362,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-13",
+                    "downloads": 2,
+                    "id": 119207418,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-16",
+                    "downloads": 1,
+                    "id": 121435888,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-18",
+                    "downloads": 5,
+                    "id": 122311002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-22",
+                    "downloads": 4,
+                    "id": 125076744,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-28",
+                    "downloads": 1,
+                    "id": 128985675,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-02",
+                    "downloads": 1,
+                    "id": 77054560,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-03",
+                    "downloads": 1,
+                    "id": 77291437,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-05",
+                    "downloads": 1,
+                    "id": 78637102,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-14",
+                    "downloads": 2,
+                    "id": 82918836,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-20",
+                    "downloads": 1,
+                    "id": 86305758,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-21",
+                    "downloads": 1,
+                    "id": 86746238,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-22",
+                    "downloads": 3,
+                    "id": 87585489,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-24",
+                    "downloads": 1,
+                    "id": 88334982,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-28",
+                    "downloads": 1,
+                    "id": 90548601,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-10",
+                    "downloads": 1,
+                    "id": 96689421,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-13",
+                    "downloads": 2,
+                    "id": 98323485,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-14",
+                    "downloads": 2,
+                    "id": 99712307,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-21",
+                    "downloads": 3,
+                    "id": 104389898,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-22",
+                    "downloads": 1,
+                    "id": 105416107,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-23",
+                    "downloads": 1,
+                    "id": 105856002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-24",
+                    "downloads": 2,
+                    "id": 106740518,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-26",
+                    "downloads": 9,
+                    "id": 108792009,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-27",
+                    "downloads": 2,
+                    "id": 109442750,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-03",
+                    "downloads": 5,
+                    "id": 113262838,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-06",
+                    "downloads": 1,
+                    "id": 114917921,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-07",
+                    "downloads": 2,
+                    "id": 115286362,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-13",
+                    "downloads": 2,
+                    "id": 119207418,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-16",
+                    "downloads": 1,
+                    "id": 121435888,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-18",
+                    "downloads": 5,
+                    "id": 122311002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-22",
+                    "downloads": 4,
+                    "id": 125076744,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-28",
+                    "downloads": 1,
+                    "id": 128985675,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-02",
+                    "downloads": 1,
+                    "id": 77054560,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-03",
+                    "downloads": 1,
+                    "id": 77291437,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-05",
+                    "downloads": 1,
+                    "id": 78637102,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-14",
+                    "downloads": 2,
+                    "id": 82918836,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-20",
+                    "downloads": 1,
+                    "id": 86305758,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-21",
+                    "downloads": 1,
+                    "id": 86746238,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-22",
+                    "downloads": 3,
+                    "id": 87585489,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-24",
+                    "downloads": 1,
+                    "id": 88334982,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-28",
+                    "downloads": 1,
+                    "id": 90548601,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-10",
+                    "downloads": 1,
+                    "id": 96689421,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-13",
+                    "downloads": 2,
+                    "id": 98323485,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-14",
+                    "downloads": 2,
+                    "id": 99712307,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-21",
+                    "downloads": 3,
+                    "id": 104389898,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-22",
+                    "downloads": 1,
+                    "id": 105416107,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-23",
+                    "downloads": 1,
+                    "id": 105856002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-24",
+                    "downloads": 2,
+                    "id": 106740518,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-26",
+                    "downloads": 9,
+                    "id": 108792009,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-27",
+                    "downloads": 2,
+                    "id": 109442750,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-03",
+                    "downloads": 5,
+                    "id": 113262838,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-06",
+                    "downloads": 1,
+                    "id": 114917921,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-07",
+                    "downloads": 2,
+                    "id": 115286362,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-13",
+                    "downloads": 2,
+                    "id": 119207418,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-16",
+                    "downloads": 1,
+                    "id": 121435888,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-18",
+                    "downloads": 5,
+                    "id": 122311002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-22",
+                    "downloads": 4,
+                    "id": 125076744,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-28",
+                    "downloads": 1,
+                    "id": 128985675,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-02",
+                    "downloads": 1,
+                    "id": 77054560,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-03",
+                    "downloads": 1,
+                    "id": 77291437,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-05",
+                    "downloads": 1,
+                    "id": 78637102,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-14",
+                    "downloads": 2,
+                    "id": 82918836,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-20",
+                    "downloads": 1,
+                    "id": 86305758,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-21",
+                    "downloads": 1,
+                    "id": 86746238,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-22",
+                    "downloads": 3,
+                    "id": 87585489,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-24",
+                    "downloads": 1,
+                    "id": 88334982,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-28",
+                    "downloads": 1,
+                    "id": 90548601,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-10",
+                    "downloads": 1,
+                    "id": 96689421,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-13",
+                    "downloads": 2,
+                    "id": 98323485,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-14",
+                    "downloads": 2,
+                    "id": 99712307,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-21",
+                    "downloads": 3,
+                    "id": 104389898,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-22",
+                    "downloads": 1,
+                    "id": 105416107,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-23",
+                    "downloads": 1,
+                    "id": 105856002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-24",
+                    "downloads": 2,
+                    "id": 106740518,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-26",
+                    "downloads": 9,
+                    "id": 108792009,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-27",
+                    "downloads": 2,
+                    "id": 109442750,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-03",
+                    "downloads": 5,
+                    "id": 113262838,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-06",
+                    "downloads": 1,
+                    "id": 114917921,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-07",
+                    "downloads": 2,
+                    "id": 115286362,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-13",
+                    "downloads": 2,
+                    "id": 119207418,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-16",
+                    "downloads": 1,
+                    "id": 121435888,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-18",
+                    "downloads": 5,
+                    "id": 122311002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-22",
+                    "downloads": 4,
+                    "id": 125076744,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-28",
+                    "downloads": 1,
+                    "id": 128985675,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-02",
+                    "downloads": 1,
+                    "id": 77054560,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-03",
+                    "downloads": 1,
+                    "id": 77291437,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-05",
+                    "downloads": 1,
+                    "id": 78637102,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-14",
+                    "downloads": 2,
+                    "id": 82918836,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-20",
+                    "downloads": 1,
+                    "id": 86305758,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-21",
+                    "downloads": 1,
+                    "id": 86746238,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-22",
+                    "downloads": 3,
+                    "id": 87585489,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-24",
+                    "downloads": 1,
+                    "id": 88334982,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-28",
+                    "downloads": 1,
+                    "id": 90548601,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-10",
+                    "downloads": 1,
+                    "id": 96689421,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-13",
+                    "downloads": 2,
+                    "id": 98323485,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-14",
+                    "downloads": 2,
+                    "id": 99712307,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-21",
+                    "downloads": 3,
+                    "id": 104389898,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-22",
+                    "downloads": 1,
+                    "id": 105416107,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-23",
+                    "downloads": 1,
+                    "id": 105856002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-24",
+                    "downloads": 2,
+                    "id": 106740518,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-26",
+                    "downloads": 9,
+                    "id": 108792009,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-27",
+                    "downloads": 2,
+                    "id": 109442750,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-03",
+                    "downloads": 5,
+                    "id": 113262838,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-06",
+                    "downloads": 1,
+                    "id": 114917921,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-07",
+                    "downloads": 2,
+                    "id": 115286362,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-13",
+                    "downloads": 2,
+                    "id": 119207418,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-16",
+                    "downloads": 1,
+                    "id": 121435888,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-18",
+                    "downloads": 5,
+                    "id": 122311002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-22",
+                    "downloads": 4,
+                    "id": 125076744,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-28",
+                    "downloads": 1,
+                    "id": 128985675,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-02",
+                    "downloads": 1,
+                    "id": 77054560,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-03",
+                    "downloads": 1,
+                    "id": 77291437,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-05",
+                    "downloads": 1,
+                    "id": 78637102,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-14",
+                    "downloads": 2,
+                    "id": 82918836,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-20",
+                    "downloads": 1,
+                    "id": 86305758,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-21",
+                    "downloads": 1,
+                    "id": 86746238,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-22",
+                    "downloads": 3,
+                    "id": 87585489,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-24",
+                    "downloads": 1,
+                    "id": 88334982,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-28",
+                    "downloads": 1,
+                    "id": 90548601,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-10",
+                    "downloads": 1,
+                    "id": 96689421,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-13",
+                    "downloads": 2,
+                    "id": 98323485,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-14",
+                    "downloads": 2,
+                    "id": 99712307,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-21",
+                    "downloads": 3,
+                    "id": 104389898,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-22",
+                    "downloads": 1,
+                    "id": 105416107,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-23",
+                    "downloads": 1,
+                    "id": 105856002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-24",
+                    "downloads": 2,
+                    "id": 106740518,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-26",
+                    "downloads": 9,
+                    "id": 108792009,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-27",
+                    "downloads": 2,
+                    "id": 109442750,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-03",
+                    "downloads": 5,
+                    "id": 113262838,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-06",
+                    "downloads": 1,
+                    "id": 114917921,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-07",
+                    "downloads": 2,
+                    "id": 115286362,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-13",
+                    "downloads": 2,
+                    "id": 119207418,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-16",
+                    "downloads": 1,
+                    "id": 121435888,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-18",
+                    "downloads": 5,
+                    "id": 122311002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-22",
+                    "downloads": 4,
+                    "id": 125076744,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-28",
+                    "downloads": 1,
+                    "id": 128985675,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-02",
+                    "downloads": 1,
+                    "id": 77054560,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-03",
+                    "downloads": 1,
+                    "id": 77291437,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-05",
+                    "downloads": 1,
+                    "id": 78637102,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-14",
+                    "downloads": 2,
+                    "id": 82918836,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-20",
+                    "downloads": 1,
+                    "id": 86305758,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-21",
+                    "downloads": 1,
+                    "id": 86746238,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-22",
+                    "downloads": 3,
+                    "id": 87585489,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-24",
+                    "downloads": 1,
+                    "id": 88334982,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-28",
+                    "downloads": 1,
+                    "id": 90548601,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-10",
+                    "downloads": 1,
+                    "id": 96689421,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-13",
+                    "downloads": 2,
+                    "id": 98323485,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-14",
+                    "downloads": 2,
+                    "id": 99712307,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-21",
+                    "downloads": 3,
+                    "id": 104389898,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-22",
+                    "downloads": 1,
+                    "id": 105416107,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-23",
+                    "downloads": 1,
+                    "id": 105856002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-24",
+                    "downloads": 2,
+                    "id": 106740518,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-26",
+                    "downloads": 9,
+                    "id": 108792009,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-27",
+                    "downloads": 2,
+                    "id": 109442750,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-03",
+                    "downloads": 5,
+                    "id": 113262838,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-06",
+                    "downloads": 1,
+                    "id": 114917921,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-07",
+                    "downloads": 2,
+                    "id": 115286362,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-13",
+                    "downloads": 2,
+                    "id": 119207418,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-16",
+                    "downloads": 1,
+                    "id": 121435888,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-18",
+                    "downloads": 5,
+                    "id": 122311002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-22",
+                    "downloads": 4,
+                    "id": 125076744,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-28",
+                    "downloads": 1,
+                    "id": 128985675,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-02",
+                    "downloads": 1,
+                    "id": 77054560,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-03",
+                    "downloads": 1,
+                    "id": 77291437,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-05",
+                    "downloads": 1,
+                    "id": 78637102,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-14",
+                    "downloads": 2,
+                    "id": 82918836,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-20",
+                    "downloads": 1,
+                    "id": 86305758,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-21",
+                    "downloads": 1,
+                    "id": 86746238,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-22",
+                    "downloads": 3,
+                    "id": 87585489,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-24",
+                    "downloads": 1,
+                    "id": 88334982,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-28",
+                    "downloads": 1,
+                    "id": 90548601,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-10",
+                    "downloads": 1,
+                    "id": 96689421,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-13",
+                    "downloads": 2,
+                    "id": 98323485,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-14",
+                    "downloads": 2,
+                    "id": 99712307,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-21",
+                    "downloads": 3,
+                    "id": 104389898,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-22",
+                    "downloads": 1,
+                    "id": 105416107,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-23",
+                    "downloads": 1,
+                    "id": 105856002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-24",
+                    "downloads": 2,
+                    "id": 106740518,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-26",
+                    "downloads": 9,
+                    "id": 108792009,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-27",
+                    "downloads": 2,
+                    "id": 109442750,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-03",
+                    "downloads": 5,
+                    "id": 113262838,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-06",
+                    "downloads": 1,
+                    "id": 114917921,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-07",
+                    "downloads": 2,
+                    "id": 115286362,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-13",
+                    "downloads": 2,
+                    "id": 119207418,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-16",
+                    "downloads": 1,
+                    "id": 121435888,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-18",
+                    "downloads": 5,
+                    "id": 122311002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-22",
+                    "downloads": 4,
+                    "id": 125076744,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-28",
+                    "downloads": 1,
+                    "id": 128985675,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-02",
+                    "downloads": 1,
+                    "id": 77054560,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-03",
+                    "downloads": 1,
+                    "id": 77291437,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-05",
+                    "downloads": 1,
+                    "id": 78637102,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-14",
+                    "downloads": 2,
+                    "id": 82918836,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-20",
+                    "downloads": 1,
+                    "id": 86305758,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-21",
+                    "downloads": 1,
+                    "id": 86746238,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-22",
+                    "downloads": 3,
+                    "id": 87585489,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-24",
+                    "downloads": 1,
+                    "id": 88334982,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-28",
+                    "downloads": 1,
+                    "id": 90548601,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-10",
+                    "downloads": 1,
+                    "id": 96689421,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-13",
+                    "downloads": 2,
+                    "id": 98323485,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-14",
+                    "downloads": 2,
+                    "id": 99712307,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-21",
+                    "downloads": 3,
+                    "id": 104389898,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-22",
+                    "downloads": 1,
+                    "id": 105416107,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-23",
+                    "downloads": 1,
+                    "id": 105856002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-24",
+                    "downloads": 2,
+                    "id": 106740518,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-26",
+                    "downloads": 9,
+                    "id": 108792009,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-27",
+                    "downloads": 2,
+                    "id": 109442750,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-03",
+                    "downloads": 5,
+                    "id": 113262838,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-06",
+                    "downloads": 1,
+                    "id": 114917921,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-07",
+                    "downloads": 2,
+                    "id": 115286362,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-13",
+                    "downloads": 2,
+                    "id": 119207418,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-16",
+                    "downloads": 1,
+                    "id": 121435888,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-18",
+                    "downloads": 5,
+                    "id": 122311002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-22",
+                    "downloads": 4,
+                    "id": 125076744,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-28",
+                    "downloads": 1,
+                    "id": 128985675,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-02",
+                    "downloads": 1,
+                    "id": 77054560,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-03",
+                    "downloads": 1,
+                    "id": 77291437,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-05",
+                    "downloads": 1,
+                    "id": 78637102,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-14",
+                    "downloads": 2,
+                    "id": 82918836,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-20",
+                    "downloads": 1,
+                    "id": 86305758,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-21",
+                    "downloads": 1,
+                    "id": 86746238,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-22",
+                    "downloads": 3,
+                    "id": 87585489,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-24",
+                    "downloads": 1,
+                    "id": 88334982,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-28",
+                    "downloads": 1,
+                    "id": 90548601,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-10",
+                    "downloads": 1,
+                    "id": 96689421,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-13",
+                    "downloads": 2,
+                    "id": 98323485,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-14",
+                    "downloads": 2,
+                    "id": 99712307,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-21",
+                    "downloads": 3,
+                    "id": 104389898,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-22",
+                    "downloads": 1,
+                    "id": 105416107,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-23",
+                    "downloads": 1,
+                    "id": 105856002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-24",
+                    "downloads": 2,
+                    "id": 106740518,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-26",
+                    "downloads": 9,
+                    "id": 108792009,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-27",
+                    "downloads": 2,
+                    "id": 109442750,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-03",
+                    "downloads": 5,
+                    "id": 113262838,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-06",
+                    "downloads": 1,
+                    "id": 114917921,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-07",
+                    "downloads": 2,
+                    "id": 115286362,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-13",
+                    "downloads": 2,
+                    "id": 119207418,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-16",
+                    "downloads": 1,
+                    "id": 121435888,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-18",
+                    "downloads": 5,
+                    "id": 122311002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-22",
+                    "downloads": 4,
+                    "id": 125076744,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-28",
+                    "downloads": 1,
+                    "id": 128985675,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-02",
+                    "downloads": 1,
+                    "id": 77054560,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-03",
+                    "downloads": 1,
+                    "id": 77291437,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-05",
+                    "downloads": 1,
+                    "id": 78637102,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-14",
+                    "downloads": 2,
+                    "id": 82918836,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-20",
+                    "downloads": 1,
+                    "id": 86305758,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-21",
+                    "downloads": 1,
+                    "id": 86746238,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-22",
+                    "downloads": 3,
+                    "id": 87585489,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-24",
+                    "downloads": 1,
+                    "id": 88334982,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-28",
+                    "downloads": 1,
+                    "id": 90548601,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-10",
+                    "downloads": 1,
+                    "id": 96689421,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-13",
+                    "downloads": 2,
+                    "id": 98323485,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-14",
+                    "downloads": 2,
+                    "id": 99712307,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-21",
+                    "downloads": 3,
+                    "id": 104389898,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-22",
+                    "downloads": 1,
+                    "id": 105416107,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-23",
+                    "downloads": 1,
+                    "id": 105856002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-24",
+                    "downloads": 2,
+                    "id": 106740518,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-26",
+                    "downloads": 9,
+                    "id": 108792009,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-27",
+                    "downloads": 2,
+                    "id": 109442750,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-03",
+                    "downloads": 5,
+                    "id": 113262838,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-06",
+                    "downloads": 1,
+                    "id": 114917921,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-07",
+                    "downloads": 2,
+                    "id": 115286362,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-13",
+                    "downloads": 2,
+                    "id": 119207418,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-16",
+                    "downloads": 1,
+                    "id": 121435888,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-18",
+                    "downloads": 5,
+                    "id": 122311002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-22",
+                    "downloads": 4,
+                    "id": 125076744,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-28",
+                    "downloads": 1,
+                    "id": 128985675,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-02",
+                    "downloads": 1,
+                    "id": 77054560,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-03",
+                    "downloads": 1,
+                    "id": 77291437,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-05",
+                    "downloads": 1,
+                    "id": 78637102,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-14",
+                    "downloads": 2,
+                    "id": 82918836,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-20",
+                    "downloads": 1,
+                    "id": 86305758,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-21",
+                    "downloads": 1,
+                    "id": 86746238,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-22",
+                    "downloads": 3,
+                    "id": 87585489,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-24",
+                    "downloads": 1,
+                    "id": 88334982,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-28",
+                    "downloads": 1,
+                    "id": 90548601,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-10",
+                    "downloads": 1,
+                    "id": 96689421,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-13",
+                    "downloads": 2,
+                    "id": 98323485,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-14",
+                    "downloads": 2,
+                    "id": 99712307,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-21",
+                    "downloads": 3,
+                    "id": 104389898,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-22",
+                    "downloads": 1,
+                    "id": 105416107,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-23",
+                    "downloads": 1,
+                    "id": 105856002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-24",
+                    "downloads": 2,
+                    "id": 106740518,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-26",
+                    "downloads": 9,
+                    "id": 108792009,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-27",
+                    "downloads": 2,
+                    "id": 109442750,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-03",
+                    "downloads": 5,
+                    "id": 113262838,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-06",
+                    "downloads": 1,
+                    "id": 114917921,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-07",
+                    "downloads": 2,
+                    "id": 115286362,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-13",
+                    "downloads": 2,
+                    "id": 119207418,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-16",
+                    "downloads": 1,
+                    "id": 121435888,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-18",
+                    "downloads": 5,
+                    "id": 122311002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-22",
+                    "downloads": 4,
+                    "id": 125076744,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-28",
+                    "downloads": 1,
+                    "id": 128985675,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-02",
+                    "downloads": 1,
+                    "id": 77054560,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-03",
+                    "downloads": 1,
+                    "id": 77291437,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-05",
+                    "downloads": 1,
+                    "id": 78637102,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-14",
+                    "downloads": 2,
+                    "id": 82918836,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-20",
+                    "downloads": 1,
+                    "id": 86305758,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-21",
+                    "downloads": 1,
+                    "id": 86746238,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-22",
+                    "downloads": 3,
+                    "id": 87585489,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-24",
+                    "downloads": 1,
+                    "id": 88334982,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-28",
+                    "downloads": 1,
+                    "id": 90548601,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-10",
+                    "downloads": 1,
+                    "id": 96689421,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-13",
+                    "downloads": 2,
+                    "id": 98323485,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-14",
+                    "downloads": 2,
+                    "id": 99712307,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-21",
+                    "downloads": 3,
+                    "id": 104389898,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-22",
+                    "downloads": 1,
+                    "id": 105416107,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-23",
+                    "downloads": 1,
+                    "id": 105856002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-24",
+                    "downloads": 2,
+                    "id": 106740518,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-26",
+                    "downloads": 9,
+                    "id": 108792009,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-27",
+                    "downloads": 2,
+                    "id": 109442750,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-03",
+                    "downloads": 5,
+                    "id": 113262838,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-06",
+                    "downloads": 1,
+                    "id": 114917921,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-07",
+                    "downloads": 2,
+                    "id": 115286362,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-13",
+                    "downloads": 2,
+                    "id": 119207418,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-16",
+                    "downloads": 1,
+                    "id": 121435888,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-18",
+                    "downloads": 5,
+                    "id": 122311002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-22",
+                    "downloads": 4,
+                    "id": 125076744,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-28",
+                    "downloads": 1,
+                    "id": 128985675,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-02",
+                    "downloads": 1,
+                    "id": 77054560,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-03",
+                    "downloads": 1,
+                    "id": 77291437,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-05",
+                    "downloads": 1,
+                    "id": 78637102,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-14",
+                    "downloads": 2,
+                    "id": 82918836,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-20",
+                    "downloads": 1,
+                    "id": 86305758,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-21",
+                    "downloads": 1,
+                    "id": 86746238,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-22",
+                    "downloads": 3,
+                    "id": 87585489,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-24",
+                    "downloads": 1,
+                    "id": 88334982,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-28",
+                    "downloads": 1,
+                    "id": 90548601,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-10",
+                    "downloads": 1,
+                    "id": 96689421,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-13",
+                    "downloads": 2,
+                    "id": 98323485,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-14",
+                    "downloads": 2,
+                    "id": 99712307,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-21",
+                    "downloads": 3,
+                    "id": 104389898,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-22",
+                    "downloads": 1,
+                    "id": 105416107,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-23",
+                    "downloads": 1,
+                    "id": 105856002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-24",
+                    "downloads": 2,
+                    "id": 106740518,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-26",
+                    "downloads": 9,
+                    "id": 108792009,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-27",
+                    "downloads": 2,
+                    "id": 109442750,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-03",
+                    "downloads": 5,
+                    "id": 113262838,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-06",
+                    "downloads": 1,
+                    "id": 114917921,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-07",
+                    "downloads": 2,
+                    "id": 115286362,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-13",
+                    "downloads": 2,
+                    "id": 119207418,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-16",
+                    "downloads": 1,
+                    "id": 121435888,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-18",
+                    "downloads": 5,
+                    "id": 122311002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-22",
+                    "downloads": 4,
+                    "id": 125076744,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-28",
+                    "downloads": 1,
+                    "id": 128985675,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-02",
+                    "downloads": 1,
+                    "id": 77054560,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-03",
+                    "downloads": 1,
+                    "id": 77291437,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-05",
+                    "downloads": 1,
+                    "id": 78637102,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-14",
+                    "downloads": 2,
+                    "id": 82918836,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-20",
+                    "downloads": 1,
+                    "id": 86305758,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-21",
+                    "downloads": 1,
+                    "id": 86746238,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-22",
+                    "downloads": 3,
+                    "id": 87585489,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-24",
+                    "downloads": 1,
+                    "id": 88334982,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-28",
+                    "downloads": 1,
+                    "id": 90548601,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-10",
+                    "downloads": 1,
+                    "id": 96689421,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-13",
+                    "downloads": 2,
+                    "id": 98323485,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-14",
+                    "downloads": 2,
+                    "id": 99712307,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-21",
+                    "downloads": 3,
+                    "id": 104389898,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-22",
+                    "downloads": 1,
+                    "id": 105416107,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-23",
+                    "downloads": 1,
+                    "id": 105856002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-24",
+                    "downloads": 2,
+                    "id": 106740518,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-26",
+                    "downloads": 9,
+                    "id": 108792009,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-27",
+                    "downloads": 2,
+                    "id": 109442750,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-03",
+                    "downloads": 5,
+                    "id": 113262838,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-06",
+                    "downloads": 1,
+                    "id": 114917921,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-07",
+                    "downloads": 2,
+                    "id": 115286362,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-13",
+                    "downloads": 2,
+                    "id": 119207418,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-16",
+                    "downloads": 1,
+                    "id": 121435888,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-18",
+                    "downloads": 5,
+                    "id": 122311002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-22",
+                    "downloads": 4,
+                    "id": 125076744,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-28",
+                    "downloads": 1,
+                    "id": 128985675,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-02",
+                    "downloads": 1,
+                    "id": 77054560,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-03",
+                    "downloads": 1,
+                    "id": 77291437,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-05",
+                    "downloads": 1,
+                    "id": 78637102,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-14",
+                    "downloads": 2,
+                    "id": 82918836,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-20",
+                    "downloads": 1,
+                    "id": 86305758,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-21",
+                    "downloads": 1,
+                    "id": 86746238,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-22",
+                    "downloads": 3,
+                    "id": 87585489,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-24",
+                    "downloads": 1,
+                    "id": 88334982,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-28",
+                    "downloads": 1,
+                    "id": 90548601,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-10",
+                    "downloads": 1,
+                    "id": 96689421,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-13",
+                    "downloads": 2,
+                    "id": 98323485,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-14",
+                    "downloads": 2,
+                    "id": 99712307,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-21",
+                    "downloads": 3,
+                    "id": 104389898,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-22",
+                    "downloads": 1,
+                    "id": 105416107,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-23",
+                    "downloads": 1,
+                    "id": 105856002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-24",
+                    "downloads": 2,
+                    "id": 106740518,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-26",
+                    "downloads": 9,
+                    "id": 108792009,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-27",
+                    "downloads": 2,
+                    "id": 109442750,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-03",
+                    "downloads": 5,
+                    "id": 113262838,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-06",
+                    "downloads": 1,
+                    "id": 114917921,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-07",
+                    "downloads": 2,
+                    "id": 115286362,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-13",
+                    "downloads": 2,
+                    "id": 119207418,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-16",
+                    "downloads": 1,
+                    "id": 121435888,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-18",
+                    "downloads": 5,
+                    "id": 122311002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-22",
+                    "downloads": 4,
+                    "id": 125076744,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-28",
+                    "downloads": 1,
+                    "id": 128985675,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-02",
+                    "downloads": 1,
+                    "id": 77054560,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-03",
+                    "downloads": 1,
+                    "id": 77291437,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-05",
+                    "downloads": 1,
+                    "id": 78637102,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-14",
+                    "downloads": 2,
+                    "id": 82918836,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-20",
+                    "downloads": 1,
+                    "id": 86305758,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-21",
+                    "downloads": 1,
+                    "id": 86746238,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-22",
+                    "downloads": 3,
+                    "id": 87585489,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-24",
+                    "downloads": 1,
+                    "id": 88334982,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-28",
+                    "downloads": 1,
+                    "id": 90548601,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-10",
+                    "downloads": 1,
+                    "id": 96689421,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-13",
+                    "downloads": 2,
+                    "id": 98323485,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-14",
+                    "downloads": 2,
+                    "id": 99712307,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-21",
+                    "downloads": 3,
+                    "id": 104389898,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-22",
+                    "downloads": 1,
+                    "id": 105416107,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-23",
+                    "downloads": 1,
+                    "id": 105856002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-24",
+                    "downloads": 2,
+                    "id": 106740518,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-26",
+                    "downloads": 9,
+                    "id": 108792009,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-27",
+                    "downloads": 2,
+                    "id": 109442750,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-03",
+                    "downloads": 5,
+                    "id": 113262838,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-06",
+                    "downloads": 1,
+                    "id": 114917921,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-07",
+                    "downloads": 2,
+                    "id": 115286362,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-13",
+                    "downloads": 2,
+                    "id": 119207418,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-16",
+                    "downloads": 1,
+                    "id": 121435888,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-18",
+                    "downloads": 5,
+                    "id": 122311002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-22",
+                    "downloads": 4,
+                    "id": 125076744,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-28",
+                    "downloads": 1,
+                    "id": 128985675,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-02",
+                    "downloads": 1,
+                    "id": 77054560,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-03",
+                    "downloads": 1,
+                    "id": 77291437,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-05",
+                    "downloads": 1,
+                    "id": 78637102,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-14",
+                    "downloads": 2,
+                    "id": 82918836,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-20",
+                    "downloads": 1,
+                    "id": 86305758,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-21",
+                    "downloads": 1,
+                    "id": 86746238,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-22",
+                    "downloads": 3,
+                    "id": 87585489,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-24",
+                    "downloads": 1,
+                    "id": 88334982,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-28",
+                    "downloads": 1,
+                    "id": 90548601,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-10",
+                    "downloads": 1,
+                    "id": 96689421,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-13",
+                    "downloads": 2,
+                    "id": 98323485,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-14",
+                    "downloads": 2,
+                    "id": 99712307,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-21",
+                    "downloads": 3,
+                    "id": 104389898,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-22",
+                    "downloads": 1,
+                    "id": 105416107,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-23",
+                    "downloads": 1,
+                    "id": 105856002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-24",
+                    "downloads": 2,
+                    "id": 106740518,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-26",
+                    "downloads": 9,
+                    "id": 108792009,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-27",
+                    "downloads": 2,
+                    "id": 109442750,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-03",
+                    "downloads": 5,
+                    "id": 113262838,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-06",
+                    "downloads": 1,
+                    "id": 114917921,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-07",
+                    "downloads": 2,
+                    "id": 115286362,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-13",
+                    "downloads": 2,
+                    "id": 119207418,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-16",
+                    "downloads": 1,
+                    "id": 121435888,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-18",
+                    "downloads": 5,
+                    "id": 122311002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-22",
+                    "downloads": 4,
+                    "id": 125076744,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-28",
+                    "downloads": 1,
+                    "id": 128985675,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-02",
+                    "downloads": 1,
+                    "id": 77054560,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-03",
+                    "downloads": 1,
+                    "id": 77291437,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-05",
+                    "downloads": 1,
+                    "id": 78637102,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-14",
+                    "downloads": 2,
+                    "id": 82918836,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-20",
+                    "downloads": 1,
+                    "id": 86305758,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-21",
+                    "downloads": 1,
+                    "id": 86746238,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-22",
+                    "downloads": 3,
+                    "id": 87585489,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-24",
+                    "downloads": 1,
+                    "id": 88334982,
+                    "version": 259
+                },
+                {
+                    "date": "2017-09-28",
+                    "downloads": 1,
+                    "id": 90548601,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-10",
+                    "downloads": 1,
+                    "id": 96689421,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-13",
+                    "downloads": 2,
+                    "id": 98323485,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-14",
+                    "downloads": 2,
+                    "id": 99712307,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-21",
+                    "downloads": 3,
+                    "id": 104389898,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-22",
+                    "downloads": 1,
+                    "id": 105416107,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-23",
+                    "downloads": 1,
+                    "id": 105856002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-24",
+                    "downloads": 2,
+                    "id": 106740518,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-26",
+                    "downloads": 9,
+                    "id": 108792009,
+                    "version": 259
+                },
+                {
+                    "date": "2017-10-27",
+                    "downloads": 2,
+                    "id": 109442750,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-03",
+                    "downloads": 5,
+                    "id": 113262838,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-06",
+                    "downloads": 1,
+                    "id": 114917921,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-07",
+                    "downloads": 2,
+                    "id": 115286362,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-13",
+                    "downloads": 2,
+                    "id": 119207418,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-16",
+                    "downloads": 1,
+                    "id": 121435888,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-18",
+                    "downloads": 5,
+                    "id": 122311002,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-22",
+                    "downloads": 4,
+                    "id": 125076744,
+                    "version": 259
+                },
+                {
+                    "date": "2017-11-28",
+                    "downloads": 1,
+                    "id": 128985675,
+                    "version": 259
                 }
             ]
         },


### PR DESCRIPTION
This patch prevents to index fine-grained versions and downloads information, which may cause ES to fail in handling to many indexes