### PR TITLE
[enriched] Add support for github pull request data

### DIFF
--- a/grimoire_elk/raw/github.py
+++ b/grimoire_elk/raw/github.py
@@ -52,6 +52,19 @@ class Mapping(BaseMapping):
                                     }
                                 }
                             },
+                            "review_comments_data": {
+                                "dynamic":false,
+                                "properties": {
+                                    "body": {
+                                        "type": "text",
+                                        "index": true
+                                    },
+                                   "diff_hunk": {
+                                       "type": "text",
+                                       "index": true
+                                   }
+                                }
+                            },
                             "body": {
                                 "type": "text",
                                 "index": true


### PR DESCRIPTION
The main aim of this PR is to trigger the discussion about how to integrate GitHub pull request data in GrimoireLab. This PR proposes to extend GitHubOcean and GitHubEnrich to include the new data without creating [a new connector](https://github.com/chaoss/grimoirelab-elk/blob/master/grimoire_elk/utils.py#L189). Conversely, PR https://github.com/chaoss/grimoirelab-elk/pull/398 proposes to add a new connector to ELK.

This PR requires a modification to mordred (PR https://github.com/chaoss/grimoirelab-sirmordred/pull/175) in order to allow the definition of multiple sections for the same backend (thus enabling the explotation of backends with multiple categories in a transparent way). On the other hand, PR https://github.com/chaoss/grimoirelab-elk/pull/398 doesn't need to modify mordred, however it implies the creation of a dedicated connector for each category of a backend.

Given that both solutions have advantages and drawbacks, what are your thoughts @acs @jgbarah @aswanipranjal ?