### PR TITLE
Fix Mattermost generation of values for emails and names on identities

### DIFF
--- a/grimoire_elk/enriched/mattermost.py
+++ b/grimoire_elk/enriched/mattermost.py
@@ -80,8 +80,20 @@ class MattermostEnrich(Enrich):
 
         identity['username'] = from_['username']
         identity['name'] = from_['username']
+
         if 'first_name' in from_:
-            identity['name'] = from_['first_name'] + " " + from_['last_name']
+            name_parts = []
+            first_name = from_.get('first_name')
+            if first_name:
+                name_parts.append(first_name)
+
+            last_name = from_.get('last_name')
+            if last_name:
+                name_parts.append(last_name)
+
+            composed_name = ' '.join(name_parts)
+
+            identity['name'] = composed_name if composed_name else None
         if 'email' in from_:
             identity['email'] = from_['email']
         return identity

--- a/grimoire_elk/enriched/mattermost.py
+++ b/grimoire_elk/enriched/mattermost.py
@@ -95,7 +95,8 @@ class MattermostEnrich(Enrich):
 
             identity['name'] = composed_name if composed_name else None
         if 'email' in from_:
-            identity['email'] = from_['email']
+            email = from_['email']
+            identity['email'] = email if email else None
         return identity
 
     def get_identities(self, item):


### PR DESCRIPTION
This PR address two problems in the Mattermost enricher:

* creation of a white space name (i.e " ") when the first and last name of the identities are empty
* set empty string values when the email of an identity is not available