### PR TITLE
[enrich-stackexchange] Reorganize tags fields

### DIFF
--- a/schema/stackoverflow.csv
+++ b/schema/stackoverflow.csv
@@ -3,6 +3,7 @@ answer_status,keyword
 answer_count,long
 answer_id,long
 answer_tags,keyword
+answers_tags, keyword
 author_bot,boolean
 author_id,keyword
 author,keyword
@@ -22,6 +23,7 @@ is_accepted,boolean
 is_accepted_answer,long
 is_stackexchange_answer,long
 is_stackexchange_question,long
+item_id,long
 last_activity_date,long
 link,keyword
 metadata__enriched_on,date
@@ -40,12 +42,12 @@ owner_uuid,keyword
 question_accepted_answer_id,long
 question_has_accepted_answer,boolean
 question_id,long
-question_tags_analyzed,keyword
 question_tags,keyword
 question_title,keyword
 score,long
 tag,keyword
 tags,keyword
+thread_tags, keyword
 title_analyzed,text
 title,keyword
 type,keyword

--- a/tests/data/stackexchange.json
+++ b/tests/data/stackexchange.json
@@ -29,7 +29,7 @@
                 },
                 "question_id": 38611467,
                 "score": -2,
-                "tags": [],
+                "tags": ["grimoirelab"],
                 "title": "Python: get every possible combination of weights for a portfolio",
                 "up_vote_count": 0
             },
@@ -206,9 +206,7 @@
         "question_id": 38611900,
         "reopen_vote_count": 0,
         "score": -1,
-        "tags": [
-            "python"
-        ],
+        "tags": [],
         "title": "I need to figure out how to make my program repeat. (Python coding class)",
         "up_vote_count": 0,
         "view_count": 9


### PR DESCRIPTION
This code reorganizes the tags fields for questions and answers.
+ Enriched answers include the fields:
  - `answer_tags` (tags of the answer)
  - `question_tags` (tags of the question)
+ Enrich questions include the fields:
  - `question_tags` (tags of the question)
  - `answers_tags` (all tags of answers)
  - `thread_tags` (the sum of question and answers tags)