### PR TITLE
[enrich-gitlab] Replace list with yield

### DIFF
--- a/grimoire_elk/enriched/gitlab.py
+++ b/grimoire_elk/enriched/gitlab.py
@@ -100,15 +100,13 @@ class GitLabEnrich(Enrich):
 
     def get_identities(self, item):
         """ Return the identities from an item """
-        identities = []
 
         item = item['data']
         for identity in self.issue_roles:
             if item[identity]:
                 user = self.get_sh_identity(item[identity])
                 if user:
-                    identities.append(user)
-        return identities
+                    yield user
 
     def get_sh_identity(self, item, identity_field=None):
         identity = {}


### PR DESCRIPTION
This code replaces the list used in the method get_identities with a yield, thus reducing the memory footprint.