### PR TITLE
[ELK] Remove credentials from log messages

### DIFF
--- a/grimoire_elk/elastic_items.py
+++ b/grimoire_elk/elastic_items.py
@@ -100,12 +100,13 @@ class ElasticItems():
         scroll_size = page['hits']['total']
 
         if scroll_size == 0:
-            logger.warning("No results found from %s", self.elastic.index_url)
+            logger.warning("No results found from %s", self.elastic.anonymize_url(self.elastic.index_url))
             return
 
         while scroll_size > 0:
 
-            logger.debug("Fetching from %s: %d received", self.elastic.index_url, len(page['hits']['hits']))
+            logger.debug("Fetching from %s: %d received", self.elastic.anonymize_url(self.elastic.index_url),
+                         len(page['hits']['hits']))
             for item in page['hits']['hits']:
                 eitem = item['_source']
                 yield eitem
@@ -117,7 +118,7 @@ class ElasticItems():
 
             scroll_size = len(page['hits']['hits'])
 
-        logger.debug("Fetching from %s: done receiving", self.elastic.index_url)
+        logger.debug("Fetching from %s: done receiving", self.elastic.anonymize_url(self.elastic.index_url))
 
     def get_elastic_items(self, elastic_scroll_id=None, _filter=None):
         """ Get the items from the index related to the backend applying and
@@ -229,10 +230,10 @@ class ElasticItems():
                 }
                 """ % (filters, order_query)
 
-            logger.debug("Raw query to %s\n%s", url, json.dumps(json.loads(query), indent=4))
+            logger.debug("Raw query to %s\n%s", self.elastic.anonymize_url(url),
+                         json.dumps(json.loads(query), indent=4))
             query_data = query
 
-        items = []
         rjson = None
         try:
             res = self.requests.post(url, data=query_data, headers=headers)
@@ -240,7 +241,6 @@ class ElasticItems():
             rjson = res.json()
         except Exception:
             # The index could not exists yet or it could be empty
-            logger.warning("No JSON found in %s" % (res.text))
-            logger.warning("No results found from %s" % (url))
+            logger.warning("No results found from %s", self.elastic.anonymize_url(url))
 
         return rjson

--- a/grimoire_elk/elk.py
+++ b/grimoire_elk/elk.py
@@ -289,7 +289,8 @@ def get_items_from_uuid(uuid, enrich_backend, ocean_backend):
 
 
 def refresh_projects(enrich_backend):
-    logger.debug("Refreshing project field in %s", enrich_backend.elastic.index_url)
+    logger.debug("Refreshing project field in %s",
+                 enrich_backend.elastic.anonymize_url(enrich_backend.elastic.index_url))
     total = 0
 
     eitems = enrich_backend.fetch()
@@ -329,7 +330,8 @@ def refresh_identities(enrich_backend, author_field=None, author_values=None):
             eitem.update(new_identities)
             yield eitem
 
-    logger.debug("Refreshing identities fields from %s", enrich_backend.elastic.index_url)
+    logger.debug("Refreshing identities fields from %s",
+                 enrich_backend.elastic.anonymize_url(enrich_backend.elastic.index_url))
 
     total = 0
 
@@ -591,7 +593,8 @@ def enrich_backend(url, clean, backend_name, backend_params,
             logger.info("Running only studies (no SH and no enrichment)")
             do_studies(ocean_backend, enrich_backend, studies_args)
         elif do_refresh_projects:
-            logger.info("Refreshing project field in %s", enrich_backend.elastic.index_url)
+            logger.info("Refreshing project field in %s",
+                        enrich_backend.elastic.anonymize_url(enrich_backend.elastic.index_url))
             field_id = enrich_backend.get_field_unique_id()
             eitems = refresh_projects(enrich_backend)
             enrich_backend.elastic.bulk_upload(eitems, field_id)
@@ -606,7 +609,8 @@ def enrich_backend(url, clean, backend_name, backend_params,
                 author_attr = 'author_uuid'
                 author_values = [author_uuid]
 
-            logger.info("Refreshing identities fields in %s", enrich_backend.elastic.index_url)
+            logger.info("Refreshing identities fields in %s",
+                        enrich_backend.elastic.anonymize_url(enrich_backend.elastic.index_url))
 
             field_id = enrich_backend.get_field_unique_id()
             eitems = refresh_identities(enrich_backend, author_attr, author_values)
@@ -616,7 +620,8 @@ def enrich_backend(url, clean, backend_name, backend_params,
             elastic_ocean = get_elastic(url, ocean_index, clean, ocean_backend)
             ocean_backend.set_elastic(elastic_ocean)
 
-            logger.info("Adding enrichment data to %s", enrich_backend.elastic.index_url)
+            logger.info("Adding enrichment data to %s",
+                        enrich_backend.elastic.anonymize_url(enrich_backend.elastic.index_url))
 
             if db_sortinghat and enrich_backend.has_identities():
                 # FIXME: This step won't be done from enrich in the future

--- a/grimoire_elk/enriched/dockerhub.py
+++ b/grimoire_elk/enriched/dockerhub.py
@@ -137,13 +137,13 @@ class DockerHubEnrich(Enrich):
 
         url = self.elastic.index_url + '/items/_bulk'
 
-        logger.debug("Adding items to %s (in %i packs)", url, max_items)
+        logger.debug("Adding items to %s (in %i packs)", self.elastic.anonymize_url(url), max_items)
 
         for item in items:
             if current >= max_items:
                 total += self.elastic.safe_put_bulk(url, bulk_json)
                 json_size = sys.getsizeof(bulk_json) / (1024 * 1024)
-                logger.debug("Added %i items to %s (%0.2f MB)", total, url, json_size)
+                logger.debug("Added %i items to %s (%0.2f MB)", total, self.elastic.anonymize_url(url), json_size)
                 bulk_json = ""
                 current = 0
 

--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -347,7 +347,7 @@ class Enrich(ElasticItems):
 
         url = self.elastic.index_url + '/items/_bulk'
 
-        logger.debug("Adding items to %s (in %i packs)", url, max_items)
+        logger.debug("Adding items to %s (in %i packs)", self.elastic.anonymize_url(url), max_items)
 
         if events:
             logger.debug("Adding events items")
@@ -357,7 +357,7 @@ class Enrich(ElasticItems):
                 try:
                     total += self.elastic.safe_put_bulk(url, bulk_json)
                     json_size = sys.getsizeof(bulk_json) / (1024 * 1024)
-                    logger.debug("Added %i items to %s (%0.2f MB)", total, url, json_size)
+                    logger.debug("Added %i items to %s (%0.2f MB)", total, self.elastic.anonymize_url(url), json_size)
                 except UnicodeEncodeError:
                     # Why is requests encoding the POST data as ascii?
                     logger.error("Unicode error in enriched items")
@@ -952,7 +952,7 @@ class Enrich(ElasticItems):
 
         :return: None
         """
-        logger.info("[Demography] Starting study %s" % self.elastic.index_url)
+        logger.info("[Demography] Starting study %s", self.elastic.anonymize_url(self.elastic.index_url))
 
         # The first step is to find the current min and max date for all the authors
         authors_min_max_data = {}
@@ -991,7 +991,7 @@ class Enrich(ElasticItems):
 
         self.elastic.add_alias(DEMOGRAPHICS_ALIAS)
 
-        logger.info("[Demography] End %s", self.elastic.index_url)
+        logger.info("[Demography] End %s", self.elastic.anonymize_url(self.elastic.index_url))
 
     @staticmethod
     def authors_min_max_dates(date_field, author_field="author_uuid"):

--- a/grimoire_elk/enriched/git.py
+++ b/grimoire_elk/enriched/git.py
@@ -492,7 +492,7 @@ class GitEnrich(Enrich):
 
         url = self.elastic.index_url + '/items/_bulk'
 
-        logger.debug("Adding items to %s (in %i packs)", url, max_items)
+        logger.debug("Adding items to %s (in %i packs)", self.elastic.anonymize_url(url), max_items)
 
         items = ocean_backend.fetch()
 
@@ -522,7 +522,7 @@ class GitEnrich(Enrich):
                 try:
                     total += self.elastic.safe_put_bulk(url, bulk_json)
                     json_size = sys.getsizeof(bulk_json) / (1024 * 1024)
-                    logger.debug("Added %i items to %s (%0.2f MB)", total, url, json_size)
+                    logger.debug("Added %i items to %s (%0.2f MB)", total, self.elastic.anonymize_url(url), json_size)
                 except UnicodeEncodeError:
                     # Why is requests encoding the POST data as ascii?
                     logger.error("Unicode error in enriched items")

--- a/grimoire_elk/enriched/github.py
+++ b/grimoire_elk/enriched/github.py
@@ -231,7 +231,7 @@ class GitHubEnrich(Enrich):
 
         url = self.elastic.url + GEOLOCATION_INDEX + "geolocations/_bulk"
 
-        logger.debug("Adding geoloc to %s (in %i packs)" % (url, max_items))
+        logger.debug("Adding geoloc to %s (in %i packs)", self.elastic.anonymize_url(url), max_items)
 
         for loc in self.geolocations:
             if current >= max_items:
@@ -385,7 +385,8 @@ class GitHubEnrich(Enrich):
         # pull_requests index search url in which the data is to be updated
         enrich_index_search_url = self.elastic.index_url + "/_search"
 
-        logger.info("Doing enrich_pull_request study for index {}".format(self.elastic.index_url))
+        logger.info("Doing enrich_pull_request study for index {}"
+                    .format(self.elastic.anonymize_url(self.elastic.index_url)))
         time.sleep(1)  # HACK: Wait until git enrich index has been written
 
         def make_request(url, error_msg, data=None, req_type="GET"):

--- a/grimoire_elk/enriched/kitsune.py
+++ b/grimoire_elk/enriched/kitsune.py
@@ -217,7 +217,7 @@ class KitsuneEnrich(Enrich):
 
         url = self.elastic.index_url + '/items/_bulk'
 
-        logger.debug("Adding items to %s (in %i packs)", url, max_items)
+        logger.debug("Adding items to %s (in %i packs)", self.elastic.anonymize_url(url), max_items)
 
         items = ocean_backend.fetch()
         for item in items:

--- a/grimoire_elk/enriched/mbox.py
+++ b/grimoire_elk/enriched/mbox.py
@@ -211,7 +211,7 @@ class MBoxEnrich(Enrich):
 
         url = self.elastic.index_url + '/items/_bulk'
 
-        logger.debug("Adding items to %s (in %i packs)" % (url, max_items))
+        logger.debug("Adding items to %s (in %i packs)", self.elastic.anonymize_url(url), max_items)
 
         for item in items:
             if current >= max_items:

--- a/grimoire_elk/enriched/mbox_study_kip.py
+++ b/grimoire_elk/enriched/mbox_study_kip.py
@@ -434,7 +434,7 @@ def kafka_kip(enrich):
 
         logger.info("Total eitems with kafka kip fields %i", total)
 
-    logger.debug("Doing kafka_kip study from %s", enrich.elastic.index_url)
+    logger.debug("Doing kafka_kip study from %s", enrich.elastic.anonymize_url(enrich.elastic.index_url))
 
     # First iteration with the basic fields
     eitems = add_kip_fields(enrich)

--- a/grimoire_elk/enriched/mediawiki.py
+++ b/grimoire_elk/enriched/mediawiki.py
@@ -243,7 +243,7 @@ class MediaWikiEnrich(Enrich):
 
         url = self.elastic.index_url + '/items/_bulk'
 
-        logger.debug("Adding items to %s (in %i packs)" % (url, max_items))
+        logger.debug("Adding items to %s (in %i packs)", self.elastic.anonymize_url(url), max_items)
 
         items = ocean_backend.fetch()
         for item in items:

--- a/grimoire_elk/enriched/mozillaclub.py
+++ b/grimoire_elk/enriched/mozillaclub.py
@@ -153,7 +153,7 @@ class MozillaClubEnrich(Enrich):
 
         url = self.elastic.index_url + '/items/_bulk'
 
-        logger.debug("Adding items to %s (in %i packs)", url, max_items)
+        logger.debug("Adding items to %s (in %i packs)", self.elastic.anonymize_url(url), max_items)
 
         items = ocean_backend.fetch()
         for item in items:

--- a/tests/test_enrich.py
+++ b/tests/test_enrich.py
@@ -597,7 +597,8 @@ class TestEnrich(unittest.TestCase):
             self._enrich.elastic.add_alias(DEMOGRAPHICS_ALIAS)
 
         self.assertEqual(cm.output[0],
-                         'INFO:grimoire_elk.elastic:Alias %s created on %s.' % (DEMOGRAPHICS_ALIAS, tmp_index_url))
+                         'INFO:grimoire_elk.elastic:Alias %s created on %s.'
+                         % (DEMOGRAPHICS_ALIAS, self._enrich.elastic.anonymize_url(tmp_index_url)))
 
         r = self._enrich.requests.get(self._enrich.elastic.index_url + "/_alias", headers=HEADER_JSON, verify=False)
         self.assertIn(DEMOGRAPHICS_ALIAS, r.json()[self._enrich.elastic.index]['aliases'])
@@ -607,8 +608,8 @@ class TestEnrich(unittest.TestCase):
             self._enrich.elastic.add_alias(DEMOGRAPHICS_ALIAS)
 
         self.assertEqual(cm.output[0],
-                         'WARNING:grimoire_elk.elastic:Alias %s '
-                         'already exists on %s.' % (DEMOGRAPHICS_ALIAS, tmp_index_url))
+                         'WARNING:grimoire_elk.elastic:Alias %s already exists on %s.'
+                         % (DEMOGRAPHICS_ALIAS, self._enrich.elastic.anonymize_url(tmp_index_url)))
 
         requests.delete(tmp_index_url, verify=False)
 

--- a/tests/test_gerrit.py
+++ b/tests/test_gerrit.py
@@ -73,11 +73,11 @@ class TestGerrit(TestBaseBackend):
                 study(ocean_backend, enrich_backend, date_field="grimoire_creation_date")
 
             self.assertEqual(cm.output[0],
-                             'INFO:grimoire_elk.enriched.enrich:[Demography] Starting study '
-                             '%s/test_gerrit_enrich' % self.es_con)
+                             'INFO:grimoire_elk.enriched.enrich:[Demography] Starting study %s/test_gerrit_enrich'
+                             % enrich_backend.elastic.anonymize_url(self.es_con))
             self.assertEqual(cm.output[-1],
-                             'INFO:grimoire_elk.enriched.enrich:[Demography] '
-                             'End %s/test_gerrit_enrich' % self.es_con)
+                             'INFO:grimoire_elk.enriched.enrich:[Demography] End %s/test_gerrit_enrich'
+                             % enrich_backend.elastic.anonymize_url(self.es_con))
 
         time.sleep(1)  # HACK: Wait until git enrich index has been written
         for item in enrich_backend.fetch():

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -133,9 +133,11 @@ class TestGit(TestBaseBackend):
                 study(ocean_backend, enrich_backend, date_field="utc_commit")
 
             self.assertEqual(cm.output[0], 'INFO:grimoire_elk.enriched.enrich:[Demography] '
-                                           'Starting study %s/test_git_enrich' % self.es_con)
+                                           'Starting study %s/test_git_enrich'
+                             % enrich_backend.elastic.anonymize_url(self.es_con))
             self.assertEqual(cm.output[-1], 'INFO:grimoire_elk.enriched.enrich:[Demography] '
-                                            'End %s/test_git_enrich' % self.es_con)
+                                            'End %s/test_git_enrich'
+                             % enrich_backend.elastic.anonymize_url(self.es_con))
 
         time.sleep(1)  # HACK: Wait until git enrich index has been written
         for item in enrich_backend.fetch():


### PR DESCRIPTION
This PR allows to remove credentials (username and password) from the log messages which track the URLs that interact with the ElasticSearch server. Thus, it avoids possible security leaks when copy/paste traceback errors in no-safe environments (GitHub, GitLab).