### PR TITLE
[ocean] Replace Jenkins mapping property for changeSet.items.comment

### DIFF
--- a/grimoire_elk/elk/jenkins.py
+++ b/grimoire_elk/elk/jenkins.py
@@ -49,8 +49,9 @@ class Mapping(BaseMapping):
             {
                 "properties": {
                     "fullDisplayName_analyzed": {
-                      "type": "text"
-                      }
+                        "type": "text",
+                        "index": true
+                    }
                }
             } """
         else:
@@ -58,9 +59,9 @@ class Mapping(BaseMapping):
             {
                 "properties": {
                     "fullDisplayName_analyzed": {
-                      "type": "string",
-                      "index": "analyzed"
-                      }
+                        "type": "string",
+                        "index": "analyzed"
+                    }
                }
             } """
 

--- a/grimoire_elk/ocean/jenkins.py
+++ b/grimoire_elk/ocean/jenkins.py
@@ -41,27 +41,29 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        mapping = '''
-         {
-            "dynamic":true,
-                "properties": {
-                    "data": {
-                        "properties": {
-                            "runs": {
-                                "dynamic":false,
-                                "properties": {}
-                            },
-                            "actions": {
-                                "dynamic":false,
-                                "properties": {}
-                            },
-                            "changeSet": {
-                                "properties": {
-                                    "items": {
-                                        "properties": {
-                                            "comment": {
-                                                "type": "text",
-                                                "index": "not_analyzed"
+        if es_major != 2:
+            mapping = '''
+             {
+                "dynamic":true,
+                    "properties": {
+                        "data": {
+                            "properties": {
+                                "runs": {
+                                    "dynamic":false,
+                                    "properties": {}
+                                },
+                                "actions": {
+                                    "dynamic":false,
+                                    "properties": {}
+                                },
+                                "changeSet": {
+                                    "properties": {
+                                        "items": {
+                                            "properties": {
+                                                "comment": {
+                                                    "type": "text",
+                                                    "index": true
+                                                }
                                             }
                                         }
                                     }
@@ -69,9 +71,40 @@ class Mapping(BaseMapping):
                             }
                         }
                     }
-                }
-        }
-        '''
+            }
+            '''
+        else:
+            mapping = '''
+                         {
+                            "dynamic":true,
+                                "properties": {
+                                    "data": {
+                                        "properties": {
+                                            "runs": {
+                                                "dynamic":false,
+                                                "properties": {}
+                                            },
+                                            "actions": {
+                                                "dynamic":false,
+                                                "properties": {}
+                                            },
+                                            "changeSet": {
+                                                "properties": {
+                                                    "items": {
+                                                        "properties": {
+                                                            "comment": {
+                                                                "type": "string",
+                                                                "index": "analyzed"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                        }
+                        '''
 
         return {"items": mapping}
 


### PR DESCRIPTION
This patch changes how the comments on changeSet items are prevented to be indexed. Thus, the old value "not_analyzed" of the mapping "index" is replaced by "false"