### PR TITLE
[tests] Add support for test using SSL

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -144,10 +144,10 @@ class TestBaseBackend(unittest.TestCase):
 
     def tearDown(self):
         delete_raw = self.es_con + "/" + self.ocean_index
-        requests.delete(delete_raw)
+        requests.delete(delete_raw, verify=False)
 
         delete_enrich = self.es_con + "/" + self.enrich_index
-        requests.delete(delete_enrich)
+        requests.delete(delete_enrich, verify=False)
 
     def _test_items_to_raw(self):
         """Test whether fetched items are properly loaded to ES"""


### PR DESCRIPTION
When using secure envs, for instance those versions
of Kibiter including Search Guard, test will fail
if certificate cannot be verified. Including this
change, certificate validation is disabled so tests
can be run without the need of a valid certificate.