### PR TITLE
[mbox/nntp] Remove X-fields in raw data    

### DIFF
--- a/grimoire_elk/raw/mbox.py
+++ b/grimoire_elk/raw/mbox.py
@@ -85,3 +85,11 @@ class MBoxOcean(ElasticOcean):
         params = {"dirpath": params[1], "uri": params[0]}
 
         return params
+
+    def _fix_item(self, item):
+        # Remove all custom fields to avoid the 1000 fields limit in ES
+
+        fields = list(item["data"].keys())
+        for field in fields:
+            if field.lower().startswith("x-"):
+                item["data"].pop(field)

--- a/grimoire_elk/raw/nntp.py
+++ b/grimoire_elk/raw/nntp.py
@@ -76,3 +76,11 @@ class NNTPOcean(ElasticOcean):
         params = {"host": params[0], "group": params[1]}
 
         return params
+
+    def _fix_item(self, item):
+        # Remove all custom fields to avoid the 1000 fields limit in ES
+
+        fields = list(item["data"].keys())
+        for field in fields:
+            if field.lower().startswith("x-"):
+                item["data"].pop(field)


### PR DESCRIPTION
This patch removes from the raw data the custom fields (X-...) to avoid hitting the limit of 1000 fields in ES.