### PR TITLE
[enrich-mozillaclub] Replace list with yield

### DIFF
--- a/grimoire_elk/enriched/mozillaclub.py
+++ b/grimoire_elk/enriched/mozillaclub.py
@@ -82,13 +82,10 @@ class MozillaClubEnrich(Enrich):
         return "uuid"
 
     def get_identities(self, item):
-        ''' Return the identities from an item '''
+        """Return the identities from an item"""
 
-        identities = []
-
-        identities.append(self.get_sh_identity(item, self.get_field_author()))
-
-        return identities
+        user = self.get_sh_identity(item, self.get_field_author())
+        yield user
 
     def get_sh_identity(self, item, identity_field):
         identity = {}


### PR DESCRIPTION
This code replaces the list used in the method get_identities with a yield, thus reducing the memory footprint.