### PR TITLE
[enrich-stackexchange] Handle KeyError exception

### DIFF
--- a/grimoire_elk/enriched/stackexchange.py
+++ b/grimoire_elk/enriched/stackexchange.py
@@ -153,7 +153,9 @@ class StackExchangeEnrich(Enrich):
             eitem['question_has_accepted_answer'] = 0
             eitem['question_accepted_answer_id'] = None
 
-            if question['answer_count'] >= 1:
+            if question['answer_count'] >= 1 and 'answers' not in question:
+                logger.warning("Missing answers for question %s", question['question_id'])
+            elif question['answer_count'] >= 1 and 'answers' in question:
                 answers_id = [p['answer_id'] for p in question['answers']
                               if 'is_accepted' in p and p['is_accepted']]
                 eitem['question_accepted_answer_id'] = answers_id[0] if answers_id else None


### PR DESCRIPTION
This code allows to prevent keyerror exceptions over a question having `answer_count` greater than 0 but not list of `answers` associated.