### PR TITLE
[enrich-mbox] Replace lists with yields

### DIFF
--- a/grimoire_elk/enriched/mbox.py
+++ b/grimoire_elk/enriched/mbox.py
@@ -81,14 +81,12 @@ class MBoxEnrich(Enrich):
 
     def get_identities(self, item):
         """ Return the identities from an item """
-        identities = []
 
         item = item['data']
         for identity in ['From']:
             if identity in item and item[identity]:
                 user = self.get_sh_identity(item[identity])
-                identities.append(user)
-        return identities
+                yield user
 
     def get_sh_identity(self, item, identity_field=None):
         # "From": "hwalsh at wikiledia.net (Heat Walsh)"


### PR DESCRIPTION
This code optimizes the memory consumption of the mbox enricher. Thus, it replaces the list in the method `get_identities` with a yield statement.