### PR TITLE
[enrich-meetup] Prevent insert enrich items with no time

### DIFF
--- a/grimoire_elk/enriched/meetup.py
+++ b/grimoire_elk/enriched/meetup.py
@@ -324,11 +324,6 @@ class MeetupEnrich(Enrich):
 
             yield ersvp
 
-    def has_identities(self):
-        """ Return whether the enriched items contains identities """
-
-        return False
-
     def get_field_unique_id(self):
         return "id"
 
@@ -339,6 +334,10 @@ class MeetupEnrich(Enrich):
 
         for item in ocean_backend.fetch():
             eitem = self.get_rich_item(item)
+
+            if 'uuid' not in eitem:
+                continue
+
             items_to_enrich.append(eitem)
 
             if 'comments' in item['data'] and 'id' in eitem:


### PR DESCRIPTION
This code prevents to insert meetup enriched items which don't come with a time attribute. Furthermore, it also removes the redefinition of the method `has_identities`, which was avoiding inserting meetup identities.