### PR TITLE
[enrich] Fix limit comment message in gerrit

### DIFF
--- a/grimoire_elk/enriched/gerrit.py
+++ b/grimoire_elk/enriched/gerrit.py
@@ -211,7 +211,7 @@ class GerritEnrich(Enrich):
         eitem["patchsets"] = len(review["patchSets"])
 
         # Limit the size of comment messages
-        if review['comments']:
+        if 'comments' in review:
             for comment in review['comments']:
                 comment['message'] = comment['message'][:self.KEYWORD_MAX_SIZE]
 


### PR DESCRIPTION
This patch checks that comments within a review exist, before limiting their size.