### PR TITLE
[enriched] Add `latest_date` method to connector

### DIFF
--- a/grimoire_elk/enriched/ceres_base.py
+++ b/grimoire_elk/enriched/ceres_base.py
@@ -50,6 +50,9 @@ class Connector:
     def write(self, items):
         raise NotImplementedError
 
+    def latest_date(self):
+        raise NotImplementedError
+
 
 class CeresBase:
     """Base class to process items and create enriched indexes.


### PR DESCRIPTION
`latest_date` is used by CeresBase but was not included in the
definition Connector abstract class.

This is not a high priority bug as it does not affect to code execution.

Solves #340 