### PR TITLE
[git] Add a new time_to_commit field to enriched index.

### DIFF
--- a/grimoire_elk/elk/git.py
+++ b/grimoire_elk/elk/git.py
@@ -343,6 +343,8 @@ class GitEnrich(Enrich):
         eitem["utc_author"] = (author_date - author_date.utcoffset()).replace(tzinfo=None).isoformat()
         eitem["utc_commit"] = (commit_date - commit_date.utcoffset()).replace(tzinfo=None).isoformat()
         eitem["tz"] = int(author_date.strftime("%z")[0:3])
+        # Compute time to commit
+        eitem["time_to_commit"] = (eitem["utc_commit"] - eitem["utc_author"]).hours()
         # Other enrichment
         eitem["repo_name"] = item["origin"]
         # Number of files touched


### PR DESCRIPTION
Time to commit can be computed as commit date minus author time. This patch does that, creating a new field in the enriched index.

Uploading this on behalf of @BenLloydPearson.

This should close #235 

We're uploading this without proper testing. Please, have a detailed look before accepting.