### PR TITLE
[raw] Fix typos in ES 2.2 mappings for gerrit

### DIFF
--- a/grimoire_elk/raw/gerrit.py
+++ b/grimoire_elk/raw/gerrit.py
@@ -93,22 +93,21 @@ class Mapping(BaseMapping):
                                 "properties": {
                                     "message": {
                                         "type": "string",
-                                        "index": "anaylzed"
+                                        "index": "analyzed"
                                     }
                                 }
                             },
                             "subject": {
                                 "type": "string",
-                                "index": "anaylzed"
+                                "index": "analyzed"
                             },
-                            ,
                             "patchSets": {
                                 "properties": {
                                     "approvals": {
                                         "properties": {
                                             "description": {
                                                 "type": "string",
-                                                "index": "anaylzed"
+                                                "index": "analyzed"
                                             }
                                         }
                                     }


### PR DESCRIPTION
This patch fixes the mappings for ES 2.2 defined for gerrit data.