### PR TITLE
Remove alias in use check for onion

### DIFF
--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -950,8 +950,7 @@ class Enrich(ElasticItems):
 
         # Create alias if output index exists (index is always created from scratch, so
         # alias need to be created each time)
-        if out_conn.exists() and not out_conn.exists_alias(out_index, ONION_ALIAS) \
-                and not self.elastic.alias_in_use(ONION_ALIAS):
+        if out_conn.exists() and not out_conn.exists_alias(out_index, ONION_ALIAS):
             logger.info(log_prefix + " Creating alias: %s", ONION_ALIAS)
             out_conn.create_alias(ONION_ALIAS)
 


### PR DESCRIPTION
This commit removes the check for `all_onion` alias that
prevents its creation if it is already in use. This check
only allowed to link one data source to the alias, so onion
data for the rest of the sources remained unlinked.