### PR TITLE
[enrich] Fix mapping for attribute question_title in discourse

### DIFF
--- a/grimoire_elk/enriched/discourse.py
+++ b/grimoire_elk/enriched/discourse.py
@@ -32,33 +32,7 @@ from ..elastic_mapping import Mapping as BaseMapping
 logger = logging.getLogger(__name__)
 
 
-class Mapping(BaseMapping):
-
-    @staticmethod
-    def get_elastic_mappings(es_major):
-        """Get Elasticsearch mapping.
-
-        :param es_major: major version of Elasticsearch, as string
-        :returns:        dictionary with a key, 'items', with the mapping
-        """
-
-        mapping = """
-        {
-            "properties": {
-               "question_title": {
-                   "type": "text",
-                   "index": false
-               }
-            }
-        }
-        """
-
-        return {"items": mapping}
-
-
 class DiscourseEnrich(Enrich):
-
-    mapping = Mapping
 
     def __init__(self, db_sortinghat=None, db_projects_map=None, json_projects_map=None,
                  db_user='', db_password='', db_host=''):
@@ -232,6 +206,8 @@ class DiscourseEnrich(Enrich):
 
         # The first post is the first published, and it is the question
         first_post = topic['post_stream']['posts'][0]
+
+        eitem['question_title'] = eitem['question_title'][:self.KEYWORD_MAX_SIZE]
         eitem['category_id'] = topic['category_id']
         eitem['categories'] = self.__related_categories(topic['category_id'])
         if topic['category_id'] in self.categories:


### PR DESCRIPTION
This patch fixes the mapping of the enriched attribute question_title within the discourse backend. It allows the attribute to be searchable and aggregatable, thus avoiding breaking the corresponding panel.