### PR TITLE
[ocean] Fix mappings with jenkins to avoid regression errors

### DIFF
--- a/grimoire_elk/ocean/jenkins.py
+++ b/grimoire_elk/ocean/jenkins.py
@@ -62,7 +62,7 @@ class Mapping(BaseMapping):
                                             "properties": {
                                                 "comment": {
                                                     "type": "text",
-                                                    "index": true
+                                                    "index": false
                                                 }
                                             }
                                         }
@@ -94,7 +94,7 @@ class Mapping(BaseMapping):
                                             "properties": {
                                                 "comment": {
                                                     "type": "string",
-                                                    "index": "analyzed"
+                                                    "index": "not_analyzed"
                                                 }
                                             }
                                         }


### PR DESCRIPTION
This patch fixes the mappings for jenkins in order to avoid conflicts with the existing mapping on data.changeSet.items.comment.