### PR TITLE
[enrich] Include ocean backend to studies

### DIFF
--- a/grimoire_elk/elk.py
+++ b/grimoire_elk/elk.py
@@ -466,14 +466,14 @@ def get_ocean_backend(backend_cmd, enrich_backend, no_incremental,
     return ocean_backend
 
 
-def do_studies(enrich_backend, studies_args):
+def do_studies(ocean_backend, enrich_backend, studies_args):
     for study in enrich_backend.studies:
         selected_studies = [(s['name'], s['params']) for s in studies_args if s['type'] == study.__name__]
 
         for (name, params) in selected_studies:
             logger.info("Starting study: %s, params %s", name, str(params))
             try:
-                study(enrich_backend, **params)
+                study(ocean_backend, enrich_backend, **params)
             except Exception as e:
                 logger.error("Problem executing study %s, %s", name, str(e))
                 raise e
@@ -568,7 +568,7 @@ def enrich_backend(url, clean, backend_name, backend_params,
 
         if only_studies:
             logger.info("Running only studies (no SH and no enrichment)")
-            do_studies(enrich_backend, studies_args)
+            do_studies(ocean_backend, enrich_backend, studies_args)
         elif do_refresh_projects:
             logger.info("Refreshing project field in %s", enrich_backend.elastic.index_url)
             field_id = enrich_backend.get_field_unique_id()
@@ -615,7 +615,7 @@ def enrich_backend(url, clean, backend_name, backend_params,
                     if enrich_count is not None:
                         logger.info("Total events enriched %i ", enrich_count)
                 if studies:
-                    do_studies(enrich_backend, studies_args)
+                    do_studies(ocean_backend, enrich_backend, studies_args)
 
     except Exception as ex:
         logger.error("%s", traceback.format_exc())

--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -846,13 +846,13 @@ class Enrich(ElasticItems):
 
         return sh_ids
 
-    def enrich_onion(self, enrich_backend, in_index, out_index, data_source, contribs_field,
-                     timeframe_field, sort_on_field, no_incremental=False):
+    def enrich_onion(self, enrich_backend, in_index, out_index, data_source,
+                     contribs_field, timeframe_field, sort_on_field, no_incremental=False):
 
         logger.info("[Onion] Starting study")
 
         # Creating connections
-        es = Elasticsearch([self.elastic.url], timeout=100, verify_certs=self.elastic.requests.verify)
+        es = Elasticsearch([enrich_backend.elastic.url], timeout=100, verify_certs=self.elastic.requests.verify)
         in_conn = ESOnionConnector(es_conn=es, es_index=in_index,
                                    contribs_field=contribs_field,
                                    timeframe_field=timeframe_field,

--- a/grimoire_elk/enriched/git.py
+++ b/grimoire_elk/enriched/git.py
@@ -594,7 +594,7 @@ class GitEnrich(Enrich):
 
         return total
 
-    def enrich_demography(self, enrich_backend, no_incremental=False):
+    def enrich_demography(self, ocean_backend, enrich_backend, no_incremental=False):
 
         from_date = None
 
@@ -757,16 +757,17 @@ class GitEnrich(Enrich):
 
         logger.debug("Completed demography enrich from %s" % (self.elastic.index_url))
 
-    def enrich_areas_of_code(self, enrich_backend, no_incremental=False,
+    def enrich_areas_of_code(self, ocean_backend, enrich_backend, no_incremental=False,
                              in_index="git-raw",
                              out_index="git_aoc-enriched",
                              sort_on_field='metadata__timestamp'):
         logger.info("[Areas of Code] Starting study")
 
         # Creating connections
-        es = Elasticsearch([self.elastic.url], timeout=100, verify_certs=self.elastic.requests.verify)
-        in_conn = ESPandasConnector(es_conn=es, es_index=in_index, sort_on_field=sort_on_field)
-        out_conn = ESPandasConnector(es_conn=es, es_index=out_index, sort_on_field=sort_on_field,
+        es_in = Elasticsearch([ocean_backend.elastic.url], timeout=100, verify_certs=self.elastic.requests.verify)
+        es_out = Elasticsearch([enrich_backend.elastic.url], timeout=100, verify_certs=self.elastic.requests.verify)
+        in_conn = ESPandasConnector(es_conn=es_in, es_index=in_index, sort_on_field=sort_on_field)
+        out_conn = ESPandasConnector(es_conn=es_out, es_index=out_index, sort_on_field=sort_on_field,
                                      read_only=False)
 
         exists_index = out_conn.exists()
@@ -788,7 +789,7 @@ class GitEnrich(Enrich):
 
         logger.info("[Areas of Code] End")
 
-    def enrich_onion(self, enrich_backend, no_incremental=False,
+    def enrich_onion(self, ocean_backend, enrich_backend, no_incremental=False,
                      in_index='git_onion-src',
                      out_index='git_onion-enriched',
                      data_source='git',

--- a/grimoire_elk/enriched/github.py
+++ b/grimoire_elk/enriched/github.py
@@ -379,7 +379,8 @@ class GitHubEnrich(Enrich):
 
         return total
 
-    def enrich_onion(self, enrich_backend, no_incremental=False,
+    def enrich_onion(self, ocean_backend, enrich_backend,
+                     no_incremental=False,
                      in_index_iss='github_issues_onion-src',
                      in_index_prs='github_prs_onion-src',
                      out_index_iss='github_issues_onion-enriched',

--- a/grimoire_elk/enriched/mbox.py
+++ b/grimoire_elk/enriched/mbox.py
@@ -243,6 +243,6 @@ class MBoxEnrich(Enrich):
 
         return total
 
-    def kafka_kip(self, enrich_backend, no_incremental=False):
+    def kafka_kip(self, ocean_backend, enrich_backend, no_incremental=False):
         # KIP study is not incremental
         kafka_kip(self)

--- a/tests/base.py
+++ b/tests/base.py
@@ -287,6 +287,6 @@ class TestBaseBackend(unittest.TestCase):
             if test_studies:
                 if study.__name__ not in test_studies:
                     continue
-            study(enrich_backend)
+            study(ocean_backend, enrich_backend)
 
         return enrich_backend


### PR DESCRIPTION
This code adds the ocean backend as parameter for studies. This modification is required since some studies need access to the raw index (which could be stored in a different machine).