### PR TITLE
[phabricator] Handle dots in JSON attribute names

### DIFF
--- a/grimoire_elk/raw/phabricator.py
+++ b/grimoire_elk/raw/phabricator.py
@@ -74,8 +74,11 @@ class PhabricatorOcean(ElasticOcean):
     mapping = Mapping
 
     def _fix_item(self, item):
-        # https://discuss.elastic.co/t/field-name-cannot-contain/33251/16
-        if 'custom.external_reference' in item["data"]['fields']:
-            item["data"]['fields']["custom_external_reference"] = item["data"]['fields'].pop("custom.external_reference")
-        if 'custom.security_topic' in item["data"]['fields']:
-            item["data"]['fields']["custom_security_topic"] = item["data"]['fields'].pop("custom.security_topic")
+        # fields cannot contain dots in ES 2.2. For consistency reason, this fix is applied also
+        # to more recent versions of ES
+
+        for field in item["data"]["fields"]:
+            if '.' in field:
+                undotted_field = field.replace('.', '_')
+                item["data"]["fields"][undotted_field] = item["data"]["fields"][field]
+                item["data"]['fields'].pop(field)

--- a/tests/data/phabricator.json
+++ b/tests/data/phabricator.json
@@ -23,6 +23,7 @@
                 "userName": "jdoe"
             },
             "authorPHID": "PHID-USER-2uk52xorcqb6sjvp467y",
+            "custom.dev:deadline": 1464306027,
             "dateCreated": 1462297064,
             "dateModified": 1462306027,
             "name": "Tasks #69",
@@ -501,6 +502,7 @@
                 "userName": "jdoe"
             },
             "authorPHID": "PHID-USER-2uk52xorcqb6sjvp467y",
+            "custom.dev:deadline": 1462494642,
             "dateCreated": 1462379566,
             "dateModified": 1462464642,
             "name": "Task #73",
@@ -1059,6 +1061,7 @@
                 "userName": "jdoe"
             },
             "authorPHID": "PHID-USER-2uk52xorcqb6sjvp467y",
+            "custom.dev:deadline": 1462306057,
             "dateCreated": 1462645103,
             "dateModified": 1462792338,
             "name": "Task #78",
@@ -1545,6 +1548,7 @@
                 "userName": "jane"
             },
             "authorPHID": "PHID-USER-ojtcpympsmwenszuef7p",
+            "custom.dev:deadline": 1468196707,
             "dateCreated": 1465815168,
             "dateModified": 1467196707,
             "name": "Task 296",


### PR DESCRIPTION
This patch replaces dots in field attribute names with underscores. Thus, it prevents errors on ES versions previous to 5 (which don't allow to store this kind of attributes). For consistency reasons, this fix is applied also to more recent versions of ES.