### PR TITLE
[enrich] Handle missing accepted_answer_id attribute

### DIFF
--- a/grimoire_elk/enriched/askbot.py
+++ b/grimoire_elk/enriched/askbot.py
@@ -139,6 +139,9 @@ class AskbotEnrich(Enrich):
 
         question = item['data']
 
+        if 'accepted_answer_id' not in question:
+            question['accepted_answer_id'] = None
+
         # Fields that are the same in item and eitem
         copy_fields = ["id", "url", "title", "summary", "score"]
         for f in copy_fields:

--- a/tests/data/askbot.json
+++ b/tests/data/askbot.json
@@ -2610,7 +2610,6 @@
     "backend_version": "0.4.0",
     "category": "question",
     "data": {
-        "accepted_answer_id": null,
         "added_at": "1270788444",
         "answer_count": 1,
         "answer_ids": [


### PR DESCRIPTION
This patch initializes the attribute accepted_answer_id to a null value when it is not present in the json returned by the api. Thus, it avoids KeyError exceptions during the enrichment phase.