### PR TITLE
[identities] Load identities to sortinghat by bulks

### DIFF
--- a/grimoire_elk/enriched/sortinghat_gelk.py
+++ b/grimoire_elk/enriched/sortinghat_gelk.py
@@ -115,7 +115,11 @@ class SortingHat(object):
         total = 0
 
         for identity in identities:
-            cls.add_identity(db, identity, backend)
-            total += 1
+            try:
+                cls.add_identity(db, identity, backend)
+                total += 1
+            except Exception as e:
+                logger.error("Unexcepted error when adding identities: %s" % e)
+                continue
 
         logger.info("Total identities added to SH: %i", total)


### PR DESCRIPTION
This PR changes the way of loading identities to sortinghat. In a nutshell, instead of loading in memory all the identities before sending them to sortinghat, they are sent to bulks of 500. Thus, the consuption of memory is safe when dealing with a large number of identities. Furthermore, this PR enables also to log exceptions that may occur when processing identities. This log can help to shed some light on mordred
threads that from time to time die without leaving any trace.