### PR TITLE
[enrich] Set identities fields to UNDEFINED for null values

### DIFF
--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -626,10 +626,10 @@ class Enrich(ElasticItems):
                     break
         return enroll
 
-    def __get_item_sh_fields_empty(self, rol):
+    def __get_item_sh_fields_empty(self, rol, undefined=False):
         """ Return a SH identity with all fields to empty_field """
         # If empty_field is None, the fields do not appear in index patterns
-        empty_field = ''
+        empty_field = '' if not undefined else '-- UNDEFINED --'
         return {
             rol + "_id": empty_field,
             rol + "_uuid": empty_field,
@@ -665,7 +665,7 @@ class Enrich(ElasticItems):
 
         # If the identity does not exists return and empty identity
         if rol + "_uuid" not in eitem_sh or not eitem_sh[rol + "_uuid"]:
-            return self.__get_item_sh_fields_empty(rol)
+            return self.__get_item_sh_fields_empty(rol, undefined=True)
 
         # Get the SH profile to use first this data
         profile = self.get_profile_sh(eitem_sh[rol + "_uuid"])

--- a/tests/test_enrich.py
+++ b/tests/test_enrich.py
@@ -199,15 +199,15 @@ class TestEnrich(unittest.TestCase):
 
         # Method to test
         eitem_sh = self._enrich.get_item_sh_fields(identity=identity)
-        self.assertEqual(eitem_sh['author_id'], self.empty_item['author_id'])
-        self.assertEqual(eitem_sh['author_uuid'], self.empty_item['author_uuid'])
-        self.assertEqual(eitem_sh['author_name'], self.empty_item['author_name'])
-        self.assertEqual(eitem_sh['author_user_name'], self.empty_item['author_user_name'])
-        self.assertEqual(eitem_sh['author_domain'], self.empty_item['author_domain'])
-        self.assertEqual(eitem_sh['author_gender'], self.empty_item['author_gender'])
-        self.assertEqual(eitem_sh['author_gender_acc'], self.empty_item['author_gender_acc'])
-        self.assertEqual(eitem_sh['author_org_name'], self.empty_item['author_org_name'])
-        self.assertEqual(eitem_sh['author_bot'], self.empty_item['author_bot'])
+        self.assertEqual(eitem_sh['author_id'], '-- UNDEFINED --')
+        self.assertEqual(eitem_sh['author_uuid'], '-- UNDEFINED --')
+        self.assertEqual(eitem_sh['author_name'], '-- UNDEFINED --')
+        self.assertEqual(eitem_sh['author_user_name'], '-- UNDEFINED --')
+        self.assertEqual(eitem_sh['author_domain'], '-- UNDEFINED --')
+        self.assertEqual(eitem_sh['author_gender'], '-- UNDEFINED --')
+        self.assertEqual(eitem_sh['author_gender_acc'], None)
+        self.assertEqual(eitem_sh['author_org_name'], '-- UNDEFINED --')
+        self.assertEqual(eitem_sh['author_bot'], False)
 
         # 2. No uuid field
         sh_ids = {
@@ -217,15 +217,15 @@ class TestEnrich(unittest.TestCase):
 
         # Method to test
         eitem_sh = self._enrich.get_item_sh_fields(identity=identity)
-        self.assertEqual(eitem_sh['author_id'], self.empty_item['author_id'])
-        self.assertEqual(eitem_sh['author_uuid'], self.empty_item['author_uuid'])
-        self.assertEqual(eitem_sh['author_name'], self.empty_item['author_name'])
-        self.assertEqual(eitem_sh['author_user_name'], self.empty_item['author_user_name'])
-        self.assertEqual(eitem_sh['author_domain'], self.empty_item['author_domain'])
-        self.assertEqual(eitem_sh['author_gender'], self.empty_item['author_gender'])
-        self.assertEqual(eitem_sh['author_gender_acc'], self.empty_item['author_gender_acc'])
-        self.assertEqual(eitem_sh['author_org_name'], self.empty_item['author_org_name'])
-        self.assertEqual(eitem_sh['author_bot'], self.empty_item['author_bot'])
+        self.assertEqual(eitem_sh['author_id'], '-- UNDEFINED --')
+        self.assertEqual(eitem_sh['author_uuid'], '-- UNDEFINED --')
+        self.assertEqual(eitem_sh['author_name'], '-- UNDEFINED --')
+        self.assertEqual(eitem_sh['author_user_name'], '-- UNDEFINED --')
+        self.assertEqual(eitem_sh['author_domain'], '-- UNDEFINED --')
+        self.assertEqual(eitem_sh['author_gender'], '-- UNDEFINED --')
+        self.assertEqual(eitem_sh['author_gender_acc'], None)
+        self.assertEqual(eitem_sh['author_org_name'], '-- UNDEFINED --')
+        self.assertEqual(eitem_sh['author_bot'], False)
 
     def test_get_item_sh_fields_identity_no_profile(self):
         """Test retrieval when no profile data is found or data is not what we expected"""
@@ -519,15 +519,15 @@ class TestEnrich(unittest.TestCase):
 
         # Method to test
         eitem_sh = self._enrich.get_item_sh_fields(sh_id=sh_id)
-        self.assertEqual(eitem_sh['author_id'], self.empty_item['author_id'])
-        self.assertEqual(eitem_sh['author_uuid'], self.empty_item['author_uuid'])
-        self.assertEqual(eitem_sh['author_name'], self.empty_item['author_name'])
-        self.assertEqual(eitem_sh['author_user_name'], self.empty_item['author_user_name'])
-        self.assertEqual(eitem_sh['author_domain'], self.empty_item['author_domain'])
-        self.assertEqual(eitem_sh['author_gender'], self.empty_item['author_gender'])
-        self.assertEqual(eitem_sh['author_gender_acc'], self.empty_item['author_gender_acc'])
-        self.assertEqual(eitem_sh['author_org_name'], self.empty_item['author_org_name'])
-        self.assertEqual(eitem_sh['author_bot'], self.empty_item['author_bot'])
+        self.assertEqual(eitem_sh['author_id'], '-- UNDEFINED --')
+        self.assertEqual(eitem_sh['author_uuid'], '-- UNDEFINED --')
+        self.assertEqual(eitem_sh['author_name'], '-- UNDEFINED --')
+        self.assertEqual(eitem_sh['author_user_name'], '-- UNDEFINED --')
+        self.assertEqual(eitem_sh['author_domain'], '-- UNDEFINED --')
+        self.assertEqual(eitem_sh['author_gender'], '-- UNDEFINED --')
+        self.assertEqual(eitem_sh['author_gender_acc'], None)
+        self.assertEqual(eitem_sh['author_org_name'], '-- UNDEFINED --')
+        self.assertEqual(eitem_sh['author_bot'], False)
 
         # 2. uuid is an empty string
 
@@ -535,15 +535,15 @@ class TestEnrich(unittest.TestCase):
 
         # Method to test
         eitem_sh = self._enrich.get_item_sh_fields(sh_id=sh_id)
-        self.assertEqual(eitem_sh['author_id'], self.empty_item['author_id'])
-        self.assertEqual(eitem_sh['author_uuid'], self.empty_item['author_uuid'])
-        self.assertEqual(eitem_sh['author_name'], self.empty_item['author_name'])
-        self.assertEqual(eitem_sh['author_user_name'], self.empty_item['author_user_name'])
-        self.assertEqual(eitem_sh['author_domain'], self.empty_item['author_domain'])
-        self.assertEqual(eitem_sh['author_gender'], self.empty_item['author_gender'])
-        self.assertEqual(eitem_sh['author_gender_acc'], self.empty_item['author_gender_acc'])
-        self.assertEqual(eitem_sh['author_org_name'], self.empty_item['author_org_name'])
-        self.assertEqual(eitem_sh['author_bot'], self.empty_item['author_bot'])
+        self.assertEqual(eitem_sh['author_id'], '-- UNDEFINED --')
+        self.assertEqual(eitem_sh['author_uuid'], '-- UNDEFINED --')
+        self.assertEqual(eitem_sh['author_name'], '-- UNDEFINED --')
+        self.assertEqual(eitem_sh['author_user_name'], '-- UNDEFINED --')
+        self.assertEqual(eitem_sh['author_domain'], '-- UNDEFINED --')
+        self.assertEqual(eitem_sh['author_gender'], '-- UNDEFINED --')
+        self.assertEqual(eitem_sh['author_gender_acc'], None)
+        self.assertEqual(eitem_sh['author_org_name'], '-- UNDEFINED --')
+        self.assertEqual(eitem_sh['author_bot'], False)
 
     def test_no_params(self):
         """Neither identity nor sh_id are passed as arguments"""

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -77,12 +77,12 @@ class TestGit(TestBaseBackend):
         item = self.items[0]
         eitem = enrich_backend.get_rich_item(item)
         self.assertEqual(eitem['committer_name'], '')
-        self.assertEqual(eitem['Commit_name'], 'Unknown')
-        self.assertEqual(eitem['Commit_user_name'], 'Unknown')
-        self.assertEqual(eitem['Commit_org_name'], 'Unknown')
+        self.assertEqual(eitem['Commit_name'], '-- UNDEFINED --')
+        self.assertEqual(eitem['Commit_user_name'], '-- UNDEFINED --')
+        self.assertEqual(eitem['Commit_org_name'], '-- UNDEFINED --')
 
-        self.assertNotEqual(eitem['author_name'], 'Unknown')
-        self.assertNotEqual(eitem['Author_name'], 'Unknown')
+        self.assertEqual(eitem['author_name'], 'Eduardo Morais')
+        self.assertEqual(eitem['Author_name'], 'Eduardo Morais')
         self.assertEqual(eitem['Author_user_name'], 'Unknown')
 
     def test_raw_to_enrich_projects(self):


### PR DESCRIPTION
When there are identities that are not found in SortingHat, the fields in the enriched items related to those identities are set to an empty string (''). When someone sees this value, it is not clear either there is an error in the visualization, in the way this value was obtained or if the value was blank in the origin.

For these reasons, the new default value will be "-- UNDEFINED --", so these kind of problems can be tracked more easy.