### PR TITLE
[tests] Check value has_identities of enrichers

### DIFF
--- a/grimoire_elk/enriched/mediawiki.py
+++ b/grimoire_elk/enriched/mediawiki.py
@@ -235,9 +235,6 @@ class MediaWikiEnrich(Enrich):
         # Enrich always events for MediaWiki items
         return self.enrich_events(items)
 
-    def has_identities(self):
-        False
-
     def enrich_events(self, ocean_backend):
         max_items = self.elastic.max_items_bulk
         current = 0

--- a/tests/test_askbot.py
+++ b/tests/test_askbot.py
@@ -36,6 +36,12 @@ class TestAskbot(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -36,6 +36,12 @@ class TestBugzilla(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_bugzillarest.py
+++ b/tests/test_bugzillarest.py
@@ -39,6 +39,12 @@ class TestBugzillaRest(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_confluence.py
+++ b/tests/test_confluence.py
@@ -36,6 +36,12 @@ class TestConfluence(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_crates.py
+++ b/tests/test_crates.py
@@ -36,6 +36,12 @@ class TestCrates(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_discourse.py
+++ b/tests/test_discourse.py
@@ -36,6 +36,12 @@ class TestDiscourse(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_dockerhub.py
+++ b/tests/test_dockerhub.py
@@ -36,6 +36,12 @@ class TestDockerhub(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertFalse(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_functest.py
+++ b/tests/test_functest.py
@@ -36,6 +36,12 @@ class TestFunctest(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertFalse(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_gerrit.py
+++ b/tests/test_gerrit.py
@@ -42,6 +42,12 @@ class TestGerrit(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -43,6 +43,12 @@ class TestGit(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -36,6 +36,12 @@ class TestGit(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -36,6 +36,12 @@ class TestGitLab(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_google_hits.py
+++ b/tests/test_google_hits.py
@@ -35,6 +35,12 @@ class TestGoogleHits(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertFalse(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_groupsio.py
+++ b/tests/test_groupsio.py
@@ -36,6 +36,12 @@ class TestGrousio(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_hyperkitty.py
+++ b/tests/test_hyperkitty.py
@@ -37,6 +37,12 @@ class TestHyperkitty(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_jenkins.py
+++ b/tests/test_jenkins.py
@@ -36,6 +36,12 @@ class TestJenkins(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertFalse(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -36,6 +36,12 @@ class TestJira(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_kitsune.py
+++ b/tests/test_kitsune.py
@@ -36,6 +36,12 @@ class TestKitsune(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_mattermost.py
+++ b/tests/test_mattermost.py
@@ -37,6 +37,12 @@ class TestMattermost(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_mbox.py
+++ b/tests/test_mbox.py
@@ -39,6 +39,12 @@ class TestMbox(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_mediawiki.py
+++ b/tests/test_mediawiki.py
@@ -36,6 +36,12 @@ class TestMediawiki(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_meetup.py
+++ b/tests/test_meetup.py
@@ -36,6 +36,12 @@ class TestMeetup(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_mozillaclub.py
+++ b/tests/test_mozillaclub.py
@@ -36,6 +36,12 @@ class TestMozillaClub(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_nntp.py
+++ b/tests/test_nntp.py
@@ -36,6 +36,12 @@ class TestNNTP(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_phabricator.py
+++ b/tests/test_phabricator.py
@@ -36,6 +36,12 @@ class TestPhabricator(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_pipermail.py
+++ b/tests/test_pipermail.py
@@ -36,6 +36,12 @@ class TestPipermail(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_puppetforge.py
+++ b/tests/test_puppetforge.py
@@ -36,6 +36,12 @@ class TestPuppetForge(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_redmine.py
+++ b/tests/test_redmine.py
@@ -36,6 +36,12 @@ class TestRedmine(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_remo.py
+++ b/tests/test_remo.py
@@ -36,6 +36,12 @@ class TestRemo(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -36,6 +36,12 @@ class TestRSS(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -37,6 +37,12 @@ class TestSlack(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_stackexchange.py
+++ b/tests/test_stackexchange.py
@@ -36,6 +36,12 @@ class TestStackexchange(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_supybot.py
+++ b/tests/test_supybot.py
@@ -36,6 +36,12 @@ class TestSupybot(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -36,6 +36,12 @@ class TestTelegram(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 

--- a/tests/test_twitter.py
+++ b/tests/test_twitter.py
@@ -35,6 +35,12 @@ class TestTwitter(TestBaseBackend):
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
 
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
     def test_items_to_raw(self):
         """Test whether JSON items are properly inserted into ES"""
 


### PR DESCRIPTION
In order to avoid introducing bugs related to loading identities (as it has recently happened for mediawiki), this PR proposes to include a test to check the value of the `has_identities` method for each enricher.