### PR TITLE
[studies] Prevent create aliases already in use

### DIFF
--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -996,7 +996,9 @@ class Enrich(ElasticItems):
                 logger.error(ex)
                 return
 
-        self.elastic.add_alias(DEMOGRAPHICS_ALIAS)
+        if not self.elastic.alias_in_use(DEMOGRAPHICS_ALIAS):
+            logger.info("Creating alias: %s", DEMOGRAPHICS_ALIAS)
+            self.elastic.add_alias(DEMOGRAPHICS_ALIAS)
 
         logger.info("[Demography] End %s", self.elastic.anonymize_url(self.elastic.index_url))
 

--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -935,7 +935,8 @@ class Enrich(ElasticItems):
 
         # Create alias if output index exists (index is always created from scratch, so
         # alias need to be created each time)
-        if out_conn.exists() and not out_conn.exists_alias(out_index, ONION_ALIAS):
+        if out_conn.exists() and not out_conn.exists_alias(out_index, ONION_ALIAS) \
+                and not self.elastic.alias_in_use(ONION_ALIAS):
             logger.info(log_prefix + " Creating alias: %s", ONION_ALIAS)
             out_conn.create_alias(ONION_ALIAS)
 

--- a/grimoire_elk/enriched/git.py
+++ b/grimoire_elk/enriched/git.py
@@ -625,7 +625,8 @@ class GitEnrich(Enrich):
 
         # Create alias if output index exists and alias does not
         if out_conn.exists():
-            if not out_conn.exists_alias(AREAS_OF_CODE_ALIAS):
+            if not out_conn.exists_alias(AREAS_OF_CODE_ALIAS) \
+                    and not enrich_backend.elastic.alias_in_use(AREAS_OF_CODE_ALIAS):
                 logger.info(log_prefix + " Creating alias: %s", AREAS_OF_CODE_ALIAS)
                 out_conn.create_alias(AREAS_OF_CODE_ALIAS)
             else:


### PR DESCRIPTION
This PR prevents to create the aliases for studies _demographics_, _onion_ and _areas of code_ if these aliases are already used on another indexes.

To test the PR, you can use micro-mordred with the following configuration and projects.json
**setup.cfg**
```
...
[git]
raw_index = git_chaoss_180804
enriched_index = git_chaoss_180804_enriched_180804
category = commit
studies = [enrich_demography:git, enrich_areas_of_code:git, enrich_onion:git]

[enrich_demography:git]
date_field = utc_commit
author_field = author_uuid

[enrich_areas_of_code:git]
#no_incremental = true
in_index = git_chaoss_180804
out_index = git-aoc_chaoss_enriched_180804

[enrich_onion:git]
in_index = git_chaoss_180804_enriched_180804
out_index = git-onion_chaoss_enriched_180804
contribs_field = hash
no_incremental = false
...
```

**projects.json**
```
...
"git": [
            "https://github.com/chaoss/grimoirelab-perceval"
        ],
...
```
Execute the following steps:
- run `micro --raw --enrich --cfg ./setup.cfg --backends git`
- check that the aliases `git_areas_of_code`,  `all_onion` and `demographipcs` are present at `https://localhost:9200/_alias?pretty`
- change the name of the indexes in the setup.cfg

```
...
[git]
raw_index = git_chaoss_18080x
enriched_index = git_chaoss_180804_enriched_18080x
category = commit
studies = [enrich_demography:git, enrich_areas_of_code:git, enrich_onion:git]

[enrich_demography:git]
date_field = utc_commit
author_field = author_uuid

[enrich_areas_of_code:git]
#no_incremental = true
in_index = git_chaoss_18080x
out_index = git-aoc_chaoss_enriched_18080x

[enrich_onion:git]
in_index = git_chaoss_180804_enriched_18080x
out_index = git-onion_chaoss_enriched_18080x
contribs_field = hash
no_incremental = false
...
```

- run `micro --raw --enrich --cfg ./setup.cfg --backends git`
- check that the aliases git_areas_of_code,  all_onion and demographipcs are not duplicated