### PR TITLE
[enrich-meetup] Fix error printing the number of comments and RSVPs

### DIFF
--- a/grimoire_elk/enriched/meetup.py
+++ b/grimoire_elk/enriched/meetup.py
@@ -361,11 +361,11 @@ class MeetupEnrich(Enrich):
             if ncomments != icomments:
                 missing = ncomments - icomments
                 logger.error("%s/%s missing comments for Meetup",
-                             str(missing), str(len(ncomments)))
+                             str(missing), str(ncomments))
 
             if nrsvps != irsvps:
                 missing = nrsvps - irsvps
                 logger.error("%s/%s missing rsvps for Meetup",
-                             str(missing), str(len(nrsvps)))
+                             str(missing), str(nrsvps))
 
         return nitems


### PR DESCRIPTION
This error was introduced in bb91ac23bc8644706116c0637b920ebd4ecd66e6 when lists were replaced by iterators. `ncomments` and `nrsvps` variables are integers and not lists.