### PR TITLE
[studies][demography] Use author_id field to aggregate the authors instead of Author

### DIFF
--- a/grimoire_elk/enriched/git.py
+++ b/grimoire_elk/enriched/git.py
@@ -668,7 +668,7 @@ class GitEnrich(Enrich):
           "aggs": {
             "author": {
               "terms": {
-                "field": "Author",
+                "field": "author_id",
                 "size": 10000
               },
               "aggs": {
@@ -710,7 +710,7 @@ class GitEnrich(Enrich):
                 "bool": {
                     "must": [
                         {"term":
-                            { "Author" : ""  }
+                            { "author_id" : ""  }
                         }
                         ]
                 }
@@ -723,7 +723,7 @@ class GitEnrich(Enrich):
         for author in authors:
             # print("%s: %s %s" % (author['key'], author['min']['value_as_string'], author['max']['value_as_string']))
             # Time to add all the commits (items) from this author
-            author_query_json['query']['bool']['must'][0]['term']['Author'] = author['key']
+            author_query_json['query']['bool']['must'][0]['term']['author_id'] = author['key']
             author_query_str = json.dumps(author_query_json)
             r = self.requests.post(self.elastic.index_url + "/_search?size=10000",
                                    data=author_query_str, headers=HEADER_JSON,

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -76,6 +76,13 @@ class TestGit(TestBaseBackend):
         result = self._test_refresh_project()
         # ... ?
 
+    def test_demography_study(self):
+        """ Test that the demography study works correctly """
+        enriched_backend = self._test_studies(test_studies=['enrich_demography'])
+        for item in enriched_backend.fetch():
+            self.assertTrue('author_min_date' in item.keys())
+            self.assertTrue('author_max_date' in item.keys())
+
     def test_arthur_params(self):
         """Test the extraction of arthur params from an URL"""
 


### PR DESCRIPTION
The Author field has been removed from the enriched index because it contains the email
in some cases and all emails are being removed from enriched indexes in GrimoireLab.

https://github.com/chaoss/grimoirelab-elk/commit/bb66977d8f285f8c6d3fc52bb3ccf6ed1d3cd00b#diff-36823e8b50c4d2b1223f80fff5688bafL335