### PR TITLE
[gitlab-enrich] Add onion study

### DIFF
--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -872,6 +872,7 @@ class Enrich(ElasticItems):
 
         # Creating connections
         es = Elasticsearch([enrich_backend.elastic.url], timeout=100, verify_certs=self.elastic.requests.verify)
+
         in_conn = ESOnionConnector(es_conn=es, es_index=in_index,
                                    contribs_field=contribs_field,
                                    timeframe_field=timeframe_field,
@@ -881,6 +882,10 @@ class Enrich(ElasticItems):
                                     timeframe_field=timeframe_field,
                                     sort_on_field=sort_on_field,
                                     read_only=False)
+
+        if not in_conn.exists():
+            logger.info("[Onion] Missing index %s", in_index)
+            return
 
         # Onion currently does not support incremental option
         logger.info("[Onion] Creating out ES index")


### PR DESCRIPTION
This PR adds onion studies for GitLab issues and merge requests. Each onion study requires 3 params at least: `in_index`, `out_index` and `data_source` (which should be either `gitlab-issues` or `gitlab-merges`).
```
[gitlab:issue]
raw_index = test_gitlab-issue-raw
enriched_index = test_gitlab-issue
api-token = ZAxX9AbUdV4HXkpyiuHV
no-archive = true
sleep-for-rate = true
studies = [enrich_onion:gitlab-issue]

[gitlab:merge]
raw_index = test_gitlab-merge-raw
enriched_index = test_gitlab-merge
api-token = ZAxX9AbUdV4HXkpyiuHV
no-archive = true
category = merge_request
sleep-for-rate = true
studies = [enrich_onion:gitlab-merge]

[enrich_onion:gitlab-merge]
in_index = test_gitlab-merge
out_index = gitlab_merges_onion
data_source = gitlab-merges

[enrich_onion:gitlab-issue]
in_index = test_gitlab-issue
out_index = gitlab_issues_onion
data_source = gitlab-issues
```