### PR TITLE
[elastic] Delete bulk_upload_sync method

### DIFF
--- a/grimoire_elk/arthur.py
+++ b/grimoire_elk/arthur.py
@@ -555,7 +555,7 @@ def enrich_backend(url, clean, backend_name, backend_params, ocean_index=None,
             logger.info("Refreshing project field in %s", enrich_backend.elastic.index_url)
             field_id = enrich_backend.get_field_unique_id()
             eitems = refresh_projects(enrich_backend)
-            enrich_backend.elastic.bulk_upload_sync(eitems, field_id)
+            enrich_backend.elastic.bulk_upload(eitems, field_id)
         elif do_refresh_identities:
 
             filter_author = None
@@ -570,7 +570,7 @@ def enrich_backend(url, clean, backend_name, backend_params, ocean_index=None,
 
             field_id = enrich_backend.get_field_unique_id()
             eitems = refresh_identities(enrich_backend, filter_author)
-            enrich_backend.elastic.bulk_upload_sync(eitems, field_id)
+            enrich_backend.elastic.bulk_upload(eitems, field_id)
         else:
             clean = False  # Don't remove ocean index when enrich
             elastic_ocean = get_elastic(url, ocean_index, clean, ocean_backend)

--- a/grimoire_elk/elk/mbox_study_kip.py
+++ b/grimoire_elk/elk/mbox_study_kip.py
@@ -439,12 +439,12 @@ def kafka_kip(enrich):
 
     # First iteration with the basic fields
     eitems = add_kip_fields(enrich)
-    enrich.elastic.bulk_upload_sync(eitems, enrich.get_field_unique_id())
+    enrich.elastic.bulk_upload(eitems, enrich.get_field_unique_id())
 
     # Second iteration with the final time and status fields
     eitems = add_kip_time_status_fields(enrich)
-    enrich.elastic.bulk_upload_sync(eitems, enrich.get_field_unique_id())
+    enrich.elastic.bulk_upload(eitems, enrich.get_field_unique_id())
 
     # Third iteration to compute the end status field for all KIPs
     eitems = add_kip_final_status_field(enrich)
-    enrich.elastic.bulk_upload_sync(eitems, enrich.get_field_unique_id())
+    enrich.elastic.bulk_upload(eitems, enrich.get_field_unique_id())

--- a/grimoire_elk/ocean/elastic.py
+++ b/grimoire_elk/ocean/elastic.py
@@ -246,7 +246,7 @@ class ElasticOcean(ElasticItems):
 
         field_id = self.get_field_unique_id()
 
-        inserted = self.elastic.bulk_upload_sync(json_items, field_id)
+        inserted = self.elastic.bulk_upload(json_items, field_id)
 
         if len(json_items) != inserted:
             missing = len(json_items) - inserted

--- a/utils/index_mapping.py
+++ b/utils/index_mapping.py
@@ -341,10 +341,10 @@ def export_items(elastic_url, in_index, out_index, elastic_url_out=None,
     uid_field = find_uuid(elastic_url, in_index)
     backend = find_perceval_backend(elastic_url, in_index)
     if search_after:
-        total = elastic_out.bulk_upload_sync(fetch(elastic_in, backend, limit,
-                                                   search_after_value, scroll=False), uid_field)
+        total = elastic_out.bulk_upload(fetch(elastic_in, backend, limit,
+                                              search_after_value, scroll=False), uid_field)
     else:
-        total = elastic_out.bulk_upload_sync(fetch(elastic_in, backend, limit), uid_field)
+        total = elastic_out.bulk_upload(fetch(elastic_in, backend, limit), uid_field)
 
     logging.info("Total items copied: %i", total)
 


### PR DESCRIPTION
This code removes the bulk_upload_sync method and replaces its calls with the ones of bulk_upload method, which now takes care of controlling that the changes made are visible to search (by adding the param ?refresh=true to the request).