### PR TITLE
[enrich-slack] Use `num_members` attribute to count channel members

### DIFF
--- a/grimoire_elk/enriched/slack.py
+++ b/grimoire_elk/enriched/slack.py
@@ -181,7 +181,10 @@ class SlackEnrich(Enrich):
         eitem['channel_name'] = channel['name']
         eitem['channel_id'] = channel['id']
         eitem['channel_created'] = channel['created']
-        eitem['channel_member_count'] = len(channel['members'])
+        # Due to a Slack API change, the list of members is returned paginated, thus the new attribute `num_members`
+        # has been added to the Slack Perceval backend. In order to avoid breaking changes, the former
+        # variable `members` is kept and used only if `num_members` is not present in the input item.
+        eitem['channel_member_count'] = channel['num_members'] if 'num_members' in channel else len(channel['members'])
         if 'topic' in channel:
             eitem['channel_topic'] = channel['topic']
         if 'purpose' in channel:

--- a/tests/data/slack.json
+++ b/tests/data/slack.json
@@ -144,6 +144,7 @@
             ],
             "name": "test channel",
             "name_normalized": "test channel",
+            "num_members": 4565,
             "previous_names": [],
             "purpose": {
                 "creator": "",
@@ -198,6 +199,7 @@
             ],
             "name": "test channel",
             "name_normalized": "test channel",
+            "num_members": 4565,
             "previous_names": [],
             "purpose": {
                 "creator": "",
@@ -284,6 +286,7 @@
             ],
             "name": "test channel",
             "name_normalized": "test channel",
+            "num_members": 4565,
             "previous_names": [],
             "purpose": {
                 "creator": "",
@@ -371,6 +374,7 @@
             ],
             "name": "test channel",
             "name_normalized": "test channel",
+            "num_members": 4565,
             "previous_names": [],
             "purpose": {
                 "creator": "",
@@ -458,6 +462,7 @@
             ],
             "name": "test channel",
             "name_normalized": "test channel",
+            "num_members": 4565,
             "previous_names": [],
             "purpose": {
                 "creator": "",
@@ -548,6 +553,7 @@
             ],
             "name": "test channel",
             "name_normalized": "test channel",
+            "num_members": 4565,
             "previous_names": [],
             "purpose": {
                 "creator": "",
@@ -638,6 +644,7 @@
             ],
             "name": "test channel",
             "name_normalized": "test channel",
+            "num_members": 4565,
             "previous_names": [],
             "purpose": {
                 "creator": "",
@@ -725,6 +732,7 @@
             ],
             "name": "test channel",
             "name_normalized": "test channel",
+            "num_members": 4565,
             "previous_names": [],
             "purpose": {
                 "creator": "",

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -51,6 +51,16 @@ class TestSlack(TestBaseBackend):
         self.assertEqual(result['raw'], 9)
         self.assertEqual(result['enrich'], 9)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        item = self.items[0]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['channel_member_count'], 3)
+
+        for item in self.items[1:]:
+            eitem = enrich_backend.get_rich_item(item)
+            self.assertEqual(eitem['channel_member_count'], 4565)
+
     def test_raw_to_enrich_sorting_hat(self):
         """Test enrich with SortingHat"""
 


### PR DESCRIPTION
This code uses the attribute `num_members` in a Perceval Slack JSON doc to count the members of a Slack channel. However, in order to avoid breaking changes, the former variable `member` is kept and used only if `num_members` is not present in the input document.