### PR TITLE
[mappings] Goodbye ES 2.x

### DIFF
--- a/grimoire_elk/enriched/askbot.py
+++ b/grimoire_elk/enriched/askbot.py
@@ -44,32 +44,17 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = """
-            {
-                "properties": {
-                    "author_badges": {
-                      "type": "text"
-                    },
-                    "summary": {
-                      "type": "text"
-                    }
-               }
-            } """
-        else:
-            mapping = """
-            {
-                "properties": {
-                    "author_badges": {
-                      "type": "string",
-                      "index": "analyzed"
-                    },
-                    "summary": {
-                      "type": "string",
-                      "index": "analyzed"
-                    }
-               }
-            } """
+        mapping = """
+        {
+            "properties": {
+                "author_badges": {
+                  "type": "text"
+                },
+                "summary": {
+                  "type": "text"
+                }
+           }
+        } """
 
         return {"items": mapping}
 

--- a/grimoire_elk/enriched/confluence.py
+++ b/grimoire_elk/enriched/confluence.py
@@ -41,25 +41,14 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = """
-            {
-                "properties": {
-                    "title_analyzed": {
-                      "type": "text"
-                      }
-               }
-            } """
-        else:
-            mapping = """
-            {
-                "properties": {
-                    "title_analyzed": {
-                      "type": "string",
-                      "index": "analyzed"
-                      }
-               }
-            } """
+        mapping = """
+        {
+            "properties": {
+                "title_analyzed": {
+                  "type": "text"
+                  }
+           }
+        } """
 
         return {"items": mapping}
 

--- a/grimoire_elk/enriched/crates.py
+++ b/grimoire_elk/enriched/crates.py
@@ -45,25 +45,14 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = """
-            {
-                "properties": {
-                    "description_analyzed": {
-                      "type": "text"
-                      }
-               }
-            } """
-        else:
-            mapping = """
-            {
-                "properties": {
-                    "description_analyzed": {
-                      "type": "string",
-                      "index": "analyzed"
-                      }
-               }
-            } """
+        mapping = """
+        {
+            "properties": {
+                "description_analyzed": {
+                  "type": "text"
+                  }
+           }
+        } """
 
         return {"items": mapping}
 

--- a/grimoire_elk/enriched/dockerhub.py
+++ b/grimoire_elk/enriched/dockerhub.py
@@ -43,44 +43,24 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = """
-            {
-                "properties": {
-                    "description": {
-                        "type": "text",
-                        "index": true
-                    },
-                    "description_analyzed": {
-                        "type": "text",
-                        "index": true
-                    },
-                    "full_description_analyzed": {
-                        "type": "text",
-                        "index": true
-                    }
-               }
-            }
-            """
-        else:
-            mapping = """
-            {
-                "properties": {
-                    "description": {
-                        "type": "string",
-                        "index": "analyzed"
-                    },
-                    "description_analyzed": {
-                        "type": "string",
-                        "index": "analyzed"
-                    },
-                    "full_description_analyzed": {
-                        "type": "string",
-                        "index": "analyzed"
-                    }
-               }
-            }
-            """
+        mapping = """
+        {
+            "properties": {
+                "description": {
+                    "type": "text",
+                    "index": true
+                },
+                "description_analyzed": {
+                    "type": "text",
+                    "index": true
+                },
+                "full_description_analyzed": {
+                    "type": "text",
+                    "index": true
+                }
+           }
+        }
+        """
 
         return {"items": mapping}
 

--- a/grimoire_elk/enriched/gerrit.py
+++ b/grimoire_elk/enriched/gerrit.py
@@ -44,34 +44,19 @@ class Mapping(BaseMapping):
         :param es_major: major version of Elasticsearch, as string
         :returns:        dictionary with a key, 'items', with the mapping
         """
-        if es_major == '2':
-            # Keep compatibility with 2.x mappings
-            mapping = """
-            {
-                "properties": {
-                   "summary_analyzed": {
-                      "type": "string",
-                      "index": "analyzed"
-                   },
-                   "timeopen": {
-                      "type": "double"
-                   }
-                }
+
+        mapping = """
+        {
+            "properties": {
+               "summary_analyzed": {
+                  "type": "text"
+               },
+               "timeopen": {
+                  "type": "double"
+               }
             }
-            """
-        else:
-            mapping = """
-            {
-                "properties": {
-                   "summary_analyzed": {
-                      "type": "text"
-                   },
-                   "timeopen": {
-                      "type": "double"
-                   }
-                }
-            }
-            """
+        }
+        """
 
         return {"items": mapping}
 

--- a/grimoire_elk/enriched/git.py
+++ b/grimoire_elk/enriched/git.py
@@ -62,26 +62,15 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = """
-            {
-                "properties": {
-                   "message_analyzed": {
-                        "type": "text",
-                        "index": true
-                   }
+        mapping = """
+        {
+            "properties": {
+               "message_analyzed": {
+                    "type": "text",
+                    "index": true
                }
-            }"""
-        else:
-            mapping = """
-            {
-                "properties": {
-                   "message_analyzed": {
-                        "type": "string",
-                        "index": "analyzed"
-                   }
-               }
-            }"""
+           }
+        }"""
 
         return {"items": mapping}
 

--- a/grimoire_elk/enriched/github.py
+++ b/grimoire_elk/enriched/github.py
@@ -52,39 +52,21 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = """
-            {
-                "properties": {
-                   "assignee_geolocation": {
-                       "type": "geo_point"
-                   },
-                   "user_geolocation": {
-                       "type": "geo_point"
-                   },
-                   "title_analyzed": {
-                     "type": "text"
-                   }
-                }
+        mapping = """
+        {
+            "properties": {
+               "assignee_geolocation": {
+                   "type": "geo_point"
+               },
+               "user_geolocation": {
+                   "type": "geo_point"
+               },
+               "title_analyzed": {
+                 "type": "text"
+               }
             }
-            """
-        else:
-            mapping = """
-            {
-                "properties": {
-                   "assignee_geolocation": {
-                       "type": "geo_point"
-                   },
-                   "user_geolocation": {
-                       "type": "geo_point"
-                   },
-                   "title_analyzed": {
-                      "type": "string",
-                      "index": "analyzed"
-                   }
-                }
-            }
-            """
+        }
+        """
 
         return {"items": mapping}
 

--- a/grimoire_elk/enriched/jenkins.py
+++ b/grimoire_elk/enriched/jenkins.py
@@ -44,26 +44,15 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = """
-            {
-                "properties": {
-                    "fullDisplayName_analyzed": {
-                        "type": "text",
-                        "index": true
-                    }
-               }
-            } """
-        else:
-            mapping = """
-            {
-                "properties": {
-                    "fullDisplayName_analyzed": {
-                        "type": "string",
-                        "index": "analyzed"
-                    }
-               }
-            } """
+        mapping = """
+        {
+            "properties": {
+                "fullDisplayName_analyzed": {
+                    "type": "text",
+                    "index": true
+                }
+           }
+        } """
 
         return {"items": mapping}
 

--- a/grimoire_elk/enriched/kitsune.py
+++ b/grimoire_elk/enriched/kitsune.py
@@ -45,32 +45,17 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = """
-            {
-                "properties": {
-                    "content_analyzed": {
-                      "type": "text"
-                      },
-                    "tags_analyzed": {
-                      "type": "text"
-                      }
-               }
-            } """
-        else:
-            mapping = """
-            {
-                "properties": {
-                    "content_analyzed": {
-                      "type": "string",
-                      "index": "analyzed"
-                      },
-                    "tags_analyzed": {
-                      "type": "string",
-                      "index": "analyzed"
-                      }
-               }
-            } """
+        mapping = """
+        {
+            "properties": {
+                "content_analyzed": {
+                  "type": "text"
+                  },
+                "tags_analyzed": {
+                  "type": "text"
+                  }
+           }
+        } """
 
         return {"items": mapping}
 

--- a/grimoire_elk/enriched/mbox.py
+++ b/grimoire_elk/enriched/mbox.py
@@ -47,33 +47,18 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = """
-            {
-                "properties": {
-                     "Subject_analyzed": {
-                       "type": "text",
-                       "fielddata": true
-                     },
-                     "body": {
-                       "type": "text"
-                     }
-               }
-            } """
-        else:
-            mapping = """
-            {
-                "properties": {
-                     "Subject_analyzed": {
-                      "type": "string",
-                      "index": "analyzed"
-                     },
-                     "body": {
-                      "type": "string",
-                      "index": "analyzed"
-                     }
-               }
-            } """
+        mapping = """
+        {
+            "properties": {
+                 "Subject_analyzed": {
+                   "type": "text",
+                   "fielddata": true
+                 },
+                 "body": {
+                   "type": "text"
+                 }
+           }
+        } """
 
         return {"items": mapping}
 

--- a/grimoire_elk/enriched/mediawiki.py
+++ b/grimoire_elk/enriched/mediawiki.py
@@ -44,25 +44,14 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != "2":
-            mapping = """
-            {
-                "properties": {
-                    "title_analyzed": {
-                        "type": "text"
-                    }
-               }
-            } """
-        else:
-            mapping = """
-                {
-                    "properties": {
-                        "title_analyzed": {
-                            "type": "string",
-                             "index": "analyzed"
-                        }
-                   }
-                } """
+        mapping = """
+        {
+            "properties": {
+                "title_analyzed": {
+                    "type": "text"
+                }
+           }
+        } """
 
         return {"items": mapping}
 

--- a/grimoire_elk/enriched/meetup.py
+++ b/grimoire_elk/enriched/meetup.py
@@ -43,46 +43,26 @@ class Mapping(BaseMapping):
         :param es_major: major version of Elasticsearch, as string
         :returns:        dictionary with a key, 'items', with the mapping
         """
-        if es_major != "2":
-            mapping = """
-            {
-                "properties": {
-                    "description_analyzed": {
-                        "type": "text",
-                        "index": true
-                    },
-                    "comment": {
-                        "type": "text",
-                        "index": true
-                    },
-                    "venue_geolocation": {
-                        "type": "geo_point"
-                    },
-                    "group_geolocation": {
-                        "type": "geo_point"
-                    }
-               }
-            } """
-        else:
-            mapping = """
-                {
-                    "properties": {
-                        "description_analyzed": {
-                            "type": "string",
-                            "index": "analyzed"
-                        },
-                        "comment": {
-                            "type": "string",
-                            "index": "analyzed"
-                        },
-                        "venue_geolocation": {
-                            "type": "geo_point"
-                        },
-                        "group_geolocation": {
-                            "type": "geo_point"
-                        }
-                   }
-                } """
+
+        mapping = """
+        {
+            "properties": {
+                "description_analyzed": {
+                    "type": "text",
+                    "index": true
+                },
+                "comment": {
+                    "type": "text",
+                    "index": true
+                },
+                "venue_geolocation": {
+                    "type": "geo_point"
+                },
+                "group_geolocation": {
+                    "type": "geo_point"
+                }
+           }
+        } """
 
         return {"items": mapping}
 

--- a/grimoire_elk/enriched/mozillaclub.py
+++ b/grimoire_elk/enriched/mozillaclub.py
@@ -42,52 +42,26 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != "2":
-            mapping = """
-            {
-                "properties": {
-                    "Event_Description": {
-                        "type": "keyword"
-                    },
-                    "Event_Creations": {
-                        "type": "keyword"
-                    },
-                    "Feedback_from_Attendees": {
-                        "type": "keyword"
-                    },
-                    "Your_Feedback": {
-                        "type": "keyword"
-                    },
-                    "geolocation": {
-                        "type": "geo_point"
-                    }
-               }
-            } """
-        else:
-            mapping = """
-            {
-                "properties": {
-                    "Event_Description": {
-                        "type": "string",
-                        "index": "not_analyzed"
-                    },
-                    "Event_Creations": {
-                        "type": "string",
-                        "index": "not_analyzed"
-                    },
-                    "Feedback_from_Attendees": {
-                        "type": "string",
-                        "index": "not_analyzed"
-                    },
-                    "Your_Feedback": {
-                        "type": "string",
-                        "index": "not_analyzed"
-                    },
-                    "geolocation": {
-                        "type": "geo_point"
-                    }
-               }
-            } """
+        mapping = """
+        {
+            "properties": {
+                "Event_Description": {
+                    "type": "keyword"
+                },
+                "Event_Creations": {
+                    "type": "keyword"
+                },
+                "Feedback_from_Attendees": {
+                    "type": "keyword"
+                },
+                "Your_Feedback": {
+                    "type": "keyword"
+                },
+                "geolocation": {
+                    "type": "geo_point"
+                }
+           }
+        } """
 
         return {"items": mapping}
 

--- a/grimoire_elk/enriched/phabricator.py
+++ b/grimoire_elk/enriched/phabricator.py
@@ -47,40 +47,22 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = """
-            {
-                "properties": {
-                    "main_description_analyzed": {
-                      "type": "text"
-                    },
-                    "assigned_to_roles": {
-                      "type": "text",
-                      "fielddata": true
-                     },
-                    "tags_analyzed": {
-                      "type": "text",
-                      "fielddata": true
-                     }
-               }
-            } """
-        else:
-            mapping = """
-            {
-                "properties": {
-                    "main_description_analyzed": {
-                      "type": "string",
-                      "index": "analyzed"
-                    },
-                    "assigned_to_roles": {
-                      "type": "string"
-                     },
-                    "tags_analyzed": {
-                      "type": "string",
-                      "index": "analyzed"
-                     }
-               }
-            } """
+        mapping = """
+        {
+            "properties": {
+                "main_description_analyzed": {
+                  "type": "text"
+                },
+                "assigned_to_roles": {
+                  "type": "text",
+                  "fielddata": true
+                 },
+                "tags_analyzed": {
+                  "type": "text",
+                  "fielddata": true
+                 }
+           }
+        } """
 
         return {"items": mapping}
 

--- a/grimoire_elk/enriched/redmine.py
+++ b/grimoire_elk/enriched/redmine.py
@@ -47,25 +47,14 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != "2":
-            mapping = """
-            {
-                "properties": {
-                    "description_analyzed": {
-                        "type": "text"
-                    }
-               }
-            } """
-        else:
-            mapping = """
-            {
-                "properties": {
-                    "description_analyzed": {
-                        "type": "string",
-                        "index": "analyzed"
-                    }
-               }
-            } """
+        mapping = """
+        {
+            "properties": {
+                "description_analyzed": {
+                    "type": "text"
+                }
+           }
+        } """
 
         return {"items": mapping}
 

--- a/grimoire_elk/enriched/remo.py
+++ b/grimoire_elk/enriched/remo.py
@@ -41,31 +41,17 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = """
-            {
-                "properties": {
-                    "description_analyzed": {
-                      "type": "text"
-                    },
-                    "geolocation": {
-                        "type": "geo_point"
-                    }
-               }
-            } """
-        else:
-            mapping = """
-            {
-                "properties": {
-                    "description_analyzed": {
-                      "type": "string",
-                      "index": "analyzed"
-                    },
-                    "geolocation": {
-                        "type": "geo_point"
-                    }
-               }
-            } """
+        mapping = """
+        {
+            "properties": {
+                "description_analyzed": {
+                  "type": "text"
+                },
+                "geolocation": {
+                    "type": "geo_point"
+                }
+           }
+        } """
 
         return {"items": mapping}
 

--- a/grimoire_elk/enriched/rss.py
+++ b/grimoire_elk/enriched/rss.py
@@ -43,34 +43,19 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != "2":
-            mapping = """
-            {
-                "properties": {
-                    "summary_analyzed": {
-                        "type": "text",
-                        "index": true
-                    },
-                    "summary": {
-                        "type": "text",
-                        "index": true
-                    }
-               }
-            } """
-        else:
-            mapping = """
-                {
-                    "properties": {
-                        "summary_analyzed": {
-                            "type": "string",
-                            "index": "analyzed"
-                        },
-                        "summary": {
-                            "type": "string",
-                            "index": "analyzed"
-                        }
-                   }
-                } """
+        mapping = """
+        {
+            "properties": {
+                "summary_analyzed": {
+                    "type": "text",
+                    "index": true
+                },
+                "summary": {
+                    "type": "text",
+                    "index": true
+                }
+           }
+        } """
 
         return {"items": mapping}
 

--- a/grimoire_elk/enriched/slack.py
+++ b/grimoire_elk/enriched/slack.py
@@ -42,26 +42,15 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = """
-            {
-                "properties": {
-                    "text_analyzed": {
-                      "type": "text",
-                      "fielddata": true
-                      }
-               }
-            } """
-        else:
-            mapping = """
-            {
-                "properties": {
-                    "text_analyzed": {
-                      "type": "string",
-                      "index": "analyzed"
-                      }
-               }
-            } """
+        mapping = """
+        {
+            "properties": {
+                "text_analyzed": {
+                  "type": "text",
+                  "fielddata": true
+                  }
+           }
+        } """
 
         return {"items": mapping}
 

--- a/grimoire_elk/enriched/stackexchange.py
+++ b/grimoire_elk/enriched/stackexchange.py
@@ -44,25 +44,14 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = """
-            {
-                "properties": {
-                    "title_analyzed": {
-                      "type": "text"
-                    }
-               }
-            } """
-        else:
-            mapping = """
-            {
-                "properties": {
-                    "title_analyzed": {
-                      "type": "string",
-                      "index": "analyzed"
-                    }
-               }
-            } """
+        mapping = """
+        {
+            "properties": {
+                "title_analyzed": {
+                  "type": "text"
+                }
+           }
+        } """
 
         return {"items": mapping}
 

--- a/grimoire_elk/enriched/supybot.py
+++ b/grimoire_elk/enriched/supybot.py
@@ -43,26 +43,15 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = """
-            {
-                "properties": {
-                    "body_analyzed": {
-                      "type": "text",
-                      "fielddata": true
-                      }
-               }
-            } """
-        else:
-            mapping = """
-            {
-                "properties": {
-                    "body_analyzed": {
-                      "type": "string",
-                      "index": "analyzed"
-                      }
-               }
-            } """
+        mapping = """
+        {
+            "properties": {
+                "body_analyzed": {
+                  "type": "text",
+                  "fielddata": true
+                  }
+           }
+        } """
 
         return {"items": mapping}
 

--- a/grimoire_elk/enriched/telegram.py
+++ b/grimoire_elk/enriched/telegram.py
@@ -41,26 +41,15 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = """
-            {
-                "properties": {
-                    "text_analyzed": {
-                      "type": "text",
-                      "fielddata": true
-                      }
-               }
-            } """
-        else:
-            mapping = """
-            {
-                "properties": {
-                    "text_analyzed": {
-                      "type": "string",
-                      "index": "analyzed"
-                      }
-               }
-            } """
+        mapping = """
+        {
+            "properties": {
+                "text_analyzed": {
+                  "type": "text",
+                  "fielddata": true
+                  }
+           }
+        } """
 
         return {"items": mapping}
 

--- a/grimoire_elk/enriched/twitter.py
+++ b/grimoire_elk/enriched/twitter.py
@@ -43,31 +43,17 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = """
-            {
-                "properties": {
-                    "text_analyzed": {
-                      "type": "text"
-                      },
-                      "geolocation": {
-                         "type": "geo_point"
-                      }
-               }
-            } """
-        else:
-            mapping = """
-            {
-                "properties": {
-                    "text_analyzed": {
-                      "type": "string",
-                      "index": "analyzed"
-                      },
-                      "geolocation": {
-                         "type": "geo_point"
-                      }
-               }
-            } """
+        mapping = """
+        {
+            "properties": {
+                "text_analyzed": {
+                  "type": "text"
+                  },
+                  "geolocation": {
+                     "type": "geo_point"
+                  }
+           }
+        } """
 
         return {"items": mapping}
 

--- a/grimoire_elk/raw/askbot.py
+++ b/grimoire_elk/raw/askbot.py
@@ -36,62 +36,33 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "answers": {
-                                    "dynamic":false,
-                                    "properties": {}
-                                },
-                                "author": {
-                                    "dynamic":false,
-                                    "properties": {}
-                                },
-                                "comments": {
-                                    "dynamic":false,
-                                    "properties": {}
-                                },
-                                "summary": {
-                                    "type": "text",
-                                    "index": true
-                                }
+        mapping = '''
+         {
+            "dynamic":true,
+                "properties": {
+                    "data": {
+                        "properties": {
+                            "answers": {
+                                "dynamic":false,
+                                "properties": {}
+                            },
+                            "author": {
+                                "dynamic":false,
+                                "properties": {}
+                            },
+                            "comments": {
+                                "dynamic":false,
+                                "properties": {}
+                            },
+                            "summary": {
+                                "type": "text",
+                                "index": true
                             }
                         }
                     }
-            }
-            '''
-        else:
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "answers": {
-                                    "dynamic":false,
-                                    "properties": {}
-                                },
-                                "author": {
-                                    "dynamic":false,
-                                    "properties": {}
-                                },
-                                "comments": {
-                                    "dynamic":false,
-                                    "properties": {}
-                                },
-                                "summary": {
-                                    "type": "string",
-                                    "index": "analyzed"
-                                }
-                            }
-                        }
-                    }
-            }
-            '''
+                }
+        }
+        '''
 
         return {"items": mapping}
 

--- a/grimoire_elk/raw/bugzilla.py
+++ b/grimoire_elk/raw/bugzilla.py
@@ -39,56 +39,30 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "long_desc": {
-                                    "dynamic": false,
-                                    "properties": {}
-                                },
-                                "short_desc": {
-                                    "dynamic": false,
-                                    "properties": {
-                                        "__text__": {
-                                            "type": "text",
-                                            "index": true
-                                        }
+        mapping = '''
+         {
+            "dynamic":true,
+                "properties": {
+                    "data": {
+                        "properties": {
+                            "long_desc": {
+                                "dynamic": false,
+                                "properties": {}
+                            },
+                            "short_desc": {
+                                "dynamic": false,
+                                "properties": {
+                                    "__text__": {
+                                        "type": "text",
+                                        "index": true
                                     }
                                 }
                             }
                         }
                     }
-            }
-            '''
-        else:
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "long_desc": {
-                                    "dynamic": false,
-                                    "properties": {}
-                                },
-                                "short_desc": {
-                                    "dynamic": false,
-                                    "properties": {
-                                        "__text__": {
-                                            "type": "string",
-                                            "index": "analyzed"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-            }
-            '''
+                }
+        }
+        '''
 
         return {"items": mapping}
 

--- a/grimoire_elk/raw/bugzillarest.py
+++ b/grimoire_elk/raw/bugzillarest.py
@@ -39,88 +39,46 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "comments": {
-                                    "dynamic":false,
-                                    "properties": {
-                                        "raw_text": {
-                                            "type": "text",
-                                            "index": true
-                                        },
-                                        "text": {
-                                            "type": "text",
-                                            "index": true
-                                        }
+        mapping = '''
+         {
+            "dynamic":true,
+                "properties": {
+                    "data": {
+                        "properties": {
+                            "comments": {
+                                "dynamic":false,
+                                "properties": {
+                                    "raw_text": {
+                                        "type": "text",
+                                        "index": true
+                                    },
+                                    "text": {
+                                        "type": "text",
+                                        "index": true
                                     }
-                                },
-                                "attachments": {
-                                    "properties": {
-                                        "description" : {
-                                            "type": "text",
-                                            "index": true
-                                        },
-                                        "summary" : {
-                                            "type": "text",
-                                            "index": true
-                                        }
-                                    }
-                                },
-                                "summary": {
-                                    "type": "text",
-                                    "index": true
                                 }
+                            },
+                            "attachments": {
+                                "properties": {
+                                    "description" : {
+                                        "type": "text",
+                                        "index": true
+                                    },
+                                    "summary" : {
+                                        "type": "text",
+                                        "index": true
+                                    }
+                                }
+                            },
+                            "summary": {
+                                "type": "text",
+                                "index": true
                             }
                         }
                     }
-            }
-            '''
-        else:
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "comments": {
-                                    "dynamic":false,
-                                    "properties": {
-                                        "raw_text": {
-                                            "type": "string",
-                                            "index": "analyzed"
-                                        },
-                                        "text": {
-                                            "type": "string",
-                                            "index": "analyzed"
-                                        }
-                                    }
-                                },
-                                "attachments": {
-                                    "properties": {
-                                        "description" : {
-                                            "type": "string",
-                                            "index": "analyzed"
-                                        },
-                                        "summary" : {
-                                            "type": "string",
-                                            "index": "analyzed"
-                                        }
-                                    }
-                                },
-                                "summary": {
-                                    "type": "string",
-                                    "index": "analyzed"
-                                }
-                            }
-                        }
-                    }
-            }
-            '''
+                }
+        }
+        '''
 
         return {"items": mapping}
 

--- a/grimoire_elk/raw/discourse.py
+++ b/grimoire_elk/raw/discourse.py
@@ -37,51 +37,49 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "details": {
-                                    "properties": {
-                                        "suggested_topics": {
-                                            "dynamic": false,
-                                            "properties": {
-                                                "slug": {
-                                                    "type": "text",
-                                                    "index": true
-                                                },
-                                                "title": {
-                                                    "type": "text",
-                                                    "index": true
-                                                }
+        mapping = '''
+         {
+            "dynamic":true,
+                "properties": {
+                    "data": {
+                        "properties": {
+                            "details": {
+                                "properties": {
+                                    "suggested_topics": {
+                                        "dynamic": false,
+                                        "properties": {
+                                            "slug": {
+                                                "type": "text",
+                                                "index": true
+                                            },
+                                            "title": {
+                                                "type": "text",
+                                                "index": true
                                             }
                                         }
                                     }
-                                },
-                                "fancy_title": {
-                                    "type": "text",
-                                    "index": true
-                                },
-                                "slug": {
-                                    "type": "text",
-                                    "index": true
-                                },
-                                "title": {
-                                    "type": "text",
-                                    "index": true
-                                },
-                                "post_stream": {
-                                    "dynamic": false,
-                                    "properties": {
-                                        "posts": {
-                                            "properties": {
-                                                "cooked": {
-                                                    "type": "text",
-                                                    "index": true
-                                                }
+                                }
+                            },
+                            "fancy_title": {
+                                "type": "text",
+                                "index": true
+                            },
+                            "slug": {
+                                "type": "text",
+                                "index": true
+                            },
+                            "title": {
+                                "type": "text",
+                                "index": true
+                            },
+                            "post_stream": {
+                                "dynamic": false,
+                                "properties": {
+                                    "posts": {
+                                        "properties": {
+                                            "cooked": {
+                                                "type": "text",
+                                                "index": true
                                             }
                                         }
                                     }
@@ -89,62 +87,9 @@ class Mapping(BaseMapping):
                             }
                         }
                     }
-            }
-            '''
-        else:
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "details": {
-                                    "properties": {
-                                        "suggested_topics": {
-                                            "dynamic": false,
-                                            "properties": {
-                                                "slug": {
-                                                    "type": "string",
-                                                    "index": "analyzed"
-                                                },
-                                                "title": {
-                                                    "type": "string",
-                                                    "index": "analyzed"
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "fancy_title": {
-                                    "type": "string",
-                                    "index": "analyzed"
-                                },
-                                "slug": {
-                                    "type": "string",
-                                    "index": "analyzed"
-                                },
-                                "title": {
-                                    "type": "string",
-                                    "index": "analyzed"
-                                },
-                                "post_stream": {
-                                    "dynamic": false,
-                                    "properties": {
-                                        "posts": {
-                                            "properties": {
-                                                "cooked": {
-                                                    "type": "string",
-                                                    "index": "analyzed"
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-            }
-            '''
+                }
+        }
+        '''
 
         return {"items": mapping}
 

--- a/grimoire_elk/raw/dockerhub.py
+++ b/grimoire_elk/raw/dockerhub.py
@@ -37,46 +37,25 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "description": {
-                                    "type": "text",
-                                    "index": true
-                                },
-                                "full_description": {
-                                    "type": "text",
-                                    "index": true
-                                }
+        mapping = '''
+         {
+            "dynamic":true,
+                "properties": {
+                    "data": {
+                        "properties": {
+                            "description": {
+                                "type": "text",
+                                "index": true
+                            },
+                            "full_description": {
+                                "type": "text",
+                                "index": true
                             }
                         }
                     }
-            }
-            '''
-        else:
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "description": {
-                                    "type": "string",
-                                    "index": "analyzed"
-                                },
-                                "full_description": {
-                                    "type": "string",
-                                    "index": "analyzed"
-                                }
-                            }
-                        }
-                    }
-            }
-            '''
+                }
+        }
+        '''
 
         return {"items": mapping}
 

--- a/grimoire_elk/raw/gerrit.py
+++ b/grimoire_elk/raw/gerrit.py
@@ -39,36 +39,34 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = '''
-             {
-                "dynamic":true,
-                "properties": {
-                    "data": {
-                        "properties": {
-                            "commitMessage": {
-                                "type": "text"
-                            },
-                            "comments": {
-                                "properties": {
-                                    "message": {
-                                        "type": "text",
-                                        "index": true
-                                    }
+        mapping = '''
+         {
+            "dynamic":true,
+            "properties": {
+                "data": {
+                    "properties": {
+                        "commitMessage": {
+                            "type": "text"
+                        },
+                        "comments": {
+                            "properties": {
+                                "message": {
+                                    "type": "text",
+                                    "index": true
                                 }
-                            },
-                            "subject": {
-                                "type": "text",
-                                "index": true
-                            },
-                            "patchSets": {
-                                "properties": {
-                                    "approvals": {
-                                        "properties": {
-                                            "description": {
-                                                "type": "text",
-                                                "index": true
-                                            }
+                            }
+                        },
+                        "subject": {
+                            "type": "text",
+                            "index": true
+                        },
+                        "patchSets": {
+                            "properties": {
+                                "approvals": {
+                                    "properties": {
+                                        "description": {
+                                            "type": "text",
+                                            "index": true
                                         }
                                     }
                                 }
@@ -77,47 +75,8 @@ class Mapping(BaseMapping):
                     }
                 }
             }
-            '''
-
-        else:
-            mapping = '''
-             {
-                "dynamic":true,
-                "properties": {
-                    "data": {
-                        "properties": {
-                            "commitMessage": {
-                                "type": "string"
-                            },
-                            "comments": {
-                                "properties": {
-                                    "message": {
-                                        "type": "string",
-                                        "index": "analyzed"
-                                    }
-                                }
-                            },
-                            "subject": {
-                                "type": "string",
-                                "index": "analyzed"
-                            },
-                            "patchSets": {
-                                "properties": {
-                                    "approvals": {
-                                        "properties": {
-                                            "description": {
-                                                "type": "string",
-                                                "index": "analyzed"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            '''
+        }
+        '''
 
         return {"items": mapping}
 

--- a/grimoire_elk/raw/git.py
+++ b/grimoire_elk/raw/git.py
@@ -39,38 +39,21 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = '''
-             {
-                "dynamic":true,
-                "properties": {
-                    "data": {
-                        "properties": {
-                            "message": {
-                                "type": "text",
-                                "index": true
-                            }
+        mapping = '''
+         {
+            "dynamic":true,
+            "properties": {
+                "data": {
+                    "properties": {
+                        "message": {
+                            "type": "text",
+                            "index": true
                         }
                     }
                 }
             }
-            '''
-        else:
-            mapping = '''
-             {
-                "dynamic":true,
-                "properties": {
-                    "data": {
-                        "properties": {
-                            "message": {
-                                "type": "string",
-                                "index": "analyzed"
-                            }
-                        }
-                    }
-                }
-            }
-            '''
+        }
+        '''
 
         return {"items": mapping}
 

--- a/grimoire_elk/raw/github.py
+++ b/grimoire_elk/raw/github.py
@@ -37,56 +37,30 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "comments_data": {
-                                    "dynamic":false,
-                                    "properties": {
-                                        "body": {
-                                            "type": "text",
-                                            "index": true
-                                        }
+        mapping = '''
+         {
+            "dynamic":true,
+                "properties": {
+                    "data": {
+                        "properties": {
+                            "comments_data": {
+                                "dynamic":false,
+                                "properties": {
+                                    "body": {
+                                        "type": "text",
+                                        "index": true
                                     }
-                                },
-                                "body": {
-                                    "type": "text",
-                                    "index": true
                                 }
+                            },
+                            "body": {
+                                "type": "text",
+                                "index": true
                             }
                         }
                     }
-            }
-            '''
-        else:
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "comments_data": {
-                                    "dynamic":false,
-                                    "properties": {
-                                        "body": {
-                                            "type": "string",
-                                            "index": "analyzed"
-                                        }
-                                    }
-                                },
-                                "body": {
-                                    "type": "string",
-                                    "index": "analyzed"
-                                }
-                            }
-                        }
-                    }
-            }
-            '''
+                }
+        }
+        '''
 
         return {"items": mapping}
 

--- a/grimoire_elk/raw/jenkins.py
+++ b/grimoire_elk/raw/jenkins.py
@@ -41,28 +41,26 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "runs": {
-                                    "dynamic":false,
-                                    "properties": {}
-                                },
-                                "actions": {
-                                    "dynamic":false,
-                                    "properties": {}
-                                },
-                                "changeSet": {
-                                    "properties": {
-                                        "items": {
-                                            "properties": {
-                                                "comment": {
-                                                    "type": "text"
-                                                }
+        mapping = '''
+         {
+            "dynamic":true,
+                "properties": {
+                    "data": {
+                        "properties": {
+                            "runs": {
+                                "dynamic":false,
+                                "properties": {}
+                            },
+                            "actions": {
+                                "dynamic":false,
+                                "properties": {}
+                            },
+                            "changeSet": {
+                                "properties": {
+                                    "items": {
+                                        "properties": {
+                                            "comment": {
+                                                "type": "text"
                                             }
                                         }
                                     }
@@ -70,40 +68,9 @@ class Mapping(BaseMapping):
                             }
                         }
                     }
-            }
-            '''
-        else:
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "runs": {
-                                    "dynamic":false,
-                                    "properties": {}
-                                },
-                                "actions": {
-                                    "dynamic":false,
-                                    "properties": {}
-                                },
-                                "changeSet": {
-                                    "properties": {
-                                        "items": {
-                                            "properties": {
-                                                "comment": {
-                                                    "type": "string",
-                                                    "index": "analyzed"
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-            }
-            '''
+                }
+        }
+        '''
 
         return {"items": mapping}
 

--- a/grimoire_elk/raw/jira.py
+++ b/grimoire_elk/raw/jira.py
@@ -40,68 +40,36 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "renderedFields": {
-                                    "dynamic":false,
-                                    "properties": {}
-                                },
-                                "fields": {
-                                    "properties": {
-                                        "description": {
-                                            "type": "text",
-                                            "index": true
-                                        }
+        mapping = '''
+         {
+            "dynamic":true,
+                "properties": {
+                    "data": {
+                        "properties": {
+                            "renderedFields": {
+                                "dynamic":false,
+                                "properties": {}
+                            },
+                            "fields": {
+                                "properties": {
+                                    "description": {
+                                        "type": "text",
+                                        "index": true
                                     }
-                                },
-                                "changelog": {
-                                    "properties": {
-                                        "histories": {
-                                            "properties": {}
-                                        }
+                                }
+                            },
+                            "changelog": {
+                                "properties": {
+                                    "histories": {
+                                        "properties": {}
                                     }
                                 }
                             }
                         }
                     }
-            }
-            '''
-        else:
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "renderedFields": {
-                                    "dynamic":false,
-                                    "properties": {}
-                                },
-                                "fields": {
-                                    "properties": {
-                                        "description": {
-                                            "type": "string",
-                                            "index": "analyzed"
-                                        }
-                                    }
-                                },
-                                "changelog": {
-                                    "properties": {
-                                        "histories": {
-                                            "properties": {}
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-            }
-            '''
+                }
+        }
+        '''
 
         return {"items": mapping}
 

--- a/grimoire_elk/raw/mediawiki.py
+++ b/grimoire_elk/raw/mediawiki.py
@@ -37,46 +37,25 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "revisions": {
-                                    "properties": {
-                                        "comment": {
-                                            "type": "text",
-                                            "index": true
-                                        }
+        mapping = '''
+         {
+            "dynamic":true,
+                "properties": {
+                    "data": {
+                        "properties": {
+                            "revisions": {
+                                "properties": {
+                                    "comment": {
+                                        "type": "text",
+                                        "index": true
                                     }
                                 }
                             }
                         }
                     }
-            }
-            '''
-        else:
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "revisions": {
-                                    "properties": {
-                                        "comment": {
-                                            "type": "string",
-                                            "index": "analyzed"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-            }
-            '''
+                }
+        }
+        '''
 
         return {"items": mapping}
 

--- a/grimoire_elk/raw/meetup.py
+++ b/grimoire_elk/raw/meetup.py
@@ -37,25 +37,23 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "comments": {
-                                    "properties": {
-                                        "comment": {
-                                            "type": "text",
-                                            "index": true
-                                        },
-                                        "member": {
-                                            "properties": {
-                                                "bio": {
-                                                    "type": "text",
-                                                    "index": true
-                                                }
+        mapping = '''
+         {
+            "dynamic":true,
+                "properties": {
+                    "data": {
+                        "properties": {
+                            "comments": {
+                                "properties": {
+                                    "comment": {
+                                        "type": "text",
+                                        "index": true
+                                    },
+                                    "member": {
+                                        "properties": {
+                                            "bio": {
+                                                "type": "text",
+                                                "index": true
                                             }
                                         }
                                     }
@@ -63,36 +61,9 @@ class Mapping(BaseMapping):
                             }
                         }
                     }
-            }
-            '''
-        else:
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "comments": {
-                                    "properties": {
-                                        "comment": {
-                                            "type": "string",
-                                            "index": "analyzed"
-                                        },
-                                        "member": {
-                                            "properties": {
-                                                "bio": {
-                                                    "type": "string",
-                                                    "index": "analyzed"
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-            }
-            '''
+                }
+        }
+        '''
 
         return {"items": mapping}
 

--- a/grimoire_elk/raw/mozillaclub.py
+++ b/grimoire_elk/raw/mozillaclub.py
@@ -35,46 +35,25 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "Event Creations": {
-                                    "type": "text",
-                                    "index": true
-                                },
-                                "Event Description": {
-                                    "type": "text",
-                                    "index": true
-                                }
+        mapping = '''
+         {
+            "dynamic":true,
+                "properties": {
+                    "data": {
+                        "properties": {
+                            "Event Creations": {
+                                "type": "text",
+                                "index": true
+                            },
+                            "Event Description": {
+                                "type": "text",
+                                "index": true
                             }
                         }
                     }
-            }
-            '''
-        else:
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "Event Creations": {
-                                    "type": "string",
-                                    "index": "analyzed"
-                                },
-                                "Event Description": {
-                                    "type": "string",
-                                    "index": "analyzed"
-                                }
-                            }
-                        }
-                    }
-            }
-            '''
+                }
+        }
+        '''
 
         return {"items": mapping}
 

--- a/grimoire_elk/raw/redmine.py
+++ b/grimoire_elk/raw/redmine.py
@@ -40,54 +40,29 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "journals": {
-                                    "dynamic": false,
-                                    "properties": {}
-                                },
-                                "subject": {
-                                    "type": "text",
-                                    "index": true
-                                },
-                                "description": {
-                                    "type": "text",
-                                    "index": true
-                                }
+        mapping = '''
+         {
+            "dynamic":true,
+                "properties": {
+                    "data": {
+                        "properties": {
+                            "journals": {
+                                "dynamic": false,
+                                "properties": {}
+                            },
+                            "subject": {
+                                "type": "text",
+                                "index": true
+                            },
+                            "description": {
+                                "type": "text",
+                                "index": true
                             }
                         }
                     }
-            }
-            '''
-        else:
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "journals": {
-                                    "dynamic": false,
-                                    "properties": {}
-                                },
-                                "subject": {
-                                    "type": "string",
-                                    "index": "analyzed"
-                                },
-                                "description": {
-                                    "type": "string",
-                                    "index": "analyzed"
-                                }
-                            }
-                        }
-                    }
-            }
-            '''
+                }
+        }
+        '''
 
         return {"items": mapping}
 

--- a/grimoire_elk/raw/remo.py
+++ b/grimoire_elk/raw/remo.py
@@ -39,38 +39,21 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "description": {
-                                    "type": "text",
-                                    "index": true
-                                }
+        mapping = '''
+         {
+            "dynamic":true,
+                "properties": {
+                    "data": {
+                        "properties": {
+                            "description": {
+                                "type": "text",
+                                "index": true
                             }
                         }
                     }
-            }
-            '''
-        else:
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "description": {
-                                    "type": "string",
-                                    "index": "analyzed"
-                                }
-                            }
-                        }
-                    }
-            }
-            '''
+                }
+        }
+        '''
 
         return {"items": mapping}
 

--- a/grimoire_elk/raw/rss.py
+++ b/grimoire_elk/raw/rss.py
@@ -37,54 +37,29 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "content": {
-                                    "dynamic":false,
-                                    "properties": {}
-                                },
-                                "summary_detail": {
-                                    "dynamic":false,
-                                    "properties": {}
-                                },
-                                "summary": {
-                                    "type": "text",
-                                    "index": true
-                                }
+        mapping = '''
+         {
+            "dynamic":true,
+                "properties": {
+                    "data": {
+                        "properties": {
+                            "content": {
+                                "dynamic":false,
+                                "properties": {}
+                            },
+                            "summary_detail": {
+                                "dynamic":false,
+                                "properties": {}
+                            },
+                            "summary": {
+                                "type": "text",
+                                "index": true
                             }
                         }
                     }
-            }
-            '''
-        else:
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "content": {
-                                    "dynamic":false,
-                                    "properties": {}
-                                },
-                                "summary_detail": {
-                                    "dynamic":false,
-                                    "properties": {}
-                                },
-                                "summary": {
-                                    "type": "string",
-                                    "index": "analyzed"
-                                }
-                            }
-                        }
-                    }
-            }
-            '''
+                }
+        }
+        '''
 
         return {"items": mapping}
 

--- a/grimoire_elk/raw/stackexchange.py
+++ b/grimoire_elk/raw/stackexchange.py
@@ -37,54 +37,29 @@ class Mapping(BaseMapping):
         :returns:        dictionary with a key, 'items', with the mapping
         """
 
-        if es_major != '2':
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "body_markdown": {
-                                    "type": "text",
-                                    "index": true
-                                },
-                                "answers": {
-                                    "properties": {
-                                        "body_markdown": {
-                                            "type": "text",
-                                            "index": true
-                                        }
+        mapping = '''
+         {
+            "dynamic":true,
+                "properties": {
+                    "data": {
+                        "properties": {
+                            "body_markdown": {
+                                "type": "text",
+                                "index": true
+                            },
+                            "answers": {
+                                "properties": {
+                                    "body_markdown": {
+                                        "type": "text",
+                                        "index": true
                                     }
                                 }
                             }
                         }
                     }
-            }
-            '''
-        else:
-            mapping = '''
-             {
-                "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "body_markdown": {
-                                    "type": "string",
-                                    "index": "analyzed"
-                                },
-                                "answers": {
-                                    "properties": {
-                                        "body_markdown": {
-                                            "type": "string",
-                                            "index": "analyzed"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-            }
-            '''
+                }
+        }
+        '''
 
         return {"items": mapping}
 


### PR DESCRIPTION
This PR removes the code tailored to work with raw and enriched indexes in ES 2.x.
The PR has been splitted in several commits, one for data source, to simplify its reviewing. 
Note that this PR should be merged after https://github.com/chaoss/grimoirelab-elk/pull/328 to avoid failures with the tests relying on CSVs.