### PR TITLE
[elk] Fix limit description on none values for redmine

### DIFF
--- a/grimoire_elk/elk/redmine.py
+++ b/grimoire_elk/elk/redmine.py
@@ -132,7 +132,10 @@ class RedmineEnrich(Enrich):
                 eitem[f] = None
         eitem['subject'] = eitem['subject'][:self.KEYWORD_MAX_SIZE]
         eitem['description_analyzed'] = eitem['description']
-        eitem['description'] = eitem['description'][:self.KEYWORD_MAX_SIZE]
+
+        if eitem['description']:
+            eitem['description'] = eitem['description'][:self.KEYWORD_MAX_SIZE]
+
         # Fields which names are translated
         map_fields = {"due_date": "estimated_closing_date",
                       "created_on": "creation_date",


### PR DESCRIPTION
This patch targets #257. It fixes the truncation of descriptions during the enrichment of redmine items.