### PR TITLE
[elk] Handle empty message commits

### DIFF
--- a/grimoire_elk/elk/git.py
+++ b/grimoire_elk/elk/git.py
@@ -337,7 +337,10 @@ class GitEnrich(Enrich):
                 eitem[map_fields[fn]] = commit[fn]
             else:
                 eitem[map_fields[fn]] = None
-        eitem['message'] = commit['message'][:self.KEYWORD_MAX_SIZE]
+
+        if 'message' in commit:
+            eitem['message'] = commit['message'][:self.KEYWORD_MAX_SIZE]
+
         eitem['hash_short'] = eitem['hash'][0:6]
         # Enrich dates
         author_date = parser.parse(commit["AuthorDate"])


### PR DESCRIPTION
This patch allows to handle commits with empty messages. Thus, it includes a condition to check that the attribute message exists in the commit item.