### PR TITLE
[raw] Filter attachment-related data of slack messages

### DIFF
--- a/grimoire_elk/raw/slack.py
+++ b/grimoire_elk/raw/slack.py
@@ -49,6 +49,18 @@ class Mapping(BaseMapping):
                                 "attachments": {
                                     "dynamic":false,
                                     "properties": {}
+                                },
+                                "channel_info": {
+                                    "properties": {
+                                        "latest": {
+                                            "dynamic": false,
+                                            "properties": {}
+                                        }
+                                    }
+                                },
+                                "root": {
+                                   "dynamic":false,
+                                    "properties": {}
                                 }
                             }
                         }


### PR DESCRIPTION
This patch prevents to index attachment-related information which may cause timely errors (due to the timestamp value not always recognized as such by ES). This data is not used in the corresponding panel, as shown in the schema/slack.csv.