### PR TITLE
[jira] Handle data.changelog.histories fields

### DIFF
--- a/grimoire_elk/raw/jira.py
+++ b/grimoire_elk/raw/jira.py
@@ -58,6 +58,13 @@ class Mapping(BaseMapping):
                                             "index": true
                                         }
                                     }
+                                },
+                                "changelog": {
+                                    "properties": {
+                                        "histories": {
+                                            "properties": {}
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -80,6 +87,13 @@ class Mapping(BaseMapping):
                                         "description": {
                                             "type": "string",
                                             "index": "analyzed"
+                                        }
+                                    }
+                                },
+                                "changelog": {
+                                    "properties": {
+                                        "histories": {
+                                            "properties": {}
                                         }
                                     }
                                 }


### PR DESCRIPTION
This patch prevents to index changelog histories of Jira items, thus avoiding immense term exceptions when inserting data to ES.