### PR TITLE
Add alias management to studies

### DIFF
--- a/doc/studies.md
+++ b/doc/studies.md
@@ -19,6 +19,8 @@ data to apply this study on.
 ### Results
 As output you will get an index following our [areas of code index fields convention](https://github.com/chaoss/grimoirelab-elk/blob/master/schema/areas_of_code.csv). This index will be named `git_aoc-enriched`.
 
+Additionally, an alias named `git_areas_of_code` pointing to above's index is created if it doesn't exist.
+
 ## Onion Study
 This study process information from an enriched index and computes Onion metric on that.
 
@@ -107,6 +109,29 @@ This index will be named:
 * **Git**: `git_onion-enriched`.
 * **GitHub Issues**: `github_issues_onion-enriched`.
 * **GitHub Pull Requests**: `github_prs_onion-enriched`.
+
+Finally, an alias named `all_onion` is automatically created, including all of the above mentioned indices:
+```
+> GET _alias/all_onion
+
+{
+  "github_issues_onion-enriched": {
+    "aliases": {
+      "all_onion": {}
+    }
+  },
+  "git_onion-enriched": {
+    "aliases": {
+      "all_onion": {}
+    }
+  },
+  "github_prs_onion-enriched": {
+    "aliases": {
+      "all_onion": {}
+    }
+  }
+}
+```
 
 
 ## Running studies from p2o

--- a/grimoire_elk/enriched/ceres_base.py
+++ b/grimoire_elk/enriched/ceres_base.py
@@ -274,6 +274,18 @@ class ESConnector(Connector):
 
         return self._es_conn.indices.exists(index=self._es_index)
 
+    def create_alias(self, alias_name):
+        """Creates an alias pointing to the index configured in this connection"""
+
+        return self._es_conn.indices.put_alias(index=self._es_index, name=alias_name)
+
+    def exists_alias(self, alias_name):
+        """Check whether or not the given alias exists
+
+        :return: True if alias already exist"""
+
+        return self._es_conn.indices.exists_alias(name=alias_name)
+
     def _build_search_query(self, from_date):
         """Build an ElasticSearch search query to retrieve items for read methods.
 

--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -874,4 +874,10 @@ class Enrich(ElasticItems):
 
         onion_study(in_conn=in_conn, out_conn=out_conn, data_source=data_source)
 
+        # Create alias if output index exists (index is always created from scratch, so
+        # alias need to be created each time)
+        if out_conn.exists():
+            logger.info("[Onion] Creating alias: all_onion")
+            out_conn.create_alias('all_onion')
+
         logger.info("[Onion] This is the end.")

--- a/grimoire_elk/enriched/git.py
+++ b/grimoire_elk/enriched/git.py
@@ -785,6 +785,15 @@ class GitEnrich(Enrich):
             out_conn.create_index(filename, delete=exists_index)
 
         areas_of_code(git_enrich=enrich_backend, in_conn=in_conn, out_conn=out_conn)
+
+        # Create alias if output index exists and alias does not
+        if out_conn.exists():
+            if not out_conn.exists_alias('git_areas_of_code'):
+                logger.info("[Areas of Code] Creating alias: git_areas_of_code")
+                out_conn.create_alias('git_areas_of_code')
+            else:
+                logger.info("[Areas of Code] Alias already exists: git_areas_of_code.")
+
         logger.info("[Areas of Code] End")
 
     def enrich_onion(self, enrich_backend, no_incremental=False,


### PR DESCRIPTION
These commits add functionality to manage aliases after onion and areas of code execution. It is particularly important for onion because each time the study runs, index is deleted and therefore the corresponding alias is automatically removed. This way, once data is available, alias is created if needed.