### PR TITLE
[elk] Fix check condition ES version for meetup, nntp, rss

### DIFF
--- a/grimoire_elk/elk/meetup.py
+++ b/grimoire_elk/elk/meetup.py
@@ -43,7 +43,7 @@ class Mapping(BaseMapping):
         :param es_major: major version of Elasticsearch, as string
         :returns:        dictionary with a key, 'items', with the mapping
         """
-        if es_major != 2:
+        if es_major != "2":
             mapping = """
             {
                 "properties": {

--- a/grimoire_elk/elk/nntp.py
+++ b/grimoire_elk/elk/nntp.py
@@ -38,7 +38,7 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != 2:
+        if es_major != "2":
             mapping = """
             {
                 "properties": {

--- a/grimoire_elk/elk/rss.py
+++ b/grimoire_elk/elk/rss.py
@@ -43,7 +43,7 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != 2:
+        if es_major != "2":
             mapping = """
             {
                 "properties": {


### PR DESCRIPTION
This patch fixes how the ES version is checked. The parameter of get_elastic_mappings (es_major) is checked against a string (not an integer).