### PR TITLE
[ocean] Fix mappings to index Twitter data

### DIFF
--- a/grimoire_elk/ocean/twitter.py
+++ b/grimoire_elk/ocean/twitter.py
@@ -22,10 +22,67 @@
 #
 
 from .elastic import ElasticOcean
+from ..elastic_mapping import Mapping as BaseMapping
+
+
+class Mapping(BaseMapping):
+
+    @staticmethod
+    def get_elastic_mappings(es_major):
+        """Get Elasticsearch mapping.
+
+        :param es_major: major version of Elasticsearch, as string
+        :returns:        dictionary with a key, 'items', with the mapping
+        """
+
+        mapping = '''
+         {
+            "dynamic":true,
+            "properties": {
+                "user": {
+                    "dynamic":false,
+                    "properties": {
+                        "entities": {
+                            "properties": {}
+                        }
+                    }
+                },
+                "hashtags": {
+                    "dynamic":false,
+                    "properties": {
+                        "indices": {
+                            "properties": {}
+                        }
+                    }
+                },
+                "metadata": {
+                    "dynamic":false,
+                    "properties": {}
+                },
+                "entities": {
+                    "properties": {
+                        "symbols": {
+                            "properties": {}
+                        },
+                        "urls": {
+                            "properties": {}
+                        },
+                        "user_mentions": {
+                            "properties": {}
+                        }
+                    }
+                }
+            }
+        }
+        '''
+
+        return {"items": mapping}
 
 
 class TwitterOcean(ElasticOcean):
     """Twitter Ocean feeder"""
+
+    mapping = Mapping
 
     # To easy checking for this class
     is_twitter_ocean = True

--- a/utils/twitter2es.py
+++ b/utils/twitter2es.py
@@ -30,6 +30,7 @@ import os
 
 from dateutil import parser
 
+from grimoire_elk.ocean.twitter import TwitterOcean
 from grimoire_elk.elk.elastic import ElasticSearch
 
 
@@ -77,7 +78,7 @@ if __name__ == '__main__':
 
     logging.info("Importing tweets from %s to %s/%s", args.json_dir, args.elastic_url, args.index)
 
-    elastic = ElasticSearch(args.elastic_url, args.index)
+    elastic = ElasticSearch(args.elastic_url, args.index, mappings=TwitterOcean.mapping)
 
     total = 0
 


### PR DESCRIPTION
This patch reduces the number of indexes created when inserting Twitter data, thus preventing hitting the limit of total fields in index. For each Twitter items, the fields below are not indexed:
- user.entities
- hashtags.indices
- metadata
- entities.symbols
- entities.urls
- entities.user_mentions