### PR TITLE
[phabricator] Handle long description.raw value in raw items

### DIFF
--- a/grimoire_elk/raw/phabricator.py
+++ b/grimoire_elk/raw/phabricator.py
@@ -56,6 +56,10 @@ class Mapping(BaseMapping):
                                     "properties": {
                                         "subpriority" : {"type": "float"}
                                      }
+                                 },
+                                 "description": {
+                                    "dynamic":false,
+                                    "properties": {}
                                  }
                              }
                          }


### PR DESCRIPTION
This patch prevents to index description.raw attributes of phabricator items, thus avoiding immense term exception in ES. Description.raw attribute is not used neither in the enriched item nor in the corresponding panels (according to the csv in the schema folder).