### PR TITLE
[setup] Add dependency on SortingHat

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(name="grimoire-elk",
       test_suite='tests',
       scripts=["utils/p2o.py"],
       install_requires=['perceval>=0.9.6', 'perceval-mozilla>=0.1.4', 'perceval-opnfv>=0.1.2', 'perceval-puppet>=0.1.4',
-                        'kingarthur>=0.1.1', 'cereslib>=0.1.0', 'grimoirelab-toolkit>=0.1.4',
+                        'kingarthur>=0.1.1', 'cereslib>=0.1.0', 'grimoirelab-toolkit>=0.1.4', 'sortinghat>=0.6.2',
                         'elasticsearch>=5.5.2', 'elasticsearch-dsl>=5.3.0'],
       zip_safe=False
       )


### PR DESCRIPTION
When installing grimoire-elk alone, the problem below is found. This patch fixes it by adding sortinghat as a dependency.

This could be a temporary fix, while we decide if this really needs to depend on SoertingHat (now it is a extra dependency, which I didn't remove just in case).

```
$ pip install grimoire-elk
...
$ p2o.py --help
Traceback (most recent call last):
  File "/tmp/3/bin/p2o.py", line 30, in <module>
    from grimoire_elk.elk import feed_backend, enrich_backend
  File "/tmp/3/lib/python3.6/site-packages/grimoire_elk/elk.py", line 39, in <module>
    from .utils import get_elastic
  File "/tmp/3/lib/python3.6/site-packages/grimoire_elk/utils.py", line 77, in <module>
    from .enriched.git import GitEnrich
  File "/tmp/3/lib/python3.6/site-packages/grimoire_elk/enriched/git.py", line 37, in <module>
    from .study_ceres_aoc import areas_of_code, ESPandasConnector
  File "/tmp/3/lib/python3.6/site-packages/grimoire_elk/enriched/study_ceres_aoc.py", line 28, in <module>
    from cereslib.events.events import Git, Events
  File "/tmp/3/lib/python3.6/site-packages/cereslib/events/events.py", line 27, in <module>
    from grimoire_elk.enriched.sortinghat_gelk import SortingHat
  File "/tmp/3/lib/python3.6/site-packages/grimoire_elk/enriched/sortinghat_gelk.py", line 30, in <module>
    from sortinghat import api
ModuleNotFoundError: No module named 'sortinghat'
```