### PR TITLE
[gerrit] Allow partial enrichment based on `--filter-raw`

### DIFF
--- a/grimoire_elk/elk.py
+++ b/grimoire_elk/elk.py
@@ -571,6 +571,7 @@ def enrich_backend(url, clean, backend_name, backend_params, cfg_section_name,
         # filter_raw must be converted from the string param to a dict
         filter_raw_dict = {}
         if filter_raw:
+            enrich_backend.set_filter_raw(filter_raw)
             filter_raw_dict['name'] = filter_raw.split(":")[0].replace('"', '')
             filter_raw_dict['value'] = filter_raw.split(":")[1].replace('"', '')
         # filters_raw_prefix must be converted from the list param to

--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -533,12 +533,22 @@ class Enrich(ElasticItems):
         # get the data source name relying on the cfg section name, if null use the connector name
         ds_name = self.cfg_section_name if self.cfg_section_name else self.get_connector_name()
         repository = self.get_project_repository(eitem)
+
         try:
             project = (self.prjs_map[ds_name][repository])
             # logger.debug("Project FOUND for repository %s %s", repository, project)
         except KeyError:
             # logger.warning("Project not found for repository %s (data source: %s)", repository, ds_name)
             project = None
+
+            if self.filter_raw:
+                fltr = eitem['origin'] + ' --filter-raw=' + self.filter_raw
+                if ds_name in self.prjs_map and fltr in self.prjs_map[ds_name]:
+                    project = self.prjs_map[ds_name][fltr]
+
+            if project:
+                return project
+
             # Try to use always the origin in any case
             if 'origin' in eitem:
                 if ds_name in self.prjs_map and eitem['origin'] in self.prjs_map[ds_name]:

--- a/grimoire_elk/raw/gerrit.py
+++ b/grimoire_elk/raw/gerrit.py
@@ -83,3 +83,16 @@ class Mapping(BaseMapping):
 class GerritOcean(ElasticOcean):
 
     mapping = Mapping
+
+    @classmethod
+    def get_p2o_params_from_url(cls, url):
+        params = {}
+
+        tokens = url.split(' ', 1)  # Just split the URL not the filter
+        params['url'] = tokens[0]
+
+        if len(tokens) > 1:
+            f = tokens[1].split("=")[1]
+            params['filter-raw'] = f
+
+        return params


### PR DESCRIPTION
This PR allows to filter a part of the raw data for enrichment. In a nutshell, this is done by including the param `--filter-raw` in the repo within the projects.json. Later, ELK automatically creates a filter
to retain only the data that match the value of `filter-raw`.