### PR TITLE
[onion] Check author bucket to make sure it exists

### DIFF
--- a/grimoire_elk/enriched/study_ceres_onion.py
+++ b/grimoire_elk/enriched/study_ceres_onion.py
@@ -267,7 +267,11 @@ class ESOnionConnector(ESConnector):
             latest_ts_list.append(timing[self.LATEST_TS].value_as_string)
             date_list.append(timing.key_as_string)
             uuid_list.append(author.key)
-            name_list.append(author[self.AUTHOR_NAME].buckets[0].key)
+            if author[self.AUTHOR_NAME] and author[self.AUTHOR_NAME].buckets \
+                    and len(author[self.AUTHOR_NAME].buckets) > 0:
+                name_list.append(author[self.AUTHOR_NAME].buckets[0].key)
+            else:
+                name_list.append("Unknown")
             contribs_list.append(author[self.CONTRIBUTIONS].value)
 
         df = pandas.DataFrame()


### PR DESCRIPTION
Though authors should always have a name in an enriched index,
this code does not assume it to avoid unexpected crashes.