### PR TITLE
[stackexchage] Fix fields for questions having an accepted answer

### DIFF
--- a/grimoire_elk/enriched/stackexchange.py
+++ b/grimoire_elk/enriched/stackexchange.py
@@ -154,7 +154,7 @@ class StackExchangeEnrich(Enrich):
             eitem['question_has_accepted_answer'] = 0
             eitem['question_accepted_answer_id'] = None
 
-            if question['answer_count'] > 1:
+            if question['answer_count'] >= 1:
                 answers_id = [p['answer_id'] for p in question['answers']
                               if 'is_accepted' in p and p['is_accepted']]
                 eitem['question_accepted_answer_id'] = answers_id[0] if answers_id else None


### PR DESCRIPTION
This patch fixes a bug that was causing to not properly fill the fields `question_accepted_answer_id` and `question_has_accepted_answer` for questions having only one answer (which was marked as accepted).