### PR TITLE
 [onion] Add refresh interval

### DIFF
--- a/grimoire_elk/enriched/ceres_base.py
+++ b/grimoire_elk/enriched/ceres_base.py
@@ -284,12 +284,12 @@ class ESConnector(Connector):
 
         return self._es_conn.indices.put_alias(index=self._es_index, name=alias_name)
 
-    def exists_alias(self, alias_name):
+    def exists_alias(self, alias_name, index_name=None):
         """Check whether or not the given alias exists
 
         :return: True if alias already exist"""
 
-        return self._es_conn.indices.exists_alias(name=alias_name)
+        return self._es_conn.indices.exists_alias(index=index_name, name=alias_name)
 
     def _build_search_query(self, from_date):
         """Build an ElasticSearch search query to retrieve items for read methods.

--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -915,7 +915,7 @@ class Enrich(ElasticItems):
 
         # Create alias if output index exists (index is always created from scratch, so
         # alias need to be created each time)
-        if out_conn.exists() and not out_conn.exists_alias("all_onion"):
+        if out_conn.exists() and not out_conn.exists_alias(out_index, "all_onion"):
             logger.info("[Onion] Creating alias: all_onion")
             out_conn.create_alias('all_onion')
 

--- a/grimoire_elk/enriched/git.py
+++ b/grimoire_elk/enriched/git.py
@@ -861,13 +861,15 @@ class GitEnrich(Enrich):
 
         logger.info("[Areas of Code] End")
 
-    def enrich_onion(self, ocean_backend, enrich_backend, no_incremental=False,
+    def enrich_onion(self, ocean_backend, enrich_backend,
+                     no_incremental=False,
                      in_index='git_onion-src',
                      out_index='git_onion-enriched',
                      data_source='git',
                      contribs_field='hash',
                      timeframe_field='grimoire_creation_date',
-                     sort_on_field='metadata__timestamp'):
+                     sort_on_field='metadata__timestamp',
+                     seconds=Enrich.ONION_INTERVAL):
 
         super().enrich_onion(enrich_backend=enrich_backend,
                              in_index=in_index,
@@ -876,4 +878,5 @@ class GitEnrich(Enrich):
                              contribs_field=contribs_field,
                              timeframe_field=timeframe_field,
                              sort_on_field=sort_on_field,
-                             no_incremental=no_incremental)
+                             no_incremental=no_incremental,
+                             seconds=seconds)

--- a/grimoire_elk/enriched/github.py
+++ b/grimoire_elk/enriched/github.py
@@ -330,7 +330,8 @@ class GitHubEnrich(Enrich):
                      data_source_prs='github-prs',
                      contribs_field='uuid',
                      timeframe_field='grimoire_creation_date',
-                     sort_on_field='metadata__timestamp'):
+                     sort_on_field='metadata__timestamp',
+                     seconds=Enrich.ONION_INTERVAL):
 
         super().enrich_onion(enrich_backend=enrich_backend,
                              in_index=in_index_iss,
@@ -339,7 +340,8 @@ class GitHubEnrich(Enrich):
                              contribs_field=contribs_field,
                              timeframe_field=timeframe_field,
                              sort_on_field=sort_on_field,
-                             no_incremental=no_incremental)
+                             no_incremental=no_incremental,
+                             seconds=seconds)
 
         super().enrich_onion(enrich_backend=enrich_backend,
                              in_index=in_index_prs,
@@ -348,7 +350,8 @@ class GitHubEnrich(Enrich):
                              contribs_field=contribs_field,
                              timeframe_field=timeframe_field,
                              sort_on_field=sort_on_field,
-                             no_incremental=no_incremental)
+                             no_incremental=no_incremental,
+                             seconds=seconds)
 
     def enrich_pull_requests(self, ocean_backend, enrich_backend, raw_issues_index="github_issues_raw"):
         """

--- a/grimoire_elk/enriched/gitlab.py
+++ b/grimoire_elk/enriched/gitlab.py
@@ -372,7 +372,8 @@ class GitLabEnrich(Enrich):
                      in_index, out_index, data_source=None, no_incremental=False,
                      contribs_field='uuid',
                      timeframe_field='grimoire_creation_date',
-                     sort_on_field='metadata__timestamp'):
+                     sort_on_field='metadata__timestamp',
+                     seconds=Enrich.ONION_INTERVAL):
 
         if not data_source:
             raise ELKError(cause="Missing data_source attribute")
@@ -387,4 +388,5 @@ class GitLabEnrich(Enrich):
                              contribs_field=contribs_field,
                              timeframe_field=timeframe_field,
                              sort_on_field=sort_on_field,
-                             no_incremental=no_incremental)
+                             no_incremental=no_incremental,
+                             seconds=seconds)


### PR DESCRIPTION
A new parameter `seconds` can be used to define the minimum
time from one study execution to the following. By default has
been set to one week, but can be set for each data source in
`setup.cfg`. Onion will only run again if at least that number
of seconds has passed from the enrichment of the most recent
item in the index.

For information purposes, each time the study is not run due
to this parameter, a log line is printed containing that
minimum date for reference.

Note that the study won't be executed exactly at that time,
but at some point after that time. Studies are executed
after each enrichment processes.

A second commit has been included to solve a bug that prevented the alias to be created after executing the study in some cases:

```
[onion] Fix `all_onion` alias creation  …
Alias must be created if it doesn't exist for the
corresponding `out_index`. There was a bug when checking it
because code was looking only for alias to exist. As
`all_onion` points to different indices (one per data source)
it could exist pointing to another source, which was a false
positive that prevented the alias to be created.

This commit allows to check if the alias exists pointing to
the particular index we are interested in.
```