### PR TITLE
[enrich] Handle different formats for failures in functest

### DIFF
--- a/grimoire_elk/enriched/functest.py
+++ b/grimoire_elk/enriched/functest.py
@@ -82,7 +82,12 @@ class FunctestEnrich(Enrich):
                     # Only propagate tests if it is a number
                     eitem['tests'] = func_test['details']['tests']
             if 'failures' in func_test['details']:
-                eitem['failures'] = func_test['details']['failures']
+
+                if type(func_test['details']['failures']) == list:
+                    eitem['failures'] = len(func_test['details']['failures'])
+                else:
+                    eitem['failures'] = func_test['details']['failures']
+
             if 'duration' in func_test['details']:
                 eitem['duration'] = func_test['details']['duration']
 

--- a/tests/data/functest.json
+++ b/tests/data/functest.json
@@ -333,7 +333,7 @@
         "criteria": "PASS",
         "details": {
             "errors": "",
-            "failures": 0,
+            "failures": [],
             "skipped": "2017-06-01 10:51:23.615 399 INFO opnfv-tempest [-] {0} tempest.scenario.test_server_multinode.TestServerMultinode",
             "tests": 119
         },
@@ -601,7 +601,7 @@
         "criteria": "PASS",
         "details": {
             "errors": [],
-            "failures": []
+            "failures": null
         },
         "installer": "daisy",
         "pod_name": "zte-virtual1",
@@ -629,7 +629,8 @@
         "criteria": "PASS",
         "details": {
             "errors": [],
-            "failures": []
+            "failures": ["tempest.api.identity.admin.v3.test_credentials.CredentialsTestJSON",
+                         "tempest.api.identity.admin.v3.test_domains.DefaultDomainTestJSON.test_default_domain_exists"]
         },
         "installer": "daisy",
         "pod_name": "zte-virtual1",


### PR DESCRIPTION
This patch allows to handle the different formats for failures in functest. In a nutshell, failures are returned by the functest API as number or list. This heterogeneity causes ES to fail since it cannot map different types for the same attribute. Thus, this code stores the lenght of the list in the attribute failures, avoiding type conflicts.