### PR TITLE
[jira] Fix typo in enriched jira fields

### DIFF
--- a/grimoire_elk/enriched/jira.py
+++ b/grimoire_elk/enriched/jira.py
@@ -190,7 +190,7 @@ class JiraEnrich(Enrich):
         if 'description' in issue["fields"] and issue["fields"]['description']:
             eitem['main_description'] = issue["fields"]['description'][:self.KEYWORD_MAX_SIZE]
 
-        eitem['isssue_type'] = issue["fields"]['issuetype']['name']
+        eitem['issue_type'] = issue["fields"]['issuetype']['name']
         eitem['issue_description'] = issue["fields"]['issuetype']['description']
 
         if 'labels' in issue['fields']:

--- a/schema/jira.csv
+++ b/schema/jira.csv
@@ -28,7 +28,7 @@ creator_user_name,keyword
 creator_uuid,keyword
 grimoire_creation_date,date
 is_jira_issue,long
-isssue_type,keyword
+issue_type,keyword
 issue_description,keyword
 key,keyword
 labels,keyword


### PR DESCRIPTION
This PR addressed #361, thus it fixes a typo in jira enriched attribute and aligns the change with the corresponding csv schema.