### PR TITLE
[enrich] Limit size of value attribute summary in bugzilla

### DIFF
--- a/grimoire_elk/enriched/bugzilla.py
+++ b/grimoire_elk/enriched/bugzilla.py
@@ -31,41 +31,13 @@ from datetime import datetime
 from dateutil import parser
 
 from .enrich import Enrich, metadata
-from ..elastic_mapping import Mapping as BaseMapping
-
 from .utils import get_time_diff_days
 
 
 logger = logging.getLogger(__name__)
 
 
-class Mapping(BaseMapping):
-
-    @staticmethod
-    def get_elastic_mappings(es_major):
-        """Get Elasticsearch mapping.
-
-        :param es_major: major version of Elasticsearch, as string
-        :returns:        dictionary with a key, 'items', with the mapping
-        """
-
-        mapping = """
-        {
-            "properties": {
-               "main_description": {
-                   "type": "text",
-                   "index": false
-               }
-            }
-        }
-        """
-
-        return {"items": mapping}
-
-
 class BugzillaEnrich(Enrich):
-
-    # mapping = Mapping
 
     roles = ['assigned_to', 'reporter', 'qa_contact']
 
@@ -185,7 +157,7 @@ class BugzillaEnrich(Enrich):
                 eitem["main_description"] = issue['short_desc'][0]['__text__'][:self.KEYWORD_MAX_SIZE]
         if "summary" in issue:
             if "__text__" in issue["summary"][0]:
-                eitem["summary"] = issue['summary'][0]['__text__']
+                eitem["summary"] = issue['summary'][0]['__text__'][:self.KEYWORD_MAX_SIZE]
 
         # Fix dates
         date_ts = parser.parse(issue['delta_ts'][0]['__text__'])


### PR DESCRIPTION
This patch limits the size of the attribute summary to 30000 to avoid immense term errors when storing enriched items to ElasticSearch.