### PR TITLE
[studies] Add enrich_pull_requests study

### DIFF
--- a/grimoire_elk/enriched/git.py
+++ b/grimoire_elk/enriched/git.py
@@ -600,7 +600,7 @@ class GitEnrich(Enrich):
         in which the author of the item had activity in the data source. In the case of git
         the fields author_min_date and author_max_date are added.
 
-        In order to implement the algorithm first, the possible min and max data are found for
+        In order to implement the algorithm first, the possible min and max date are found for
         all the authors. To have the incremental support, only the new commits (or the commits without
         a author_min_date or author_max_date) are evaluated in order to find the authors which
         have updated information.


### PR DESCRIPTION
This code adds the `enrich_pull_requests` study to the enriched/github.py
file. This study aims at adding additional fields that are related to
pull request items but are not fetched by perceval directly for items of the
pull_requests category.
This study should be used using the functionality added by the PR:
https://github.com/chaoss/grimoirelab-sirmordred/pull/190.

This study takes in an input param: `raw_issues_index` which should contain
the data fetched from the same repository from which the pull requests data
is fetched. Using this `raw_issues_index`, the additional data is extracted from
related issue and that data is enriched and added to the relevant pull request
and updated in the enriched pull request index.

The specific fields that are added after running the study are:
- `time_to_merge_request_response`: This was already present in the pull requests enriched index. This field is updated to show the minimum date between a first review or a first comment
- `num_comments`: number of `comments` (not review comments) made on the pull request
- `pr_comment_duration`: the difference between the creation date of the pull request and the latest comment on the pull request.
- `pr_comment_diversity`: the number of different people discussing (commenting) on the pull request

for the last 2, should we consider the review comments also?