### PR TITLE
[ocean] Add ES 2.x mappings for ocean backends

### DIFF
--- a/grimoire_elk/ocean/bugzillarest.py
+++ b/grimoire_elk/ocean/bugzillarest.py
@@ -39,46 +39,88 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        mapping = '''
-         {
-            "dynamic":true,
-                "properties": {
-                    "data": {
-                        "properties": {
-                            "comments": {
-                                "dynamic":false,
-                                "properties": {
-                                    "raw_text": {
-                                        "type": "text",
-                                        "index": false
-                                    },
-                                    "text": {
-                                        "type": "text",
-                                        "index": false
+        if es_major != '2':
+            mapping = '''
+                     {
+                        "dynamic":true,
+                            "properties": {
+                                "data": {
+                                    "properties": {
+                                        "comments": {
+                                            "dynamic":false,
+                                            "properties": {
+                                                "raw_text": {
+                                                    "type": "text",
+                                                    "index": true
+                                                },
+                                                "text": {
+                                                    "type": "text",
+                                                    "index": true
+                                                }
+                                            }
+                                        },
+                                        "attachments": {
+                                            "properties": {
+                                                "description" : {
+                                                    "type": "text",
+                                                    "index": true
+                                                },
+                                                "summary" : {
+                                                    "type": "text",
+                                                    "index": true
+                                                }
+                                            }
+                                        },
+                                        "summary": {
+                                            "type": "text",
+                                            "index": true
+                                        }
                                     }
                                 }
-                            },
-                            "attachments": {
-                                "properties": {
-                                    "description" : {
-                                        "type": "text",
-                                        "index": false
-                                    },
-                                    "summary" : {
-                                        "type": "text",
-                                        "index": false
+                            }
+                    }
+                    '''
+        else:
+            mapping = '''
+             {
+                "dynamic":true,
+                    "properties": {
+                        "data": {
+                            "properties": {
+                                "comments": {
+                                    "dynamic":false,
+                                    "properties": {
+                                        "raw_text": {
+                                            "type": "string",
+                                            "index": "analyzed"
+                                        },
+                                        "text": {
+                                            "type": "string",
+                                            "index": "analyzed"
+                                        }
                                     }
+                                },
+                                "attachments": {
+                                    "properties": {
+                                        "description" : {
+                                            "type": "string",
+                                            "index": "analyzed"
+                                        },
+                                        "summary" : {
+                                            "type": "string",
+                                            "index": "analyzed"
+                                        }
+                                    }
+                                },
+                                "summary": {
+                                    "type": "string",
+                                    "index": "analyzed"
                                 }
-                            },
-                            "summary": {
-                                "type": "text",
-                                "index": false
                             }
                         }
                     }
-                }
-        }
-        '''
+            }
+            '''
 
         return {"items": mapping}
 

--- a/grimoire_elk/ocean/discourse.py
+++ b/grimoire_elk/ocean/discourse.py
@@ -37,46 +37,88 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        mapping = '''
-         {
-            "dynamic":true,
-                "properties": {
-                    "data": {
-                        "properties": {
-                            "details": {
-                                "properties": {
-                                    "suggested_topics": {
-                                        "dynamic": false,
-                                        "properties": {
-                                            "slug": {
-                                                "type": "text",
-                                                "index": false
-                                            },
-                                            "title": {
-                                                "type": "text",
-                                                "index": false
+        if es_major != '2':
+            mapping = '''
+                     {
+                        "dynamic":true,
+                            "properties": {
+                                "data": {
+                                    "properties": {
+                                        "details": {
+                                            "properties": {
+                                                "suggested_topics": {
+                                                    "dynamic": false,
+                                                    "properties": {
+                                                        "slug": {
+                                                            "type": "text",
+                                                            "index": true
+                                                        },
+                                                        "title": {
+                                                            "type": "text",
+                                                            "index": true
+                                                        }
+                                                    }
+                                                }
                                             }
+                                        },
+                                        "fancy_title": {
+                                            "type": "text",
+                                            "index": true
+                                        },
+                                        "slug": {
+                                            "type": "text",
+                                            "index": true
+                                        },
+                                        "title": {
+                                            "type": "text",
+                                            "index": true
                                         }
                                     }
                                 }
-                            },
-                            "fancy_title": {
-                                "type": "text",
-                                "index": false
-                            },
-                            "slug": {
-                                "type": "text",
-                                "index": false
-                            },
-                            "title": {
-                                "type": "text",
-                                "index": false
+                            }
+                    }
+                    '''
+        else:
+            mapping = '''
+             {
+                "dynamic":true,
+                    "properties": {
+                        "data": {
+                            "properties": {
+                                "details": {
+                                    "properties": {
+                                        "suggested_topics": {
+                                            "dynamic": false,
+                                            "properties": {
+                                                "slug": {
+                                                    "type": "string",
+                                                    "index": "analyzed"
+                                                },
+                                                "title": {
+                                                    "type": "string",
+                                                    "index": "analyzed"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "fancy_title": {
+                                    "type": "string",
+                                    "index": "analyzed"
+                                },
+                                "slug": {
+                                    "type": "string",
+                                    "index": "analyzed"
+                                },
+                                "title": {
+                                    "type": "string",
+                                    "index": "analyzed"
+                                }
                             }
                         }
                     }
-                }
-        }
-        '''
+            }
+            '''
 
         return {"items": mapping}
 
@@ -84,4 +126,4 @@ class Mapping(BaseMapping):
 class DiscourseOcean(ElasticOcean):
     """Discourse Ocean feeder"""
 
-    # mapping = Mapping
+    mapping = Mapping

--- a/grimoire_elk/ocean/gerrit.py
+++ b/grimoire_elk/ocean/gerrit.py
@@ -39,22 +39,22 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major == '2':
-            # Keep compatibility with 2.x mappings
+        if es_major != '2':
             mapping = '''
-             {
-                "dynamic":true,
-                "properties": {
-                    "data": {
+                     {
+                        "dynamic":true,
                         "properties": {
-                            "commitMessage": {
-                                "type": "string"
+                            "data": {
+                                "properties": {
+                                    "commitMessage": {
+                                        "type": "text"
+                                    }
+                                }
                             }
                         }
                     }
-                }
-            }
-            '''
+                    '''
+
         else:
             mapping = '''
              {
@@ -63,7 +63,7 @@ class Mapping(BaseMapping):
                     "data": {
                         "properties": {
                             "commitMessage": {
-                                "type": "text"
+                                "type": "string"
                             }
                         }
                     }

--- a/grimoire_elk/ocean/git.py
+++ b/grimoire_elk/ocean/git.py
@@ -39,23 +39,7 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major == '2':
-            mapping = '''
-                     {
-                        "dynamic":true,
-                        "properties": {
-                            "data": {
-                                "properties": {
-                                    "message": {
-                                        "type": "string",
-                                        "index": "analyzed"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    '''
-        else:
+        if es_major != '2':
             mapping = '''
              {
                 "dynamic":true,
@@ -65,6 +49,22 @@ class Mapping(BaseMapping):
                             "message": {
                                 "type": "text",
                                 "index": true
+                            }
+                        }
+                    }
+                }
+            }
+            '''
+        else:
+            mapping = '''
+             {
+                "dynamic":true,
+                "properties": {
+                    "data": {
+                        "properties": {
+                            "message": {
+                                "type": "string",
+                                "index": "analyzed"
                             }
                         }
                     }

--- a/grimoire_elk/ocean/github.py
+++ b/grimoire_elk/ocean/github.py
@@ -37,30 +37,56 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        mapping = '''
-         {
-            "dynamic":true,
-                "properties": {
-                    "data": {
-                        "properties": {
-                            "comments_data": {
-                                "dynamic":false,
-                                "properties": {
-                                    "body": {
-                                        "type": "text",
-                                        "index": false
+        if es_major != '2':
+            mapping = '''
+                     {
+                        "dynamic":true,
+                            "properties": {
+                                "data": {
+                                    "properties": {
+                                        "comments_data": {
+                                            "dynamic":false,
+                                            "properties": {
+                                                "body": {
+                                                    "type": "text",
+                                                    "index": true
+                                                }
+                                            }
+                                        },
+                                        "body": {
+                                            "type": "text",
+                                            "index": true
+                                        }
                                     }
                                 }
-                            },
-                            "body": {
-                                "type": "text",
-                                "index": false
+                            }
+                    }
+                    '''
+        else:
+            mapping = '''
+             {
+                "dynamic":true,
+                    "properties": {
+                        "data": {
+                            "properties": {
+                                "comments_data": {
+                                    "dynamic":false,
+                                    "properties": {
+                                        "body": {
+                                            "type": "string",
+                                            "index": "analyzed"
+                                        }
+                                    }
+                                },
+                                "body": {
+                                    "type": "string",
+                                    "index": "analyzed"
+                                }
                             }
                         }
                     }
-                }
-        }
-        '''
+            }
+            '''
 
         return {"items": mapping}
 

--- a/grimoire_elk/ocean/jenkins.py
+++ b/grimoire_elk/ocean/jenkins.py
@@ -41,7 +41,7 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != 2:
+        if es_major != '2':
             mapping = '''
              {
                 "dynamic":true,
@@ -75,36 +75,36 @@ class Mapping(BaseMapping):
             '''
         else:
             mapping = '''
-                         {
-                            "dynamic":true,
-                                "properties": {
-                                    "data": {
-                                        "properties": {
-                                            "runs": {
-                                                "dynamic":false,
-                                                "properties": {}
-                                            },
-                                            "actions": {
-                                                "dynamic":false,
-                                                "properties": {}
-                                            },
-                                            "changeSet": {
-                                                "properties": {
-                                                    "items": {
-                                                        "properties": {
-                                                            "comment": {
-                                                                "type": "string",
-                                                                "index": "analyzed"
-                                                            }
-                                                        }
-                                                    }
+             {
+                "dynamic":true,
+                    "properties": {
+                        "data": {
+                            "properties": {
+                                "runs": {
+                                    "dynamic":false,
+                                    "properties": {}
+                                },
+                                "actions": {
+                                    "dynamic":false,
+                                    "properties": {}
+                                },
+                                "changeSet": {
+                                    "properties": {
+                                        "items": {
+                                            "properties": {
+                                                "comment": {
+                                                    "type": "string",
+                                                    "index": "analyzed"
                                                 }
                                             }
                                         }
                                     }
                                 }
+                            }
                         }
-                        '''
+                    }
+            }
+            '''
 
         return {"items": mapping}
 

--- a/grimoire_elk/ocean/mediawiki.py
+++ b/grimoire_elk/ocean/mediawiki.py
@@ -37,7 +37,7 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != 2:
+        if es_major != '2':
             mapping = '''
              {
                 "dynamic":true,
@@ -59,24 +59,24 @@ class Mapping(BaseMapping):
             '''
         else:
             mapping = '''
-                 {
-                    "dynamic":true,
-                        "properties": {
-                            "data": {
-                                "properties": {
-                                    "revisions": {
-                                        "properties": {
-                                            "comment": {
-                                                "type": "string",
-                                                "index": "analyzed"
-                                            }
+             {
+                "dynamic":true,
+                    "properties": {
+                        "data": {
+                            "properties": {
+                                "revisions": {
+                                    "properties": {
+                                        "comment": {
+                                            "type": "string",
+                                            "index": "analyzed"
                                         }
                                     }
                                 }
                             }
                         }
-                }
-                '''
+                    }
+            }
+            '''
 
         return {"items": mapping}
 

--- a/grimoire_elk/ocean/meetup.py
+++ b/grimoire_elk/ocean/meetup.py
@@ -37,7 +37,7 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != 2:
+        if es_major != '2':
             mapping = '''
              {
                 "dynamic":true,
@@ -67,32 +67,32 @@ class Mapping(BaseMapping):
             '''
         else:
             mapping = '''
-                     {
-                        "dynamic":true,
+             {
+                "dynamic":true,
+                    "properties": {
+                        "data": {
                             "properties": {
-                                "data": {
+                                "comments": {
                                     "properties": {
-                                        "comments": {
+                                        "comment": {
+                                            "type": "string",
+                                            "index": "analyzed"
+                                        },
+                                        "member": {
                                             "properties": {
-                                                "comment": {
+                                                "bio": {
                                                     "type": "string",
                                                     "index": "analyzed"
-                                                },
-                                                "member": {
-                                                    "properties": {
-                                                        "bio": {
-                                                            "type": "string",
-                                                            "index": "analyzed"
-                                                        }
-                                                    }
                                                 }
                                             }
                                         }
                                     }
                                 }
                             }
+                        }
                     }
-                    '''
+            }
+            '''
 
         return {"items": mapping}
 

--- a/grimoire_elk/ocean/mozillaclub.py
+++ b/grimoire_elk/ocean/mozillaclub.py
@@ -35,7 +35,7 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != 2:
+        if es_major != '2':
             mapping = '''
              {
                 "dynamic":true,

--- a/grimoire_elk/ocean/nntp.py
+++ b/grimoire_elk/ocean/nntp.py
@@ -37,7 +37,7 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != 2:
+        if es_major != '2':
             mapping = '''
              {
                 "dynamic":true,
@@ -66,7 +66,7 @@ class Mapping(BaseMapping):
                             "properties": {
                                 "Subject": {
                                     "type": "string",
-                                    "index": "analyzed
+                                    "index": "analyzed"
                                 },
                                 "body": {
                                     "dynamic":false,

--- a/grimoire_elk/ocean/redmine.py
+++ b/grimoire_elk/ocean/redmine.py
@@ -40,8 +40,7 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != 2:
-            mapping = '''
+        mapping = '''
              {
                 "dynamic":true,
                     "properties": {
@@ -56,22 +55,6 @@ class Mapping(BaseMapping):
                     }
             }
             '''
-        else:
-            mapping = '''
-                 {
-                    "dynamic":true,
-                        "properties": {
-                            "data": {
-                                "properties": {
-                                    "journals": {
-                                        "dynamic":false,
-                                        "properties": {}
-                                    }
-                                }
-                            }
-                        }
-                }
-                '''
 
         return {"items": mapping}
 

--- a/grimoire_elk/ocean/remo.py
+++ b/grimoire_elk/ocean/remo.py
@@ -39,21 +39,38 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        mapping = '''
-         {
-            "dynamic":true,
-                "properties": {
-                    "data": {
-                        "properties": {
-                            "description": {
-                                "type": "text",
-                                "index": false
+        if es_major != '2':
+            mapping = '''
+                     {
+                        "dynamic":true,
+                            "properties": {
+                                "data": {
+                                    "properties": {
+                                        "description": {
+                                            "type": "text",
+                                            "index": true
+                                        }
+                                    }
+                                }
+                            }
+                    }
+                    '''
+        else:
+            mapping = '''
+             {
+                "dynamic":true,
+                    "properties": {
+                        "data": {
+                            "properties": {
+                                "description": {
+                                    "type": "string",
+                                    "index": "analyzed"
+                                }
                             }
                         }
                     }
-                }
-        }
-        '''
+            }
+            '''
 
         return {"items": mapping}
 

--- a/grimoire_elk/ocean/rss.py
+++ b/grimoire_elk/ocean/rss.py
@@ -37,7 +37,7 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != 2:
+        if es_major != '2':
             mapping = '''
              {
                 "dynamic":true,

--- a/grimoire_elk/ocean/stackexchange.py
+++ b/grimoire_elk/ocean/stackexchange.py
@@ -37,29 +37,54 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        mapping = '''
-         {
-            "dynamic":true,
-                "properties": {
-                    "data": {
-                        "properties": {
-                            "body_markdown": {
-                                "type": "text",
-                                "index": false
-                            },
-                            "answers": {
-                                "properties": {
-                                    "body_markdown": {
-                                        "type": "text",
-                                        "index": false
+        if es_major != '2':
+            mapping = '''
+                     {
+                        "dynamic":true,
+                            "properties": {
+                                "data": {
+                                    "properties": {
+                                        "body_markdown": {
+                                            "type": "text",
+                                            "index": true
+                                        },
+                                        "answers": {
+                                            "properties": {
+                                                "body_markdown": {
+                                                    "type": "text",
+                                                    "index": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                    }
+                    '''
+        else:
+            mapping = '''
+             {
+                "dynamic":true,
+                    "properties": {
+                        "data": {
+                            "properties": {
+                                "body_markdown": {
+                                    "type": "string",
+                                    "index": "analyzed"
+                                },
+                                "answers": {
+                                    "properties": {
+                                        "body_markdown": {
+                                            "type": "string",
+                                            "index": "analyzed"
+                                        }
                                     }
                                 }
                             }
                         }
                     }
-                }
-        }
-        '''
+            }
+            '''
 
         return {"items": mapping}
 


### PR DESCRIPTION
This patch includes ElasticSearch 2.x mappings for several ocean backends. In some cases, the patch also modifies the if condition used to detect the ElasticSearch version  