### PR TITLE
[jira] Disable dynamic mappings for data.changelog.histories

### DIFF
--- a/grimoire_elk/raw/jira.py
+++ b/grimoire_elk/raw/jira.py
@@ -61,6 +61,7 @@ class Mapping(BaseMapping):
                             "changelog": {
                                 "properties": {
                                     "histories": {
+                                        "dynamic":false,
                                         "properties": {}
                                     }
                                 }


### PR DESCRIPTION
This patch disable dynamic mappings when indexing changelog histories of Jira items.