### PR TITLE
[enrich-bugzillarest] Replace list with yield

### DIFF
--- a/grimoire_elk/enriched/bugzillarest.py
+++ b/grimoire_elk/enriched/bugzillarest.py
@@ -46,12 +46,10 @@ class BugzillaRESTEnrich(Enrich):
 
     def get_identities(self, item):
         """ Return the identities from an item """
-        identities = []
 
         for rol in self.roles:
             if rol in item['data']:
-                identities.append(self.get_sh_identity(item["data"][rol]))
-        return identities
+                yield self.get_sh_identity(item["data"][rol])
 
     def get_sh_identity(self, item, identity_field=None):
         identity = {}


### PR DESCRIPTION
This code replaces the list used in the method get_identities with a yield, thus reducing the memory footprint.