### PR TITLE
[enrich-stackexchange] Add 'origin' and 'tag' fields to answer items

### DIFF
--- a/grimoire_elk/enriched/stackexchange.py
+++ b/grimoire_elk/enriched/stackexchange.py
@@ -181,7 +181,7 @@ class StackExchangeEnrich(Enrich):
                 eitem["author_reputation"] = answer['owner']['reputation']
 
             # data fields to copy
-            copy_fields = common_fields + ["creation_date", "is_accepted", "answer_id"]
+            copy_fields = common_fields + ["origin", "tag", "creation_date", "is_accepted", "answer_id"]
             for f in copy_fields:
                 if f in answer:
                     eitem[f] = answer[f]
@@ -244,6 +244,10 @@ class StackExchangeEnrich(Enrich):
             # Time to enrich also de answers
             if 'answers' in item['data']:
                 for answer in item['data']['answers']:
+                    # Copy mandatory raw fields
+                    answer['origin'] = item['origin']
+                    answer['tag'] = item['tag']
+
                     rich_answer = self.get_rich_item(answer, kind='answer', question_tags=rich_item['question_tags'])
                     data_json = json.dumps(rich_answer)
                     bulk_json += '{"index" : {"_id" : "%i_%i" } }\n' % \

--- a/tests/data/stackexchange.json
+++ b/tests/data/stackexchange.json
@@ -168,6 +168,7 @@
     },
     "origin": "stackoverflow",
     "perceval_version": "0.2.0",
+    "tag": "stackoverflow-test",
     "timestamp": 1469619644.7069,
     "updated_on": 1469619561.0,
     "uuid": "0fd3068ee3b9dac0187f2208e220fadac120eb2f"
@@ -214,6 +215,7 @@
     },
     "origin": "stackoverflow",
     "perceval_version": "0.2.0",
+    "tag": "stackoverflow-test",
     "timestamp": 1469619644.708539,
     "updated_on": 1469619535.0,
     "uuid": "3d23ae2ab783b939b354057b20671c55fa4f2187"
@@ -318,7 +320,7 @@
     },
     "origin": "stackoverflow",
     "perceval_version": "0.9.10",
-    "tag": "stackoverflow",
+    "tag": "stackoverflow-test",
     "timestamp": 1518165823.432987,
     "updated_on": 1459975066.0,
     "uuid": "43953bd75d1d4dbedb457059acb4b79fcf6712a8"


### PR DESCRIPTION
So far, Stack Exchange enriched answers did not contain these two attributes. This caused some errors, like to assing a project to an answers due to the mapping between project and answers was done using 'origin' field.

Fixes #436.