### PR TITLE
[enrich-gitlab] Handle missing milestone attribute in raw items

### DIFF
--- a/grimoire_elk/enriched/gitlab.py
+++ b/grimoire_elk/enriched/gitlab.py
@@ -231,7 +231,8 @@ class GitLabEnrich(Enrich):
         rich_issue['gitlab_repo'] = re.sub('.git$', '', rich_issue['gitlab_repo'])
         rich_issue["url_id"] = issue['web_url'].replace(GITLAB, '')
 
-        rich_issue['milestone'] = issue['milestone']['title'] if issue['milestone'] else NO_MILESTONE_TAG
+        rich_issue['milestone'] = issue['milestone']['title'] \
+            if 'milestone' in issue and issue['milestone'] else NO_MILESTONE_TAG
 
         if self.prjs_map:
             rich_issue.update(self.get_item_project(rich_issue))
@@ -340,7 +341,8 @@ class GitLabEnrich(Enrich):
             rich_mr['time_to_first_attention'] = \
                 get_time_diff_days(merge_request['created_at'], self.get_time_to_first_attention(merge_request))
 
-        rich_mr['milestone'] = merge_request['milestone']['title'] if merge_request['milestone'] else NO_MILESTONE_TAG
+        rich_mr['milestone'] = merge_request['milestone']['title'] \
+            if 'milestone' in merge_request and merge_request['milestone'] else NO_MILESTONE_TAG
 
         if self.prjs_map:
             rich_mr.update(self.get_item_project(rich_mr))

--- a/tests/data/gitlab.json
+++ b/tests/data/gitlab.json
@@ -316,7 +316,6 @@
                 "CI/CD",
                 "Deliverable"
             ],
-            "milestone": null,
             "notes_data": [
                 {
                     "attachment": null,
@@ -935,7 +934,6 @@
                 "username": "mimi89999",
                 "web_url": "https://gitlab.com/mimi89999"
             },
-            "milestone": null,
             "notes_data": [
                 {
                     "attachment": null,

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -68,6 +68,7 @@ class TestGitLab(TestBaseBackend):
 
         item = self.items[2]
         eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['milestone'], NO_MILESTONE_TAG)
         self.assertEqual(eitem['labels'], ['CI/CD', 'Deliverable'])
 
         item = self.items[4]
@@ -82,6 +83,7 @@ class TestGitLab(TestBaseBackend):
 
         item = self.items[6]
         eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['milestone'], NO_MILESTONE_TAG)
         self.assertEqual(eitem['labels'], ['CI/CD', 'Deliverable'])
 
     def test_raw_to_enrich_sorting_hat(self):


### PR DESCRIPTION
This code handles old raw items coming from the GitLab API that don't contain the milestone attribute.