### PR TITLE
[gitlab] Add milestone attribute to enriched items

### DIFF
--- a/grimoire_elk/enriched/gitlab.py
+++ b/grimoire_elk/enriched/gitlab.py
@@ -38,6 +38,7 @@ from ..elastic_mapping import Mapping as BaseMapping
 logger = logging.getLogger(__name__)
 
 GITLAB = 'https://gitlab.com/'
+NO_MILESTONE_TAG = "-empty-"
 
 
 class Mapping(BaseMapping):
@@ -233,6 +234,8 @@ class GitLabEnrich(Enrich):
         rich_issue['gitlab_repo'] = re.sub('.git$', '', rich_issue['gitlab_repo'])
         rich_issue["url_id"] = issue['web_url'].replace(GITLAB, '')
 
+        rich_issue['milestone'] = issue['milestone']['title'] if issue['milestone'] else NO_MILESTONE_TAG
+
         if self.prjs_map:
             rich_issue.update(self.get_item_project(rich_issue))
 
@@ -343,6 +346,8 @@ class GitLabEnrich(Enrich):
         if len(merge_request['notes_data']) + len(merge_request['award_emoji_data']) != 0:
             rich_mr['time_to_first_attention'] = \
                 get_time_diff_days(merge_request['created_at'], self.get_time_to_first_attention(merge_request))
+
+        rich_mr['milestone'] = merge_request['milestone']['title'] if merge_request['milestone'] else NO_MILESTONE_TAG
 
         if self.prjs_map:
             rich_mr.update(self.get_item_project(rich_mr))

--- a/tests/data/gitlab.json
+++ b/tests/data/gitlab.json
@@ -73,7 +73,19 @@
             "id": 1,
             "iid": 1,
             "labels": [],
-            "milestone": null,
+            "milestone": {
+                "id": 134231,
+                "iid": 34,
+                "project_id": 13083,
+                "title": "8.17",
+                "description": "",
+                "state": "closed",
+                "created_at": "2016-12-01T19:53:27.790Z",
+                "updated_at": "2017-04-26T16:33:27.884Z",
+                "due_date": "2017-02-21",
+                "start_date": "2017-01-07",
+                "web_url": "https://gitlab.com/gitlab-org/gitlab-ce/milestones/34"
+            },
             "notes_data": [
                 {
                     "attachment": null,
@@ -470,7 +482,19 @@
                 "username": "Bubu",
                 "web_url": "https://gitlab.com/Bubu"
             },
-            "milestone": null,
+            "milestone": {
+                "id": 134231,
+                "iid": 34,
+                "project_id": 13083,
+                "title": "8.17",
+                "description": "",
+                "state": "closed",
+                "created_at": "2016-12-01T19:53:27.790Z",
+                "updated_at": "2017-04-26T16:33:27.884Z",
+                "due_date": "2017-02-21",
+                "start_date": "2017-01-07",
+                "web_url": "https://gitlab.com/gitlab-org/gitlab-ce/milestones/34"
+            },
             "notes_data": [
                 {
                     "attachment": null,

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -26,9 +26,10 @@ import unittest
 
 from base import TestBaseBackend
 from grimoire_elk.raw.gitlab import GitLabOcean
+from grimoire_elk.enriched.gitlab import NO_MILESTONE_TAG
 
 
-class TestGit(TestBaseBackend):
+class TestGitLab(TestBaseBackend):
     """Test GitLab backend"""
 
     connector = "gitlab"
@@ -52,6 +53,24 @@ class TestGit(TestBaseBackend):
         self.assertGreater(result['raw'], 0)
         self.assertGreater(result['enrich'], 0)
         self.assertEqual(result['raw'], result['enrich'])
+
+        enrich_backend = self.connectors[self.connector][2]()
+
+        item = self.items[0]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['milestone'], "8.17")
+
+        item = self.items[1]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['milestone'], NO_MILESTONE_TAG)
+
+        item = self.items[4]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['milestone'], "8.17")
+
+        item = self.items[5]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['milestone'], NO_MILESTONE_TAG)
 
     def test_raw_to_enrich_sorting_hat(self):
         """Test enrich with SortingHat"""


### PR DESCRIPTION
This code adds milestone information to enriched items coming from gitlab issues and merge requests. Milestone data is stored in the attribute `milestone`, in case no milestone is present, the value is set to `no-milestone`. Tests have been modified accordingly.