### PR TITLE
[enrich-mediawiki] Change way url is created

### DIFF
--- a/grimoire_elk/enriched/mediawiki.py
+++ b/grimoire_elk/enriched/mediawiki.py
@@ -157,7 +157,7 @@ class MediaWikiEnrich(Enrich):
                 eitem.update(self.get_item_project(erevision))
 
             # And now some calculated fields
-            erevision["url"] = erevision["page_origin"] + "/view/" + erevision["page_title"]
+            erevision["url"] = erevision["page_origin"] + "/" + erevision["page_title"]
             erevision["url"] = erevision["url"].replace(" ", "_")
             erevision["iscreated"] = 0
             erevision["creation_date"] = None

--- a/tests/test_mediawiki.py
+++ b/tests/test_mediawiki.py
@@ -50,6 +50,14 @@ class TestMediawiki(TestBaseBackend):
         self.assertEqual(result['raw'], 3)
         self.assertEqual(result['enrich'], 8)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        item = self.items[0]
+        eitems = enrich_backend.get_rich_item_reviews(item)
+
+        for ei in eitems:
+            self.assertEqual(ei['url'], 'https://wiki.mozilla.org/Main_Page/QA/NoMore404s')
+
     def test_raw_to_enrich_sorting_hat(self):
         """Test enrich with SortingHat"""
 


### PR DESCRIPTION
Due to a wikimedia API change, the old way of creating a URL is not valid anymore. Thus, this code proposes a new way to form the URLs, allowing to access the corresponding pages via the kibiter dashboard.