### PR TITLE
[tests] Allow testing with latest grimoirelab component versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,20 +12,13 @@ services:
 before_install:
   - pip install flake8
   - pip install coveralls
-  - pip install kingarthur
-  - pip install perceval
-  - pip install perceval-mozilla
-  - pip install perceval-opnfv
-  - pip install perceval-puppet
   - pip install pandas==0.18.1
   - pip install redis
-  - pip install sortinghat
   - pip install PyMySQL
   - pip install httpretty==0.8.6
-  - pip install cereslib
   - pip install elasticsearch==5.5.1
   - pip install elasticsearch-dsl==5.3.0
-  - pip install grimoirelab-toolkit
+  - pip install -r "requirements.txt"
 
 #install:
 #   - ./setup.py install

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+PyMySQL
+elasticsearch>=5.5.2
+elasticsearch-dsl>=5.3.0
+-e git+https://github.com/chaoss/grimoirelab-sortinghat/#egg=grimoirelab-sortinghat
+-e git+https://github.com/chaoss/grimoirelab-toolkit/#egg=grimoirelab-toolkit
+-e git+https://github.com/chaoss/grimoirelab-cereslib/#egg=grimoirelab-cereslib
+-e git+https://github.com/chaoss/grimoirelab-kingarthur/#egg=grimoirelab-kingarthur
+-e git+https://github.com/chaoss/grimoirelab-perceval/#egg=grimoirelab-perceval
+-e git+https://github.com/chaoss/grimoirelab-perceval-mozilla/#egg=grimoirelab-perceval-mozilla
+-e git+https://github.com/chaoss/grimoirelab-perceval-opnfv/#egg=grimoirelab-perceval-opnfv
+-e git+https://github.com/chaoss/grimoirelab-perceval-puppet/#egg=grimoirelab-perceval-puppet


### PR DESCRIPTION
This code allows to execute the tests using the latest versionsof the grimoirelab components required by E LK, thus simplyfing the testing of features that involve more components. The components are:
- grimoirelab-sortinghat
- grimoirelab-toolkit
- grimoirelab-cereslib
- grimoirelab-kingarthur
- grimoirelab-perceval
- grimoirelab-perceval-mozilla
- grimoirelab-perceval-opnfv
- grimoirelab-perceval-puppet