### PR TITLE
[elastic] Change log message level when alias already exists

### DIFF
--- a/grimoire_elk/elastic.py
+++ b/grimoire_elk/elastic.py
@@ -240,7 +240,7 @@ class ElasticSearch(object):
         """
         aliases = self.list_aliases()
         if alias in aliases:
-            logger.warning("Alias %s already exists on %s.", alias, self.anonymize_url(self.index_url))
+            logger.debug("Alias %s already exists on %s.", alias, self.anonymize_url(self.index_url))
             return
 
         # add alias

--- a/tests/test_enrich.py
+++ b/tests/test_enrich.py
@@ -604,11 +604,11 @@ class TestEnrich(unittest.TestCase):
         self.assertIn(DEMOGRAPHICS_ALIAS, r.json()[self._enrich.elastic.index]['aliases'])
 
         # add alias again
-        with self.assertLogs(logger, level='INFO') as cm:
+        with self.assertLogs(logger, level='DEBUG') as cm:
             self._enrich.elastic.add_alias(DEMOGRAPHICS_ALIAS)
 
         self.assertEqual(cm.output[0],
-                         'WARNING:grimoire_elk.elastic:Alias %s already exists on %s.'
+                         'DEBUG:grimoire_elk.elastic:Alias %s already exists on %s.'
                          % (DEMOGRAPHICS_ALIAS, self._enrich.elastic.anonymize_url(tmp_index_url)))
 
         requests.delete(tmp_index_url, verify=False)

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -165,6 +165,9 @@ class TestGit(TestBaseBackend):
 
         self.assertGreater(response['count'], 0)
 
+        delete_onion = self.es_con + "/git_onion-enriched"
+        requests.delete(delete_onion, verify=False)
+
     def test_arthur_params(self):
         """Test the extraction of arthur params from an URL"""
 


### PR DESCRIPTION
This code changes the log message level from warning to debug when an alias already exists. This change aims at reducing the size of logs produced by the platform. The corresponding test has been changed accordingly. 
An additional fix has been provided to ensure the removal of the onion index at the end of the corresponding test. This was needed due to the fact that study aliases cannot be used in more indexes at the same time.