### PR TITLE
[enrich] Modify max length for keyword fields

### DIFF
--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -97,7 +97,7 @@ class Enrich(ElasticItems):
     kibiter_version = None
     RAW_FIELDS_COPY = ["metadata__updated_on", "metadata__timestamp",
                        "offset", "origin", "tag", "uuid"]
-    KEYWORD_MAX_SIZE = 32000  # this control allows to avoid max_bytes_length_exceeded_exception
+    KEYWORD_MAX_SIZE = 30000  # this control allows to avoid max_bytes_length_exceeded_exception
 
     def __init__(self, db_sortinghat=None, db_projects_map=None, json_projects_map=None,
                  db_user='', db_password='', db_host='', insecure=True):


### PR DESCRIPTION
This code sets to 30000 the max length for fields of type keyword, thus preventing immense term exceptions during the creation of enriched items.