### PR TITLE
[elk] Modify logic to load new identities to SH

### DIFF
--- a/grimoire_elk/elk.py
+++ b/grimoire_elk/elk.py
@@ -378,13 +378,13 @@ def load_identities(ocean_backend, enrich_backend):
             if identity not in new_identities:
                 new_identities.append(identity)
 
-        if items_count % 500 == 0:
-            inserted_identities = load_bulk_identities(items_count,
-                                                       new_identities,
-                                                       enrich_backend.sh_db,
-                                                       enrich_backend.get_connector_name())
-            identities_count += inserted_identities
-            new_identities = []
+            if len(new_identities) > 100:
+                inserted_identities = load_bulk_identities(items_count,
+                                                           new_identities,
+                                                           enrich_backend.sh_db,
+                                                           enrich_backend.get_connector_name())
+                identities_count += inserted_identities
+                new_identities = []
 
     if new_identities:
         inserted_identities = load_bulk_identities(items_count,


### PR DESCRIPTION
This code modifies the logic of the method `load_identities` with the intent of improving the memory consumption of ELK. New identities are loaded in bulks of 100, limiting the size of the list containing them.