### PR TITLE
[utils] Avoid enriching items over and over

### DIFF
--- a/grimoire_elk/elk.py
+++ b/grimoire_elk/elk.py
@@ -455,7 +455,10 @@ def get_ocean_backend(backend_cmd, enrich_backend, no_incremental,
         elif 'offset' in signature.parameters:
             ocean_backend = connector[1](backend, offset=last_enrich)
         else:
-            ocean_backend = connector[1](backend)
+            if last_enrich:
+                ocean_backend = connector[1](backend, from_date=last_enrich)
+            else:
+                ocean_backend = connector[1](backend)
     else:
         # We can have params for non perceval backends also
         params = enrich_backend.backend_params

--- a/grimoire_elk/enriched/utils.py
+++ b/grimoire_elk/enriched/utils.py
@@ -174,6 +174,9 @@ def get_last_enrich(backend_cmd, enrich_backend):
                 last_enrich = offset
             else:
                 last_enrich = enrich_backend.get_last_offset_from_es([filter_])
+
+        else:
+            last_enrich = enrich_backend.get_last_update_from_es([filter_])
     else:
         last_enrich = enrich_backend.get_last_update_from_es()
 


### PR DESCRIPTION
This code prevents to trigger enrichment operations over all raw items for backends not having neither from_date or offset attributes in their signatures. This is the case of backends like `dockerhub`, `googlehits`, `jenkins`, `rss` and `twitter`.