### PR TITLE
[elk] raise exception in do_studies

### DIFF
--- a/grimoire_elk/elk.py
+++ b/grimoire_elk/elk.py
@@ -473,7 +473,7 @@ def do_studies(enrich_backend, no_incremental=False):
             study(enrich_backend, no_incremental)
     except Exception as e:
         logger.error("Problem executing study %s", study)
-        traceback.print_exc()
+        raise e
 
 
 def enrich_backend(url, clean, backend_name, backend_params, ocean_index=None,


### PR DESCRIPTION
This patch enables to raise an exception when a study fails, instead of printing the traceback. Thus, it allows Mordred to be aware that a thread has failed.