### PR TITLE
[raw/enrich] Handle long description in Jira fields

### DIFF
--- a/grimoire_elk/enriched/jira.py
+++ b/grimoire_elk/enriched/jira.py
@@ -193,7 +193,10 @@ class JiraEnrich(Enrich):
 
         eitem['author_email'] = None
         eitem['creation_date'] = issue["fields"]['created']
-        eitem['main_description'] = issue["fields"]['description']
+
+        if 'description' in issue["fields"]:
+            eitem['main_description'] = issue["fields"]['description'][:self.KEYWORD_MAX_SIZE]
+
         eitem['isssue_type'] = issue["fields"]['issuetype']['name']
         eitem['issue_description'] = issue["fields"]['issuetype']['description']
 

--- a/grimoire_elk/raw/jira.py
+++ b/grimoire_elk/raw/jira.py
@@ -40,21 +40,54 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        mapping = '''
-         {
-            "dynamic":true,
-                "properties": {
-                    "data": {
-                        "properties": {
-                            "renderedFields": {
-                                "dynamic":false,
-                                "properties": {}
+        if es_major != '2':
+            mapping = '''
+             {
+                "dynamic":true,
+                    "properties": {
+                        "data": {
+                            "properties": {
+                                "renderedFields": {
+                                    "dynamic":false,
+                                    "properties": {}
+                                },
+                                "fields": {
+                                    "properties": {
+                                        "description": {
+                                            "type": "text",
+                                            "index": true
+                                        }
+                                    }
+                                }
                             }
                         }
                     }
-                }
-        }
-        '''
+            }
+            '''
+        else:
+            mapping = '''
+             {
+                "dynamic":true,
+                    "properties": {
+                        "data": {
+                            "properties": {
+                                "renderedFields": {
+                                    "dynamic":false,
+                                    "properties": {}
+                                },
+                                "fields": {
+                                    "properties": {
+                                        "description": {
+                                            "type": "string",
+                                            "index": "analyzed"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+            }
+            '''
 
         return {"items": mapping}
 


### PR DESCRIPTION
This PR allows to handle long fields.description values in the raw and enriched indexes. In the raw index, a mapping is defined to to avoid immense term exceptions, while in the enriched index, the value is truncated to avoid changing the type of the attribute (keyword).