### PR TITLE
[enriched] Set not accepted answer flag to askbot unanswered question

### DIFF
--- a/grimoire_elk/enriched/askbot.py
+++ b/grimoire_elk/enriched/askbot.py
@@ -166,6 +166,8 @@ class AskbotEnrich(Enrich):
             eitem['time_to_reply'] = get_time_diff_days(added_at, first_answer_time)
             eitem['question_has_accepted_answer'] = 1 if question['accepted_answer_id'] else 0
             eitem['question_accepted_answer_id'] = question['accepted_answer_id']
+        else:
+            eitem['question_has_accepted_answer'] = 0
 
         if question['author'] and type(question['author']) is dict:
             eitem['author_askbot_user_name'] = question['author']['username']


### PR DESCRIPTION
This patch sets the default value of the attribute question_has_accepted_answer to zero for unanswered questions in askbot.