### PR TITLE
[elk] Add condition to skip loading identites

### DIFF
--- a/grimoire_elk/elk.py
+++ b/grimoire_elk/elk.py
@@ -605,7 +605,7 @@ def enrich_backend(url, clean, backend_name, backend_params,
 
             logger.info("Adding enrichment data to %s", enrich_backend.elastic.index_url)
 
-            if db_sortinghat:
+            if db_sortinghat and enrich_backend.has_identities():
                 # FIXME: This step won't be done from enrich in the future
                 total_ids = load_identities(ocean_backend, enrich_backend)
                 logger.info("Total identities loaded %i ", total_ids)

--- a/grimoire_elk/enriched/dockerhub.py
+++ b/grimoire_elk/enriched/dockerhub.py
@@ -78,6 +78,11 @@ class DockerHubEnrich(Enrich):
         identities = []
         return identities
 
+    def has_identities(self):
+        """ Return whether the enriched items contains identities """
+
+        return False
+
     @metadata
     def get_rich_item(self, item):
         eitem = {}

--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -409,6 +409,11 @@ class Enrich(ElasticItems):
         """ Return the identities from an item """
         raise NotImplementedError
 
+    def has_identities(self):
+        """ Return whether the enriched items contains identities """
+
+        return True
+
     def get_email_domain(self, email):
         domain = None
         try:

--- a/grimoire_elk/enriched/functest.py
+++ b/grimoire_elk/enriched/functest.py
@@ -39,6 +39,11 @@ class FunctestEnrich(Enrich):
 
         return identities
 
+    def has_identities(self):
+        """ Return whether the enriched items contains identities """
+
+        return False
+
     def get_field_author(self):
         # In Functest there is no identities support
         return None

--- a/grimoire_elk/enriched/google_hits.py
+++ b/grimoire_elk/enriched/google_hits.py
@@ -37,6 +37,11 @@ class GoogleHitsEnrich(Enrich):
 
         return identities
 
+    def has_identities(self):
+        """ Return whether the enriched items contains identities """
+
+        return False
+
     @metadata
     def get_rich_item(self, item):
         eitem = {}

--- a/grimoire_elk/enriched/jenkins.py
+++ b/grimoire_elk/enriched/jenkins.py
@@ -115,6 +115,11 @@ class JenkinsEnrich(Enrich):
 
         return identities
 
+    def has_identities(self):
+        """ Return whether the enriched items contains identities """
+
+        return False
+
     def get_fields_from_job_name(self, job_name):
         """Analyze a Jenkins job name, producing a dictionary
 

--- a/grimoire_elk/enriched/telegram.py
+++ b/grimoire_elk/enriched/telegram.py
@@ -79,7 +79,7 @@ class TelegramEnrich(Enrich):
 
         message = item['data']['message']
         identity = self.get_sh_identity(message['from'])
-        
+
         yield identity
 
     @metadata

--- a/tests/test_dockerhub.py
+++ b/tests/test_dockerhub.py
@@ -50,6 +50,12 @@ class TestDockerhub(TestBaseBackend):
         self.assertEqual(result['raw'], 1)
         self.assertEqual(result['enrich'], 3)
 
+    def test_has_identities(self):
+        """Test whether has_identities works"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertFalse(enrich_backend.has_identities())
+
     def test_raw_to_enrich_sorting_hat(self):
         """Test enrich with SortingHat"""
 

--- a/tests/test_enrich.py
+++ b/tests/test_enrich.py
@@ -573,6 +573,11 @@ class TestEnrich(unittest.TestCase):
         self.assertEqual(eitem_sh['author_org_name'], self.empty_item['author_org_name'])
         self.assertEqual(eitem_sh['author_bot'], self.empty_item['author_bot'])
 
+    def test_has_identities(self):
+        """Test whether has_identities works"""
+
+        self.assertTrue(self._enrich.has_identities())
+
     def test_add_alias(self):
         """Test whether add_alias properly works"""
 

--- a/tests/test_functest.py
+++ b/tests/test_functest.py
@@ -50,6 +50,12 @@ class TestFunctest(TestBaseBackend):
         self.assertEqual(result['raw'], 27)
         self.assertEqual(result['enrich'], 27)
 
+    def test_has_identities(self):
+        """Test whether has_identities works"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertFalse(enrich_backend.has_identities())
+
     def test_raw_to_enrich_sorting_hat(self):
         """Test enrich with SortingHat"""
 

--- a/tests/test_google_hits.py
+++ b/tests/test_google_hits.py
@@ -53,6 +53,12 @@ class TestGoogleHits(TestBaseBackend):
         self.assertGreater(result['enrich'], 0)
         self.assertEqual(result['raw'], result['enrich'])
 
+    def test_has_identities(self):
+        """Test whether has_identities works"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertFalse(enrich_backend.has_identities())
+
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 

--- a/tests/test_jenkins.py
+++ b/tests/test_jenkins.py
@@ -52,7 +52,7 @@ class TestJenkins(TestBaseBackend):
 
         enrich_backend = self.connectors[self.connector][2]()
 
-        enrich_backend.node_regex = '(.*)-\d+$'
+        enrich_backend.node_regex = '(.*?)(-\d*)?$'
 
         item = self.items[0]
         eitem = enrich_backend.get_rich_item(item)
@@ -63,6 +63,12 @@ class TestJenkins(TestBaseBackend):
         item = self.items[1]
         eitem = enrich_backend.get_rich_item(item)
         self.assertEqual(eitem['builtOn'], 'intel-pod7')
+
+    def test_has_identities(self):
+        """Test whether has_identities works"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertFalse(enrich_backend.has_identities())
 
     def test_raw_to_enrich_sorting_hat(self):
         """Test enrich with SortingHat"""


### PR DESCRIPTION
This PR prevents to execute the load identites operation for those enrichers that don't return items with identities data. Thus, the proposed code improves the performance of the platform.