### PR TITLE
[discourse] Add fields to csv to track accepted answers

### DIFF
--- a/schema/discourse.csv
+++ b/schema/discourse.csv
@@ -1,4 +1,5 @@
 name,type
+answer_status,keyword
 author_bot,boolean
 author_id,keyword
 author_name,keyword
@@ -15,6 +16,7 @@ first_answer,long
 first_reply_time,float
 grimoire_creation_date,date
 id,long
+is_accepted_answer,long
 is_discourse_answer,long
 is_discourse_question,long
 metadata__enriched_on,date
@@ -26,6 +28,8 @@ ocean-unique-id,keyword
 origin,keyword
 project_1,keyword
 project,keyword
+question_accepted_answer_id,long
+question_has_accepted_answer,boolean
 question_like_count,long
 question_participants,long
 question_pinned_at,date


### PR DESCRIPTION
This code add new fields to discourse.csv about:
(i) whether a question has an accepted answer,
(ii) the id of the accepted answer.