### PR TITLE
[bugzilla] Fix immense term exception for activity attribute

### DIFF
--- a/grimoire_elk/raw/bugzilla.py
+++ b/grimoire_elk/raw/bugzilla.py
@@ -57,6 +57,10 @@ class Mapping(BaseMapping):
                                         "index": true
                                     }
                                 }
+                            },
+                            "activity": {
+                                "dynamic": false,
+                                "properties": {}
                             }
                         }
                     }


### PR DESCRIPTION
This code avoids indexing fields within the activity attribute, thus avoiding immense term exception when inserting raw data to ElasticSearch.