### PR TITLE
[ocean] Prevent Slack attachment info to be indexed

### DIFF
--- a/grimoire_elk/ocean/slack.py
+++ b/grimoire_elk/ocean/slack.py
@@ -24,9 +24,42 @@
 #
 
 from .elastic import ElasticOcean
+from ..elastic_mapping import Mapping as BaseMapping
+
+
+class Mapping(BaseMapping):
+
+    @staticmethod
+    def get_elastic_mappings(es_major):
+        """Get Elasticsearch mapping.
+
+        Non dynamic discovery of type for:
+            * data.attachments.ts
+
+        :param es_major: major version of Elasticsearch, as string
+        :returns:        dictionary with a key, 'items', with the mapping
+        """
+
+        mapping = '''
+             {
+                "dynamic":true,
+                    "properties": {
+                        "data": {
+                            "properties": {
+                                "attachments": {
+                                    "dynamic":false,
+                                    "properties": {}
+                                }
+                            }
+                        }
+                    }
+            }
+            '''
+
+        return {"items": mapping}
 
 
 class SlackOcean(ElasticOcean):
     """Slack Ocean feeder"""
 
-    pass
+    mapping = Mapping


### PR DESCRIPTION
This patch avoids to define dynamic mappings for attachment data. Thus it prevents number format exceptions related to the field data.attachments.ts (which is not recognized as number)