### PR TITLE
[enrich-mediawiki] Replace list with yield

### DIFF
--- a/grimoire_elk/enriched/mediawiki.py
+++ b/grimoire_elk/enriched/mediawiki.py
@@ -75,8 +75,7 @@ class MediaWikiEnrich(Enrich):
 
         for revision in revisions:
             user = self.get_sh_identity(revision)
-            identities.append(user)
-        return identities
+            yield user
 
     def get_field_author(self):
         return 'user'


### PR DESCRIPTION
This code replaces the list used in the method get_identities with a yield, thus reducing the memory footprint.