### PR TITLE
[arthur] Fix params parsing for arthur tasks

### DIFF
--- a/grimoire_elk/ocean/dockerhub.py
+++ b/grimoire_elk/ocean/dockerhub.py
@@ -92,3 +92,13 @@ class DockerHubOcean(ElasticOcean):
         params = url.split()
 
         return params
+
+    @classmethod
+    def get_arthur_params_from_url(cls, url):
+        # In the url the org and the repository are included
+
+        params = url.split()
+        """ Get the arthur params given a URL for the data source """
+        params = {"owner": params[0], "repository": params[1]}
+
+        return params

--- a/grimoire_elk/ocean/elastic.py
+++ b/grimoire_elk/ocean/elastic.py
@@ -112,7 +112,7 @@ class ElasticOcean(ElasticItems):
     @classmethod
     def get_arthur_params_from_url(cls, url):
         """ Get the arthur params given a URL for the data source """
-        return {"uri": url}
+        return {"uri": url, "url": url}
 
     def drop_item(self, item):
         """ Drop items not to be inserted in Elastic """

--- a/grimoire_elk/ocean/hyperkitty.py
+++ b/grimoire_elk/ocean/hyperkitty.py
@@ -1,0 +1,70 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#
+# Hyperkitty Ocean feeder
+#
+# Copyright (C) 2015 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+#
+# Authors:
+#   Alvaro del Castillo San Felix <acs@bitergia.com>
+#
+
+import logging
+
+from .elastic import ElasticOcean
+from ..elastic_mapping import Mapping as BaseMapping
+
+
+logger = logging.getLogger(__name__)
+
+
+class Mapping(BaseMapping):
+
+    @staticmethod
+    def get_elastic_mappings(es_major):
+        """Get Elasticsearch mapping.
+
+        Non dynamic discovery of type for:
+            * data.body (inmense field)
+
+        :param es_major: major version of Elasticsearch, as string
+        :returns:        dictionary with a key, 'items', with the mapping
+        """
+
+        mapping = '''
+         {
+            "dynamic":true,
+                "properties": {
+                    "data": {
+                        "properties": {
+                            "body": {
+                                "dynamic":false,
+                                "properties": {}
+                            }
+                        }
+                    }
+                }
+        }
+        '''
+
+        return {"items": mapping}
+
+
+class HyperKittyOcean(ElasticOcean):
+    """HyperKitty Ocean feeder"""
+
+    mapping = Mapping

--- a/grimoire_elk/ocean/mbox.py
+++ b/grimoire_elk/ocean/mbox.py
@@ -75,3 +75,13 @@ class MBoxOcean(ElasticOcean):
         params = url.split()
 
         return params
+
+    @classmethod
+    def get_arthur_params_from_url(cls, url):
+        # In the url the dirpath and the repository are included
+
+        params = url.split()
+        """ Get the arthur params given a URL for the data source """
+        params = {"dirpath": params[1], "uri": params[0]}
+
+        return params

--- a/grimoire_elk/ocean/meetup.py
+++ b/grimoire_elk/ocean/meetup.py
@@ -113,3 +113,11 @@ class MeetupOcean(ElasticOcean):
         params.append(url)
 
         return params
+
+    @classmethod
+    def get_arthur_params_from_url(cls, url):
+        # The URL is directly the meetup group
+
+        params = {"group": url}
+
+        return params

--- a/grimoire_elk/ocean/nntp.py
+++ b/grimoire_elk/ocean/nntp.py
@@ -88,7 +88,17 @@ class NNTPOcean(ElasticOcean):
 
     @classmethod
     def get_perceval_params_from_url(cls, url):
-        # In the url the NNTP server and the group are included
+        # In the url the NNTP host and the group are included
         params = url.split()
+
+        return params
+
+    @classmethod
+    def get_arthur_params_from_url(cls, url):
+        # In the url the NNTP host and the group are included
+
+        params = url.split()
+        """ Get the arthur params given a URL for the data source """
+        params = {"host": params[0], "group": params[1]}
 
         return params

--- a/grimoire_elk/ocean/slack.py
+++ b/grimoire_elk/ocean/slack.py
@@ -63,3 +63,11 @@ class SlackOcean(ElasticOcean):
     """Slack Ocean feeder"""
 
     mapping = Mapping
+
+    @classmethod
+    def get_arthur_params_from_url(cls, url):
+        # The URL is directly the slack group
+
+        params = {"channel": url}
+
+        return params

--- a/grimoire_elk/ocean/stackexchange.py
+++ b/grimoire_elk/ocean/stackexchange.py
@@ -109,3 +109,15 @@ class StackExchangeOcean(ElasticOcean):
         params.append(url)
 
         return params
+
+    @classmethod
+    def get_arthur_params_from_url(cls, url):
+        params = []
+
+        tokens = url.replace('https://', '').replace('http://', '').split('/')
+        tag = tokens[-1]
+        site = tokens[0]
+
+        params = {"site": site, "tagged": tag}
+
+        return params

--- a/grimoire_elk/ocean/supybot.py
+++ b/grimoire_elk/ocean/supybot.py
@@ -35,3 +35,13 @@ class SupybotOcean(ElasticOcean):
         params = url.split()
 
         return params
+
+    @classmethod
+    def get_arthur_params_from_url(cls, url):
+        # In the url the uri and the dirpath are included
+
+        params = url.split()
+        """ Get the arthur params given a URL for the data source """
+        params = {"uri": params[0], "dirpath": params[1]}
+
+        return params

--- a/grimoire_elk/ocean/telegram.py
+++ b/grimoire_elk/ocean/telegram.py
@@ -27,4 +27,10 @@ from .elastic import ElasticOcean
 class TelegramOcean(ElasticOcean):
     """Telegram Ocean feeder"""
 
-    pass
+    @classmethod
+    def get_arthur_params_from_url(cls, url):
+        # The URL is directly the name of the bot
+
+        params = {"bot": url}
+
+        return params

--- a/grimoire_elk/utils.py
+++ b/grimoire_elk/utils.py
@@ -33,6 +33,7 @@ from dateutil import parser
 from grimoire_elk.elastic import ElasticConnectException
 from grimoire_elk.elastic import ElasticSearch
 # Connectors for Perceval
+from grimoire_elk.ocean.hyperkitty import HyperKittyOcean
 from perceval.backends.core.askbot import Askbot, AskbotCommand
 from perceval.backends.core.bugzilla import Bugzilla, BugzillaCommand
 from perceval.backends.core.bugzillarest import BugzillaREST, BugzillaRESTCommand
@@ -192,7 +193,7 @@ def get_connectors():
             "gerrit": [Gerrit, GerritOcean, GerritEnrich, GerritCommand],
             "git": [Git, GitOcean, GitEnrich, GitCommand],
             "github": [GitHub, GitHubOcean, GitHubEnrich, GitHubCommand],
-            "hyperkitty": [HyperKitty, MBoxOcean, HyperKittyEnrich, HyperKittyCommand],
+            "hyperkitty": [HyperKitty, HyperKittyOcean, HyperKittyEnrich, HyperKittyCommand],
             "jenkins": [Jenkins, JenkinsOcean, JenkinsEnrich, JenkinsCommand],
             "jira": [Jira, JiraOcean, JiraEnrich, JiraCommand],
             "kitsune": [Kitsune, KitsuneOcean, KitsuneEnrich, KitsuneCommand],

--- a/grimoire_elk/utils.py
+++ b/grimoire_elk/utils.py
@@ -132,6 +132,9 @@ kibiter_version = None
 
 
 def get_connector_from_name(name):
+
+    # Remove extra data from data source section: remo:activities
+    name = name.split(":")[0]
     found = None
     connectors = get_connectors()
 

--- a/tests/data/projects-release.json
+++ b/tests/data/projects-release.json
@@ -1,0 +1,114 @@
+{
+    "grimoire": {
+        "apache": [
+          ""
+        ],
+        "askbot": [
+          "https://ask.puppet.com"
+        ],
+        "bugzilla": [
+            "https://bugs.eclipse.org/bugs/"
+        ],
+        "bugzillarest": [
+            "https://bugzilla.mozilla.org"
+        ],
+        "confluence": [
+            "https://wiki.open-o.org/"
+        ],
+        "crates": [""],
+        "discourse": [
+            "https://foro.mozilla-hispano.org/"
+        ],
+        "dockerhub": [
+            "bitergia kibiter"
+        ],
+        "functest": [
+            "http://testresults.opnfv.org/test/"
+        ],
+        "gerrit": [
+            "review.openstack.org"
+        ],
+        "*git": [
+            "https://github.com/VizGrimoire/GrimoireLib --filters-raw-prefix data.files.file:grimoirelib_alch data.files.file:README.md",
+            "https://github.com/MetricsGrimoire/CMetrics"
+        ],
+        "git": [
+            "https://github.com/grimoirelab/perceval"
+        ],
+        "github": [
+            "https://github.com/chaoss/grimoirelab-perceval"
+        ],
+        "google_hits": [
+            ""
+        ],
+        "hyperkitty": [
+            "https://lists.mailman3.org/archives/list/mailman-users@mailman3.org"
+        ],
+        "*jenkins": [
+            "http://jenkins.cyanogenmod.com/"
+        ],
+        "jenkins": [
+            "https://build.opnfv.org/ci"
+        ],
+        "*jira": [
+            "https://tickets.puppetlabs.com"
+        ],
+        "*jira": [
+            "https://jira.iotivity.org/"
+        ],
+        "jira": [
+            "https://jira.opnfv.org"
+        ],
+        "kitsune": [""],
+        "mbox": [
+            "metrics-grimoire /home/bitergia/.perceval/mbox"
+        ],
+        "mediawiki": [
+            "https://wiki.mozilla.org"
+        ],
+        "meetup": [
+            "South-East-Puppet-User-Group"
+        ],
+        "mozillaclub": [
+            "https://spreadsheets.google.com/feeds/cells/1QHl2bjBhMslyFzR5XXPzMLdzzx7oeSKTbgR5PM8qp64/ohaibtm/public/values?alt=json"
+        ],
+        "nntp": [
+            "news.mozilla.org mozilla.dev.project-link"
+        ],
+        "phabricator": [
+            "https://phabricator.wikimedia.org"
+        ],
+        "pipermail": [
+            "https://mail.gnome.org/archives/libart-hackers/"
+        ],
+        "puppetforge": [
+            ""
+        ],
+        "redmine": [
+            "http://tracker.ceph.com/"
+        ],
+        "remo": [
+            "https://reps.mozilla.org"
+        ],
+        "rss": [
+            "https://blog.bitergia.com/feed/"
+        ],
+        "stackexchange": [
+            "https://stackoverflow.com/questions/tagged/ovirt",
+            "https://stackoverflow.com/questions/tagged/rdo",
+            "https://stackoverflow.com/questions/tagged/kibana"
+        ],
+        "slack": [
+            "C7LSGB0AU"
+        ],
+        "supybot": [
+            "openshift /home/bitergia/.perceval/irc/percevalbot/logs/ChannelLogger/freenode/#openshift/"
+        ],
+        "telegram": [
+            "Mozilla_analytics"
+        ],
+        "twitter": [
+            ""
+        ]
+    }
+}

--- a/tests/test_askbot.py
+++ b/tests/test_askbot.py
@@ -21,11 +21,12 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
-
+import json
 import logging
 import unittest
 
 from base import TestBaseBackend
+from grimoire_elk.ocean.askbot import AskbotOcean
 
 
 class TestAskbot(TestBaseBackend):
@@ -75,6 +76,15 @@ class TestAskbot(TestBaseBackend):
 
         result = self._test_refresh_project()
         # .. ?
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['askbot'][0]
+            print(AskbotOcean.get_arthur_params_from_url(url))
+            arthur_params = {'uri': 'https://ask.puppet.com', 'url': 'https://ask.puppet.com'}
+            self.assertDictEqual(arthur_params, AskbotOcean.get_arthur_params_from_url(url))
 
 
 if __name__ == "__main__":

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -21,11 +21,12 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
-
+import json
 import logging
 import unittest
 
 from base import TestBaseBackend
+from grimoire_elk.ocean.bugzilla import BugzillaOcean
 
 
 class TestBugzilla(TestBaseBackend):
@@ -75,6 +76,14 @@ class TestBugzilla(TestBaseBackend):
 
         result = self._test_refresh_project()
         # ... ?
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            bugzilla_url = json.load(projects_filename)['grimoire']['bugzilla'][0]
+            arthur_params = {'uri': 'https://bugs.eclipse.org/bugs/', 'url': 'https://bugs.eclipse.org/bugs/'}
+            self.assertDictEqual(arthur_params, BugzillaOcean.get_arthur_params_from_url(bugzilla_url))
 
 
 if __name__ == "__main__":

--- a/tests/test_bugzillarest.py
+++ b/tests/test_bugzillarest.py
@@ -27,6 +27,7 @@ import logging
 import unittest
 
 from base import TestBaseBackend
+from grimoire_elk.ocean.bugzillarest import BugzillaRESTOcean
 
 from grimoire_elk.elk.bugzillarest import BugzillaRESTEnrich
 
@@ -93,6 +94,14 @@ class TestBugzillaRest(TestBaseBackend):
         eitem = enricher.get_rich_item(rawitem)
         # Check the project
         self.assertEqual(eitem['project'], "Localization")
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['bugzillarest'][0]
+            arthur_params = {'uri': 'https://bugzilla.mozilla.org', 'url': 'https://bugzilla.mozilla.org'}
+            self.assertDictEqual(arthur_params, BugzillaRESTOcean.get_arthur_params_from_url(url))
 
 
 if __name__ == "__main__":

--- a/tests/test_confluence.py
+++ b/tests/test_confluence.py
@@ -21,11 +21,12 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
-
+import json
 import logging
 import unittest
 
 from base import TestBaseBackend
+from grimoire_elk.ocean.confluence import ConfluenceOcean
 
 
 class TestConfluence(TestBaseBackend):
@@ -75,6 +76,14 @@ class TestConfluence(TestBaseBackend):
 
         result = self._test_refresh_project()
         # ... ?
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['confluence'][0]
+            arthur_params = {'uri': 'https://wiki.open-o.org/', 'url': 'https://wiki.open-o.org/'}
+            self.assertDictEqual(arthur_params, ConfluenceOcean.get_arthur_params_from_url(url))
 
 
 if __name__ == "__main__":

--- a/tests/test_crates.py
+++ b/tests/test_crates.py
@@ -21,11 +21,12 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
-
+import json
 import logging
 import unittest
 
 from base import TestBaseBackend
+from grimoire_elk.ocean.crates import CratesOcean
 
 
 class TestCrates(TestBaseBackend):
@@ -76,6 +77,14 @@ class TestCrates(TestBaseBackend):
 
         result = self._test_refresh_project()
         # ... ?
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['crates'][0]
+            arthur_params = {'uri': '', 'url': ''}
+            self.assertDictEqual(arthur_params, CratesOcean.get_arthur_params_from_url(url))
 
 
 if __name__ == "__main__":

--- a/tests/test_discourse.py
+++ b/tests/test_discourse.py
@@ -21,11 +21,12 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
-
+import json
 import logging
 import unittest
 
 from base import TestBaseBackend
+from grimoire_elk.ocean.discourse import DiscourseOcean
 
 
 class TestDiscourse(TestBaseBackend):
@@ -74,6 +75,14 @@ class TestDiscourse(TestBaseBackend):
 
         result = self._test_refresh_project()
         # ... ?
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['discourse'][0]
+            arthur_params = {'uri': 'https://foro.mozilla-hispano.org/', 'url': 'https://foro.mozilla-hispano.org/'}
+            self.assertDictEqual(arthur_params, DiscourseOcean.get_arthur_params_from_url(url))
 
 
 if __name__ == "__main__":

--- a/tests/test_dockerhub.py
+++ b/tests/test_dockerhub.py
@@ -21,11 +21,12 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
-
+import json
 import logging
 import unittest
 
 from base import TestBaseBackend
+from grimoire_elk.ocean.dockerhub import DockerHubOcean
 
 
 class TestDockerhub(TestBaseBackend):
@@ -74,6 +75,14 @@ class TestDockerhub(TestBaseBackend):
 
         result = self._test_refresh_project()
         # ... ?
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['dockerhub'][0]
+            arthur_params = {'owner': 'bitergia', 'repository': 'kibiter'}
+            self.assertDictEqual(arthur_params, DockerHubOcean.get_arthur_params_from_url(url))
 
 
 if __name__ == "__main__":

--- a/tests/test_functest.py
+++ b/tests/test_functest.py
@@ -21,11 +21,12 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
-
+import json
 import logging
 import unittest
 
 from base import TestBaseBackend
+from grimoire_elk.ocean.functest import FunctestOcean
 
 
 class TestFunctest(TestBaseBackend):
@@ -74,6 +75,14 @@ class TestFunctest(TestBaseBackend):
 
         result = self._test_refresh_project()
         # ... ?
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['functest'][0]
+            arthur_params = {'uri': 'http://testresults.opnfv.org/test/', 'url': 'http://testresults.opnfv.org/test/'}
+            self.assertDictEqual(arthur_params, FunctestOcean.get_arthur_params_from_url(url))
 
 
 if __name__ == "__main__":

--- a/tests/test_gerrit.py
+++ b/tests/test_gerrit.py
@@ -21,11 +21,12 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
-
+import json
 import logging
 import unittest
 
 from base import TestBaseBackend
+from grimoire_elk.ocean.gerrit import GerritOcean
 
 
 class TestGerrit(TestBaseBackend):
@@ -74,6 +75,14 @@ class TestGerrit(TestBaseBackend):
 
         result = self._test_refresh_project()
         # ... ?
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['gerrit'][0]
+            arthur_params = {'uri': 'review.openstack.org', 'url': 'review.openstack.org'}
+            self.assertDictEqual(arthur_params, GerritOcean.get_arthur_params_from_url(url))
 
 
 if __name__ == "__main__":

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -21,11 +21,12 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
-
+import json
 import logging
 import unittest
 
 from base import TestBaseBackend
+from grimoire_elk.ocean.git import GitOcean
 
 
 class TestGit(TestBaseBackend):
@@ -74,6 +75,14 @@ class TestGit(TestBaseBackend):
 
         result = self._test_refresh_project()
         # ... ?
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['git'][0]
+            arthur_params = {'uri': 'https://github.com/grimoirelab/perceval', 'url': 'https://github.com/grimoirelab/perceval'}
+            self.assertDictEqual(arthur_params, GitOcean.get_arthur_params_from_url(url))
 
 
 if __name__ == "__main__":

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -21,11 +21,12 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
-
+import json
 import logging
 import unittest
 
 from base import TestBaseBackend
+from grimoire_elk.ocean.github import GitHubOcean
 
 
 class TestGit(TestBaseBackend):
@@ -76,6 +77,14 @@ class TestGit(TestBaseBackend):
 
         result = self._test_refresh_project()
         # ... ?
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['github'][0]
+            arthur_params = {'owner': 'chaoss', 'repository': 'grimoirelab-perceval'}
+            self.assertDictEqual(arthur_params, GitHubOcean.get_arthur_params_from_url(url))
 
 
 if __name__ == "__main__":

--- a/tests/test_hyperkitty.py
+++ b/tests/test_hyperkitty.py
@@ -21,11 +21,13 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
-
+import json
 import logging
 import unittest
 
 from base import TestBaseBackend
+
+from grimoire_elk.ocean.hyperkitty import HyperKittyOcean
 
 
 class TestHyperkitty(TestBaseBackend):
@@ -74,6 +76,15 @@ class TestHyperkitty(TestBaseBackend):
 
         result = self._test_refresh_project()
         # ... ?
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['hyperkitty'][0]
+            arthur_params = {'uri': 'https://lists.mailman3.org/archives/list/mailman-users@mailman3.org',
+                             'url': 'https://lists.mailman3.org/archives/list/mailman-users@mailman3.org'}
+            self.assertDictEqual(arthur_params, HyperKittyOcean.get_arthur_params_from_url(url))
 
 
 if __name__ == "__main__":

--- a/tests/test_jenkins.py
+++ b/tests/test_jenkins.py
@@ -21,11 +21,12 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
-
+import json
 import logging
 import unittest
 
 from base import TestBaseBackend
+from grimoire_elk.ocean.jenkins import JenkinsOcean
 
 
 class TestJenkins(TestBaseBackend):
@@ -74,6 +75,14 @@ class TestJenkins(TestBaseBackend):
 
         result = self._test_refresh_project()
         # ... ?
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['jenkins'][0]
+            arthur_params = {'uri': 'https://build.opnfv.org/ci', 'url': 'https://build.opnfv.org/ci'}
+            self.assertDictEqual(arthur_params, JenkinsOcean.get_arthur_params_from_url(url))
 
 
 if __name__ == "__main__":

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -21,11 +21,12 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
-
+import json
 import logging
 import unittest
 
 from base import TestBaseBackend
+from grimoire_elk.ocean.jenkins import JenkinsOcean
 
 
 class TestJira(TestBaseBackend):
@@ -74,6 +75,14 @@ class TestJira(TestBaseBackend):
 
         result = self._test_refresh_project()
         # ... ?
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['jenkins'][0]
+            arthur_params = {'uri': 'https://build.opnfv.org/ci', 'url': 'https://build.opnfv.org/ci'}
+            self.assertDictEqual(arthur_params, JenkinsOcean.get_arthur_params_from_url(url))
 
 
 if __name__ == "__main__":

--- a/tests/test_kitsune.py
+++ b/tests/test_kitsune.py
@@ -21,11 +21,12 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
-
+import json
 import logging
 import unittest
 
 from base import TestBaseBackend
+from grimoire_elk.ocean.kitsune import KitsuneOcean
 
 
 class TestKitsune(TestBaseBackend):
@@ -74,6 +75,14 @@ class TestKitsune(TestBaseBackend):
 
         result = self._test_refresh_project()
         # ... ?
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['kitsune'][0]
+            arthur_params = {'uri': '', 'url': ''}
+            self.assertDictEqual(arthur_params, KitsuneOcean.get_arthur_params_from_url(url))
 
 
 if __name__ == "__main__":

--- a/tests/test_mbox.py
+++ b/tests/test_mbox.py
@@ -21,11 +21,13 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
-
+import json
 import logging
 import unittest
 
 from base import TestBaseBackend
+from grimoire_elk.ocean.mbox import MBoxOcean
+
 from grimoire_elk.elk.mbox import MBoxEnrich
 
 
@@ -86,6 +88,14 @@ class TestMbox(TestBaseBackend):
         item = {'data': {"author": None}}
 
         self.assertDictEqual(empty_identity, enricher.get_sh_identity(item, "author"))
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['mbox'][0]
+            arthur_params = {'dirpath': '/home/bitergia/.perceval/mbox', 'uri': 'metrics-grimoire'}
+            self.assertDictEqual(arthur_params, MBoxOcean.get_arthur_params_from_url(url))
 
 
 if __name__ == "__main__":

--- a/tests/test_mediawiki.py
+++ b/tests/test_mediawiki.py
@@ -21,11 +21,12 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
-
+import json
 import logging
 import unittest
 
 from base import TestBaseBackend
+from grimoire_elk.ocean.mediawiki import MediaWikiOcean
 
 
 class TestMediawiki(TestBaseBackend):
@@ -74,6 +75,14 @@ class TestMediawiki(TestBaseBackend):
 
         result = self._test_refresh_project()
         # ... ?
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['mediawiki'][0]
+            arthur_params = {'uri': 'https://wiki.mozilla.org', 'url': 'https://wiki.mozilla.org'}
+            self.assertDictEqual(arthur_params, MediaWikiOcean.get_arthur_params_from_url(url))
 
 
 if __name__ == "__main__":

--- a/tests/test_meetup.py
+++ b/tests/test_meetup.py
@@ -21,11 +21,12 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
-
+import json
 import logging
 import unittest
 
 from base import TestBaseBackend
+from grimoire_elk.ocean.meetup import MeetupOcean
 
 
 class TestMeetup(TestBaseBackend):
@@ -74,6 +75,14 @@ class TestMeetup(TestBaseBackend):
 
         result = self._test_refresh_project()
         # ... ?
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['meetup'][0]
+            arthur_params = {'group': 'South-East-Puppet-User-Group'}
+            self.assertDictEqual(arthur_params, MeetupOcean.get_arthur_params_from_url(url))
 
 
 if __name__ == "__main__":

--- a/tests/test_mozillaclub.py
+++ b/tests/test_mozillaclub.py
@@ -21,11 +21,12 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
-
+import json
 import logging
 import unittest
 
 from base import TestBaseBackend
+from grimoire_elk.ocean.mozillaclub import MozillaClubOcean
 
 
 class TestMozillaClub(TestBaseBackend):
@@ -74,6 +75,16 @@ class TestMozillaClub(TestBaseBackend):
 
         result = self._test_refresh_project()
         # ... ?
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['mozillaclub'][0]
+            url_spread = 'https://spreadsheets.google.com/feeds/cells/'
+            url_spread += '1QHl2bjBhMslyFzR5XXPzMLdzzx7oeSKTbgR5PM8qp64/ohaibtm/public/values?alt=json'
+            arthur_params = {'uri': url_spread, 'url': url_spread}
+            self.assertDictEqual(arthur_params, MozillaClubOcean.get_arthur_params_from_url(url))
 
 
 if __name__ == "__main__":

--- a/tests/test_nntp.py
+++ b/tests/test_nntp.py
@@ -21,11 +21,12 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
-
+import json
 import logging
 import unittest
 
 from base import TestBaseBackend
+from grimoire_elk.ocean.nntp import NNTPOcean
 
 
 class TestNNTPClub(TestBaseBackend):
@@ -74,6 +75,14 @@ class TestNNTPClub(TestBaseBackend):
 
         result = self._test_refresh_project()
         # ... ?
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['nntp'][0]
+            arthur_params = {'group': 'mozilla.dev.project-link', 'host': 'news.mozilla.org'}
+            self.assertDictEqual(arthur_params, NNTPOcean.get_arthur_params_from_url(url))
 
 
 if __name__ == "__main__":

--- a/tests/test_phabricator.py
+++ b/tests/test_phabricator.py
@@ -21,11 +21,12 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
-
+import json
 import logging
 import unittest
 
 from base import TestBaseBackend
+from grimoire_elk.ocean.phabricator import PhabricatorOcean
 
 
 class TestPhabricator(TestBaseBackend):
@@ -74,6 +75,14 @@ class TestPhabricator(TestBaseBackend):
 
         result = self._test_refresh_project()
         # ... ?
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['phabricator'][0]
+            arthur_params = {'uri': 'https://phabricator.wikimedia.org', 'url': 'https://phabricator.wikimedia.org'}
+            self.assertDictEqual(arthur_params, PhabricatorOcean.get_arthur_params_from_url(url))
 
 
 if __name__ == "__main__":

--- a/tests/test_pipermail.py
+++ b/tests/test_pipermail.py
@@ -21,11 +21,12 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
-
+import json
 import logging
 import unittest
 
 from base import TestBaseBackend
+from grimoire_elk.ocean.pipermail import PipermailOcean
 
 
 class TestPipermail(TestBaseBackend):
@@ -74,6 +75,14 @@ class TestPipermail(TestBaseBackend):
 
         result = self._test_refresh_project()
         # ... ?
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['pipermail'][0]
+            arthur_params = {'dirpath': '/tmp', 'url': 'https://mail.gnome.org/archives/libart-hackers/'}
+            self.assertDictEqual(arthur_params, PipermailOcean.get_arthur_params_from_url(url))
 
 
 if __name__ == "__main__":

--- a/tests/test_redmine.py
+++ b/tests/test_redmine.py
@@ -21,11 +21,12 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
-
+import json
 import logging
 import unittest
 
 from base import TestBaseBackend
+from grimoire_elk.ocean.redmine import RedmineOcean
 
 
 class TestRedmine(TestBaseBackend):
@@ -74,6 +75,14 @@ class TestRedmine(TestBaseBackend):
 
         result = self._test_refresh_project()
         # ... ?
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['redmine'][0]
+            arthur_params = {'uri': 'http://tracker.ceph.com/', 'url': 'http://tracker.ceph.com/'}
+            self.assertDictEqual(arthur_params, RedmineOcean.get_arthur_params_from_url(url))
 
 
 if __name__ == "__main__":

--- a/tests/test_remo.py
+++ b/tests/test_remo.py
@@ -21,11 +21,12 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
-
+import json
 import logging
 import unittest
 
 from base import TestBaseBackend
+from grimoire_elk.ocean.remo import ReMoOcean
 
 
 class TestRemo(TestBaseBackend):
@@ -74,6 +75,14 @@ class TestRemo(TestBaseBackend):
 
         result = self._test_refresh_project()
         # ... ?
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['remo'][0]
+            arthur_params = {'uri': 'https://reps.mozilla.org', 'url': 'https://reps.mozilla.org'}
+            self.assertDictEqual(arthur_params, ReMoOcean.get_arthur_params_from_url(url))
 
 
 if __name__ == "__main__":

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -21,11 +21,12 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
-
+import json
 import logging
 import unittest
 
 from base import TestBaseBackend
+from grimoire_elk.ocean.rss import RSSOcean
 
 
 class TestRSS(TestBaseBackend):
@@ -74,6 +75,14 @@ class TestRSS(TestBaseBackend):
 
         result = self._test_refresh_project()
         # ... ?
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['rss'][0]
+            arthur_params = {'uri': 'https://blog.bitergia.com/feed/', 'url': 'https://blog.bitergia.com/feed/'}
+            self.assertDictEqual(arthur_params, RSSOcean.get_arthur_params_from_url(url))
 
 
 if __name__ == "__main__":

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -21,11 +21,12 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
-
+import json
 import logging
 import unittest
 
 from base import TestBaseBackend
+from grimoire_elk.ocean.slack import SlackOcean
 
 
 class TestSlack(TestBaseBackend):
@@ -74,6 +75,14 @@ class TestSlack(TestBaseBackend):
 
         result = self._test_refresh_project()
         # ... ?
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['slack'][0]
+            arthur_params = {'channel': 'C7LSGB0AU'}
+            self.assertDictEqual(arthur_params, SlackOcean.get_arthur_params_from_url(url))
 
 
 if __name__ == "__main__":

--- a/tests/test_stackexchange.py
+++ b/tests/test_stackexchange.py
@@ -21,11 +21,12 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
-
+import json
 import logging
 import unittest
 
 from base import TestBaseBackend
+from grimoire_elk.ocean.stackexchange import StackExchangeOcean
 
 
 class TestStackexchange(TestBaseBackend):
@@ -74,6 +75,14 @@ class TestStackexchange(TestBaseBackend):
 
         result = self._test_refresh_project()
         # ... ?
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['stackexchange'][0]
+            arthur_params = {'site': 'stackoverflow.com', 'tagged': 'ovirt'}
+            self.assertDictEqual(arthur_params, StackExchangeOcean.get_arthur_params_from_url(url))
 
 
 if __name__ == "__main__":

--- a/tests/test_supybot.py
+++ b/tests/test_supybot.py
@@ -21,11 +21,12 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
-
+import json
 import logging
 import unittest
 
 from base import TestBaseBackend
+from grimoire_elk.ocean.supybot import SupybotOcean
 
 
 class TestSupybot(TestBaseBackend):
@@ -74,6 +75,15 @@ class TestSupybot(TestBaseBackend):
 
         result = self._test_refresh_project()
         # ... ?
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['supybot'][0]
+            arthur_params = {'dirpath': '/home/bitergia/.perceval/irc/percevalbot/logs/ChannelLogger/freenode/#openshift/',
+                             'uri': 'openshift'}
+            self.assertDictEqual(arthur_params, SupybotOcean.get_arthur_params_from_url(url))
 
 
 if __name__ == "__main__":

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -21,11 +21,12 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
-
+import json
 import logging
 import unittest
 
 from base import TestBaseBackend
+from grimoire_elk.ocean.telegram import TelegramOcean
 
 
 class TestTelegram(TestBaseBackend):
@@ -74,6 +75,14 @@ class TestTelegram(TestBaseBackend):
 
         result = self._test_refresh_project()
         # ... ?
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['telegram'][0]
+            arthur_params = {'bot': 'Mozilla_analytics'}
+            self.assertDictEqual(arthur_params, TelegramOcean.get_arthur_params_from_url(url))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
All perceval backends are now supported in arthur except the ones provided by perceval-mozilla/opnfv/puppet because and problem installing their pip packages with arthur.