### PR TITLE
[ELK] Use the cfg section name to retrieve project name

### DIFF
--- a/grimoire_elk/elastic_items.py
+++ b/grimoire_elk/elastic_items.py
@@ -53,6 +53,7 @@ class ElasticItems():
         self.requests = grimoire_con(insecure)
         self.elastic = None
         self.elastic_url = None
+        self.cfg_section_name = None
 
     def get_repository_filter_raw(self, term=False):
         """ Returns the filter to be used in queries in a repository items """
@@ -82,6 +83,9 @@ class ElasticItems():
         """ Find the name for the current connector """
         from .utils import get_connector_name
         return get_connector_name(type(self))
+
+    def set_cfg_section_name(self, cfg_section_name):
+        self.cfg_section_name = cfg_section_name
 
     # Items generator
     def fetch(self, _filter=None):

--- a/grimoire_elk/elk.py
+++ b/grimoire_elk/elk.py
@@ -503,7 +503,7 @@ def do_studies(ocean_backend, enrich_backend, studies_args):
                 raise e
 
 
-def enrich_backend(url, clean, backend_name, backend_params,
+def enrich_backend(url, clean, backend_name, backend_params, cfg_section_name,
                    ocean_index=None,
                    ocean_index_enrich=None,
                    db_projects_map=None, json_projects_map=None,
@@ -553,6 +553,8 @@ def enrich_backend(url, clean, backend_name, backend_params,
         enrich_backend = connector[2](db_sortinghat, db_projects_map, json_projects_map,
                                       db_user, db_password, db_host)
         enrich_backend.set_params(backend_params)
+        # store the cfg section name in the enrich backend to recover the corresponding project name in projects.json
+        enrich_backend.set_cfg_section_name(cfg_section_name)
         if url_enrich:
             elastic_enrich = get_elastic(url_enrich, enrich_index, clean, enrich_backend, es_enrich_aliases)
         else:

--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -525,8 +525,8 @@ class Enrich(ElasticItems):
         :param eitem: enriched item for which to find the project
         :return: the project entry (a dictionary)
         """
-
-        ds_name = self.get_connector_name()  # data source name in projects map
+        # get the data source name relying on the cfg section name, if null use the connector name
+        ds_name = self.cfg_section_name if self.cfg_section_name else self.get_connector_name()
         repository = self.get_project_repository(eitem)
         try:
             project = (self.prjs_map[ds_name][repository])


### PR DESCRIPTION
This PR replaces the use of the connector name with the cfg section name to retrieve the project name associated to a data source. 
In a nutshell, initially the connector name had a one-to-one correspondence with the cfg section name, which was used to get the project name in the projects.json. Recently, the cfg section name has been enhanced to include also an identifier (e.g., [gitlab:issue]), thus the connector name cannot be used anymore to find the project name and must be replaced with the cfg section name (which is now propagate from mordred to ELK).

Note that in case the cfg section name is null (this is the case when executing the tests in ELK), the connector name is used.