### PR TITLE
[ELK] Handle deleted commits

### DIFF
--- a/grimoire_elk/elk.py
+++ b/grimoire_elk/elk.py
@@ -423,6 +423,7 @@ def enrich_items(ocean_backend, enrich_backend, events=False):
 
     if not events:
         total = enrich_backend.enrich_items(ocean_backend)
+        enrich_backend.update_items(ocean_backend, enrich_backend)
     else:
         total = enrich_backend.enrich_events(ocean_backend)
     return total

--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -38,7 +38,8 @@ from elasticsearch import Elasticsearch
 from perceval.backend import find_signature_parameters
 from grimoirelab_toolkit.datetime import (datetime_utcnow, str_to_datetime)
 
-from ..elastic_items import ElasticItems
+from ..elastic_items import (ElasticItems,
+                             HEADER_JSON)
 from .study_ceres_onion import ESOnionConnector, onion_study
 
 from .utils import grimoire_con
@@ -73,8 +74,6 @@ CUSTOM_META_PREFIX = 'cm'
 SH_UNKNOWN_VALUE = 'Unknown'
 DEMOGRAPHICS_ALIAS = 'demographics'
 ONION_ALIAS = 'all_onion'
-
-HEADER_JSON = {"Content-Type": "application/json"}
 
 
 def metadata(func):
@@ -190,6 +189,12 @@ class Enrich(ElasticItems):
                                               parsed_args)
         backend_cmd.backend = backend_cmd.BACKEND(**init_args)
         self.perceval_backend = backend_cmd.backend
+
+    def update_items(self, ocean_backend, enrich_backend):
+        """Perform update operations over an enriched index, just after the enrichment
+        It must be redefined in the enriched connectors"""
+
+        return
 
     def __convert_json_to_projects_map(self, json):
         """ Convert JSON format to the projects map format

--- a/grimoire_elk/enriched/git.py
+++ b/grimoire_elk/enriched/git.py
@@ -662,6 +662,8 @@ class GitEnrich(Enrich):
             'value': [self.perceval_backend.origin]
         }
 
+        logger.debug("[update-items] Checking commits for %s.", self.perceval_backend.origin)
+
         git_repo = GitRepository(self.perceval_backend.uri, self.perceval_backend.gitpath)
         current_hashes = set([commit for commit in git_repo.rev_list()])
 
@@ -694,10 +696,12 @@ class GitEnrich(Enrich):
             self.remove_commits(to_process, enrich_backend.elastic.index_url,
                                 'hash', self.perceval_backend.origin)
 
-        logger.debug("[update-items] %s commits deleted from %s.",
-                     len(hashes_to_delete), ocean_backend.elastic.anonymize_url(self.elastic.index_url))
-        logger.debug("[update-items] %s commits deleted from %s.",
-                     len(hashes_to_delete), enrich_backend.elastic.anonymize_url(self.elastic.index_url))
+        logger.debug("[update-items] %s commits deleted from %s with origin %s.",
+                     len(hashes_to_delete), ocean_backend.elastic.anonymize_url(ocean_backend.elastic.index_url),
+                     self.perceval_backend.origin)
+        logger.debug("[update-items] %s commits deleted from %s with origin %s.",
+                     len(hashes_to_delete), enrich_backend.elastic.anonymize_url(enrich_backend.elastic.index_url),
+                     self.perceval_backend.origin)
 
     def remove_commits(self, items, index, attribute, origin):
         """Delete documents that correspond to commits deleted in the Git repository

--- a/grimoire_elk/raw/elastic.py
+++ b/grimoire_elk/raw/elastic.py
@@ -200,6 +200,13 @@ class ElasticOcean(ElasticItems):
                 items = self.perceval_backend.fetch()
 
         self.feed_items(items)
+        self.update_items()
+
+    def update_items(self):
+        """Perform update operations over a raw index, just after the collection.
+        It must be redefined in the raw connectors."""
+
+        return
 
     def feed_items(self, items):
         task_init = datetime.now()


### PR DESCRIPTION
This PR allows to handle deleted commits in Git raw and enriched indexes. 
A generic method `update_items` is included for raw and enriched connectors in order to update the corresponding indexes just after the collection and enrichment operations. For the case of Git, at the end of the enrichment, the list of current commit SHAs is retrieved from the repository and compared with the hashes stored in the raw index. The different of these two sets gives the deleted commits (the ones that are stored in ES but not present in the repo), which  are finally deleted from the raw and enriched indexes. 