### PR TITLE
Fix askbot mappings enrich

### DIFF
--- a/grimoire_elk/enriched/askbot.py
+++ b/grimoire_elk/enriched/askbot.py
@@ -54,6 +54,9 @@ class Mapping(BaseMapping):
                 },
                 "summary": {
                   "type": "text"
+                },
+                "id": {
+                  "type": "keyword"
                 }
            }
         } """

--- a/grimoire_elk/enriched/discourse.py
+++ b/grimoire_elk/enriched/discourse.py
@@ -266,8 +266,8 @@ class DiscourseEnrich(Enrich):
             eitem = self.get_rich_item(item)
             items_to_enrich.append(eitem)
 
-            rich_item_comments = self.get_rich_item_answers(item)
-            items_to_enrich.extend(rich_item_comments)
+            rich_item_answers = self.get_rich_item_answers(item)
+            items_to_enrich.extend(rich_item_answers)
 
             if len(items_to_enrich) < MAX_SIZE_BULK_ENRICHED_ITEMS:
                 continue

--- a/schema/askbot.csv
+++ b/schema/askbot.csv
@@ -15,7 +15,7 @@ author_uuid,keyword
 comment_count,long
 first_answer,long
 grimoire_creation_date,date
-id,long
+id,keyword
 is_accepted_answer,long
 is_askbot_answer,long
 is_askbot_comment,long

--- a/schema/discourse.csv
+++ b/schema/discourse.csv
@@ -15,7 +15,7 @@ display_username,keyword
 first_answer,long
 first_reply_time,float
 grimoire_creation_date,date
-id,long
+id,keyword
 is_accepted_answer,long
 is_discourse_answer,long
 is_discourse_question,long


### PR DESCRIPTION
This PR updates the mapping for the attribute id, which is generated as a concatenation of ids (e.g., question + answer + comment). The corresponding schema (askbot.csv) has been changed accordingly.