### PR TITLE
[jenkins] Update raw mappings to deal with large comments

### DIFF
--- a/grimoire_elk/raw/jenkins.py
+++ b/grimoire_elk/raw/jenkins.py
@@ -61,8 +61,7 @@ class Mapping(BaseMapping):
                                         "items": {
                                             "properties": {
                                                 "comment": {
-                                                    "type": "text",
-                                                    "index": false
+                                                    "type": "text"
                                                 }
                                             }
                                         }
@@ -94,7 +93,7 @@ class Mapping(BaseMapping):
                                             "properties": {
                                                 "comment": {
                                                     "type": "string",
-                                                    "index": "not_analyzed"
+                                                    "index": "analyzed"
                                                 }
                                             }
                                         }


### PR DESCRIPTION
This patch allows to deal with large comments of Jenkins data, thus it avoids immense term exceptions when inserting data to ES.