### PR TITLE
[stackexchange] Add fields to csv to track accepted answers

### DIFF
--- a/schema/stackoverflow.csv
+++ b/schema/stackoverflow.csv
@@ -1,4 +1,5 @@
 name,type
+answer_status,keyword
 answer_count,long
 answer_id,long
 answer_tags,keyword
@@ -18,6 +19,7 @@ down_vote_count,long
 favorite_count,long
 grimoire_creation_date,date
 is_accepted,boolean
+is_accepted_answer,long
 is_stackexchange_answer,long
 is_stackexchange_question,long
 last_activity_date,long
@@ -35,6 +37,8 @@ owner_name,keyword
 owner_org_name,keyword
 owner_user_name,keyword
 owner_uuid,keyword
+question_accepted_answer_id,long
+question_has_accepted_answer,boolean
 question_id,long
 question_tags_analyzed,keyword
 question_tags,keyword


### PR DESCRIPTION
This code add new fields to stackoverflow.csv about:
(i) whether a question has an accepted answer,
(ii) the id of the accepted answer.