### PR TITLE
[enriched-jira] Set Unassigned to null assignee orgs and usernames

### DIFF
--- a/grimoire_elk/enriched/jira.py
+++ b/grimoire_elk/enriched/jira.py
@@ -257,6 +257,15 @@ class JiraEnrich(Enrich):
         if self.sortinghat:
             eitem.update(self.get_item_sh(item, self.roles))
 
+            if not eitem['assignee_name']:
+                eitem['assignee_name'] = 'Unassigned'
+
+            if not eitem['assignee_org_name']:
+                eitem['assignee_org_name'] = 'Unassigned'
+
+            if not eitem['assignee_user_name']:
+                eitem['assignee_user_name'] = 'Unassigned'
+
         if self.prjs_map:
             eitem.update(self.get_item_project(eitem))
 

--- a/tests/data/jira.json
+++ b/tests/data/jira.json
@@ -406,20 +406,7 @@
             "aggregatetimeestimate": null,
             "aggregatetimeoriginalestimate": null,
             "aggregatetimespent": null,
-            "assignee": {
-                "active": true,
-                "avatarUrls": {
-                    "16x16": "https://secure.gravatar.com/avatar/9563a6aa56787546aa5801b81afd25ca?d=mm&s=16",
-                    "24x24": "https://secure.gravatar.com/avatar/9563a6aa56787546aa5801b81afd25ca?d=mm&s=24",
-                    "32x32": "https://secure.gravatar.com/avatar/9563a6aa56787546aa5801b81afd25ca?d=mm&s=32",
-                    "48x48": "https://secure.gravatar.com/avatar/9563a6aa56787546aa5801b81afd25ca?d=mm&s=48"
-                },
-                "displayName": "Ethan Brown",
-                "key": "ethan",
-                "name": "ethan",
-                "self": "https://tickets.puppetlabs.com/rest/api/2/user?username=ethan",
-                "timeZone": "America/Los_Angeles"
-            },
+            "assignee": {},
             "components": [],
             "created": "2016-07-26T14:25:28.000-0700",
             "creator": {

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -57,6 +57,21 @@ class TestJira(TestBaseBackend):
         self.assertEqual(result['raw'], 5)
         self.assertEqual(result['enrich'], 5)
 
+        enrich_backend = self.connectors[self.connector][2]()
+        enrich_backend.sortinghat = True
+
+        item = self.items[0]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['assignee_name'], 'Unassigned')
+        self.assertEqual(eitem['assignee_org_name'], 'Unassigned')
+        self.assertEqual(eitem['assignee_user_name'], 'Unassigned')
+
+        item = self.items[1]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertNotEqual(eitem['assignee_name'], 'Unassigned')
+        self.assertNotEqual(eitem['assignee_org_name'], 'Unassigned')
+        self.assertNotEqual(eitem['assignee_user_name'], 'Unassigned')
+
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 


### PR DESCRIPTION
This code sets all `assignee_name`, `assignee_org_name` and`assignee_user_name` null attributes of issues to `Unassigned`, thus avoiding to visualize results with no values.