### PR TITLE
[ocean/elk] Limit content size of keyword fields

### DIFF
--- a/grimoire_elk/elk/bugzilla.py
+++ b/grimoire_elk/elk/bugzilla.py
@@ -182,7 +182,7 @@ class BugzillaEnrich(Enrich):
         eitem["status"] = issue['bug_status'][0]['__text__']
         if "short_desc" in issue:
             if "__text__" in issue["short_desc"][0]:
-                eitem["main_description"] = issue['short_desc'][0]['__text__']
+                eitem["main_description"] = issue['short_desc'][0]['__text__'][:self.KEYWORD_MAX_SIZE]
         if "summary" in issue:
             if "__text__" in issue["summary"][0]:
                 eitem["summary"] = issue['summary'][0]['__text__']

--- a/grimoire_elk/elk/dockerhub.py
+++ b/grimoire_elk/elk/dockerhub.py
@@ -45,40 +45,42 @@ class Mapping(BaseMapping):
 
         if es_major != '2':
             mapping = """
-                    {
-                        "properties": {
-                            "description": {
-                                "type": "text",
-                                "index": true
-                            },
-                            "description_analyzed": {
-                                "type": "text",
-                                "index": true
-                            },
-                            "full_description_analyzed": {
-                                "type": "text",
-                                "index": true
-                            }
-                       }
-                    } """
+            {
+                "properties": {
+                    "description": {
+                        "type": "text",
+                        "index": true
+                    },
+                    "description_analyzed": {
+                        "type": "text",
+                        "index": true
+                    },
+                    "full_description_analyzed": {
+                        "type": "text",
+                        "index": true
+                    }
+               }
+            }
+            """
         else:
             mapping = """
-                    {
-                        "properties": {
-                            "description": {
-                                "type": "string",
-                                "index": "analyzed"
-                            },
-                            "description_analyzed": {
-                                "type": "string",
-                                "index": "analyzed"
-                            },
-                            "full_description_analyzed": {
-                                "type": "string",
-                                "index": "analyzed"
-                            }
-                       }
-                    } """
+            {
+                "properties": {
+                    "description": {
+                        "type": "string",
+                        "index": "analyzed"
+                    },
+                    "description_analyzed": {
+                        "type": "string",
+                        "index": "analyzed"
+                    },
+                    "full_description_analyzed": {
+                        "type": "string",
+                        "index": "analyzed"
+                    }
+               }
+            }
+            """
 
         return {"items": mapping}
 

--- a/grimoire_elk/elk/enrich.py
+++ b/grimoire_elk/elk/enrich.py
@@ -92,6 +92,7 @@ class Enrich(ElasticItems):
     kibiter_version = None
     RAW_FIELDS_COPY = ["metadata__updated_on", "metadata__timestamp",
                        "offset", "origin", "tag", "uuid"]
+    KEYWORD_MAX_SIZE = 32000  # this control allows to avoid max_bytes_length_exceeded_exception
 
     def __init__(self, db_sortinghat=None, db_projects_map=None, json_projects_map=None,
                  db_user='', db_password='', db_host='', insecure=True):

--- a/grimoire_elk/elk/gerrit.py
+++ b/grimoire_elk/elk/gerrit.py
@@ -199,6 +199,7 @@ class GerritEnrich(Enrich):
         for fn in map_fields:
             eitem[map_fields[fn]] = review[fn]
         eitem["summary_analyzed"] = eitem["summary"]
+        eitem["summary"] = eitem["summary"][:self.KEYWORD_MAX_SIZE]
         eitem["name"] = None
         eitem["domain"] = None
         if 'name' in review['owner']:
@@ -208,6 +209,11 @@ class GerritEnrich(Enrich):
                     eitem["domain"] = review['owner']['email'].split("@")[1]
         # New fields generated for enrichment
         eitem["patchsets"] = len(review["patchSets"])
+
+        # Limit the size of comment messages
+        if review['comments']:
+            for comment in review['comments']:
+                comment['message'] = comment['message'][:self.KEYWORD_MAX_SIZE]
 
         # Time to add the time diffs
         createdOn_date = parser.parse(review['createdOn'])

--- a/grimoire_elk/elk/git.py
+++ b/grimoire_elk/elk/git.py
@@ -334,6 +334,7 @@ class GitEnrich(Enrich):
                 eitem[map_fields[fn]] = commit[fn]
             else:
                 eitem[map_fields[fn]] = None
+        eitem['message'] = commit['message'][:self.KEYWORD_MAX_SIZE]
         eitem['hash_short'] = eitem['hash'][0:6]
         # Enrich dates
         author_date = parser.parse(commit["AuthorDate"])

--- a/grimoire_elk/elk/mediawiki.py
+++ b/grimoire_elk/elk/mediawiki.py
@@ -44,7 +44,7 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != 2:
+        if es_major != "2":
             mapping = """
             {
                 "properties": {
@@ -158,6 +158,9 @@ class MediaWikiEnrich(Enrich):
                     erevision["revision_" + f] = rev[f]
                 else:
                     erevision["revision_" + f] = None
+
+            erevision["revision_comment"] = rev["comment"][:self.KEYWORD_MAX_SIZE]
+
             if self.sortinghat:
                 erevision.update(self.get_review_sh(rev, item))
 
@@ -170,6 +173,7 @@ class MediaWikiEnrich(Enrich):
             erevision["iscreated"] = 0
             erevision["creation_date"] = None
             erevision["isrevision"] = 0
+
             if rev['parentid'] == 0:
                 erevision["iscreated"] = 1
                 erevision["creation_date"] = rev['timestamp']

--- a/grimoire_elk/elk/mozillaclub.py
+++ b/grimoire_elk/elk/mozillaclub.py
@@ -42,23 +42,23 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != 2:
+        if es_major != "2":
             mapping = """
             {
                 "properties": {
-                    "Event Description": {
+                    "Event_Description": {
                         "type": "text",
                         "index": true
                     },
-                    "Event Creations": {
+                    "Event_Creations": {
                         "type": "text",
                         "index": true
                     },
-                    "Feedback from Attendees": {
+                    "Feedback_from_Attendees": {
                         "type": "text",
                         "index": true
                     },
-                    "Your Feedback": {
+                    "Your_Feedback": {
                         "type": "text",
                         "index": true
                     },
@@ -71,19 +71,19 @@ class Mapping(BaseMapping):
             mapping = """
             {
                 "properties": {
-                    "Event Description": {
+                    "Event_Description": {
                         "type": "string",
                         "index": "analyzed"
                     },
-                    "Event Creations": {
+                    "Event_Creations": {
                         "type": "string",
                         "index": "analyzed"
                     },
-                    "Feedback from Attendees": {
+                    "Feedback_from_Attendees": {
                         "type": "string",
                         "index": "analyzed"
                     },
-                    "Your Feedback": {
+                    "Your_Feedback": {
                         "type": "string",
                         "index": "analyzed"
                     },

--- a/grimoire_elk/elk/redmine.py
+++ b/grimoire_elk/elk/redmine.py
@@ -47,7 +47,7 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != 2:
+        if es_major != "2":
             mapping = """
             {
                 "properties": {
@@ -130,7 +130,9 @@ class RedmineEnrich(Enrich):
                 eitem[f] = ticket[f]
             else:
                 eitem[f] = None
+        eitem['subject'] = eitem['subject'][:self.KEYWORD_MAX_SIZE]
         eitem['description_analyzed'] = eitem['description']
+        eitem['description'] = eitem['description'][:self.KEYWORD_MAX_SIZE]
         # Fields which names are translated
         map_fields = {"due_date": "estimated_closing_date",
                       "created_on": "creation_date",

--- a/grimoire_elk/ocean/bugzilla.py
+++ b/grimoire_elk/ocean/bugzilla.py
@@ -39,21 +39,56 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        mapping = '''
-         {
-            "dynamic":true,
-                "properties": {
-                    "data": {
-                        "properties": {
-                            "long_desc": {
-                                "dynamic":false,
-                                "properties": {}
+        if es_major != '2':
+            mapping = '''
+             {
+                "dynamic":true,
+                    "properties": {
+                        "data": {
+                            "properties": {
+                                "long_desc": {
+                                    "dynamic": false,
+                                    "properties": {}
+                                },
+                                "short_desc": {
+                                    "dynamic": false,
+                                    "properties": {
+                                        "__text__": {
+                                            "type": "text",
+                                            "index": true
+                                        }
+                                    }
+                                }
                             }
                         }
                     }
-                }
-        }
-        '''
+            }
+            '''
+        else:
+            mapping = '''
+             {
+                "dynamic":true,
+                    "properties": {
+                        "data": {
+                            "properties": {
+                                "long_desc": {
+                                    "dynamic": false,
+                                    "properties": {}
+                                },
+                                "short_desc": {
+                                    "dynamic": false,
+                                    "properties": {
+                                        "__text__": {
+                                            "type": "string",
+                                            "index": "analyzed"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+            }
+            '''
 
         return {"items": mapping}
 

--- a/grimoire_elk/ocean/gerrit.py
+++ b/grimoire_elk/ocean/gerrit.py
@@ -48,6 +48,30 @@ class Mapping(BaseMapping):
                         "properties": {
                             "commitMessage": {
                                 "type": "text"
+                            },
+                            "comments": {
+                                "properties": {
+                                    "message": {
+                                        "type": "text",
+                                        "index": true
+                                    }
+                                }
+                            },
+                            "subject": {
+                                "type": "text",
+                                "index": true
+                            },
+                            "patchSets": {
+                                "properties": {
+                                    "approvals": {
+                                        "properties": {
+                                            "description": {
+                                                "type": "text",
+                                                "index": true
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                     }
@@ -64,6 +88,31 @@ class Mapping(BaseMapping):
                         "properties": {
                             "commitMessage": {
                                 "type": "string"
+                            },
+                            "comments": {
+                                "properties": {
+                                    "message": {
+                                        "type": "string",
+                                        "index": "anaylzed"
+                                    }
+                                }
+                            },
+                            "subject": {
+                                "type": "string",
+                                "index": "anaylzed"
+                            },
+                            ,
+                            "patchSets": {
+                                "properties": {
+                                    "approvals": {
+                                        "properties": {
+                                            "description": {
+                                                "type": "string",
+                                                "index": "anaylzed"
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                     }

--- a/grimoire_elk/ocean/mediawiki.py
+++ b/grimoire_elk/ocean/mediawiki.py
@@ -84,4 +84,4 @@ class Mapping(BaseMapping):
 class MediaWikiOcean(ElasticOcean):
     """MediaWiki Ocean feeder"""
 
-    # mapping = Mapping
+    mapping = Mapping

--- a/grimoire_elk/ocean/redmine.py
+++ b/grimoire_elk/ocean/redmine.py
@@ -40,21 +40,54 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        mapping = '''
-         {
-            "dynamic":true,
-                "properties": {
-                    "data": {
-                        "properties": {
-                            "journals": {
-                                "dynamic":false,
-                                "properties": {}
+        if es_major != '2':
+            mapping = '''
+             {
+                "dynamic":true,
+                    "properties": {
+                        "data": {
+                            "properties": {
+                                "journals": {
+                                    "dynamic": false,
+                                    "properties": {}
+                                },
+                                "subject": {
+                                    "type": "text",
+                                    "index": true
+                                },
+                                "description": {
+                                    "type": "text",
+                                    "index": true
+                                }
                             }
                         }
                     }
-                }
-        }
-        '''
+            }
+            '''
+        else:
+            mapping = '''
+             {
+                "dynamic":true,
+                    "properties": {
+                        "data": {
+                            "properties": {
+                                "journals": {
+                                    "dynamic": false,
+                                    "properties": {}
+                                },
+                                "subject": {
+                                    "type": "string",
+                                    "index": "analyzed"
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "index": "analyzed"
+                                }
+                            }
+                        }
+                    }
+            }
+            '''
 
         return {"items": mapping}
 


### PR DESCRIPTION
This patch limits the content size of keyword fields to 32000, thus it avoids (i) losing items in the raw and enriched indexes (ii) breaking the panel specifications