### PR TITLE
[stackexchange] Handle deleted users

### DIFF
--- a/grimoire_elk/enriched/stackexchange.py
+++ b/grimoire_elk/enriched/stackexchange.py
@@ -76,6 +76,9 @@ class StackExchangeEnrich(Enrich):
             # for answers
             user = item[identity_field]
 
+        if 'display_name' not in user:
+            user['display_name'] = ''
+
         identity['username'] = user['display_name']
         identity['email'] = None
         identity['name'] = user['display_name']


### PR DESCRIPTION
This PR targets https://github.com/chaoss/grimoirelab-elk/issues/336. It allows to handle deleted users on stackexchange platforms, which displayed names are now replaced with 'unknown' to avoid sortinghat failing when loading identities.