### PR TITLE
[enrich-git] Handle commits with missing user info

### DIFF
--- a/grimoire_elk/enriched/git.py
+++ b/grimoire_elk/enriched/git.py
@@ -229,6 +229,9 @@ class GitEnrich(Enrich):
         identity['email'] = email
         identity['name'] = name
 
+        if not identity['username'] and not identity['email']:
+            identity['name'] = 'Unknown'
+
         return identity
 
     def get_project_repository(self, eitem):

--- a/tests/data/git.json
+++ b/tests/data/git.json
@@ -5,7 +5,7 @@
     "data": {
         "Author": "Eduardo Morais <companheiro.vermelho@gmail.com>",
         "AuthorDate": "Tue Aug 14 14:30:13 2012 -0300",
-        "Commit": "Eduardo Morais <companheiro.vermelho@gmail.com>",
+        "Commit": "",
         "CommitDate": "Tue Aug 14 14:30:13 2012 -0300",
         "commit": "bc57a9209f096a130dcc5ba7089a8663f758a703",
         "files": [

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -53,6 +53,17 @@ class TestGit(TestBaseBackend):
         self.assertEqual(result['raw'], 9)
         self.assertEqual(result['enrich'], 9)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        item = self.items[0]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['committer_name'], 'Unknown')
+
+        for item in self.items[1:]:
+            eitem = enrich_backend.get_rich_item(item)
+            self.assertNotEqual(eitem['committer_name'], 'Unknown')
+            self.assertNotEqual(eitem['author_name'], 'Unknown')
+
     def test_raw_to_enrich_sorting_hat(self):
         """Test enrich with SortingHat"""
 


### PR DESCRIPTION
This code allows to handle commits for which no author/committer are defined. For these (rare) cases, the name of the user is set to `Unknown`, while the email to None.