### PR TITLE
[elk] Use filter-raw to get the last enrich date

### DIFF
--- a/grimoire_elk/elastic.py
+++ b/grimoire_elk/elastic.py
@@ -420,10 +420,7 @@ class ElasticSearch(object):
             term = '''{"term" : { "%s" : "%s"}}''' % (filter_['name'], filter_['value'])
             terms.append(term)
 
-        if len(filters_) == 1:
-            data_query = '"query": %s,"' % filters_[0]
-        else:
-            data_query = '''"query": {"bool": {"filter": [%s]}},''' % (','.join(t for t in terms))
+        data_query = '''"query": {"bool": {"filter": [%s]}},''' % (','.join(terms))
 
         data_agg = '''
             "aggs": {
@@ -433,7 +430,7 @@ class ElasticSearch(object):
                   }
                 }
             }
-        ''' % (field)
+        ''' % field
 
         data_json = '''
         { "size": 0, %s  %s

--- a/grimoire_elk/elastic.py
+++ b/grimoire_elk/elastic.py
@@ -410,17 +410,20 @@ class ElasticSearch(object):
         url = self.index_url
         url += "/_search"
 
-        data_query = ''
         if filters_ is None:
             filters_ = []
+
+        terms = []
         for filter_ in filters_:
             if not filter_:
                 continue
-            data_query += '''
-                "query" : {
-                    "term" : { "%s" : "%s"  }
-                 },
-            ''' % (filter_['name'], filter_['value'])
+            term = '''{"term" : { "%s" : "%s"}}''' % (filter_['name'], filter_['value'])
+            terms.append(term)
+
+        if len(filters_) == 1:
+            data_query = '"query": %s,"' % filters_[0]
+        else:
+            data_query = '''"query": {"bool": {"filter": [%s]}},''' % (','.join(t for t in terms))
 
         data_agg = '''
             "aggs": {

--- a/grimoire_elk/enriched/utils.py
+++ b/grimoire_elk/enriched/utils.py
@@ -163,20 +163,28 @@ def get_last_enrich(backend_cmd, enrich_backend):
             except AttributeError:
                 offset = backend_cmd.parsed_args.offset
 
+        filter_raw_dict = None
+        if enrich_backend.filter_raw:
+            filter_raw = enrich_backend.filter_raw
+            filter_raw_dict = {
+                'name': filter_raw.split(":")[0].replace('"', ''),
+                'value': filter_raw.split(":")[1].replace('"', '')
+            }
+
         if from_date:
             if from_date.replace(tzinfo=None) != parser.parse("1970-01-01"):
                 last_enrich = from_date
             else:
-                last_enrich = enrich_backend.get_last_update_from_es([filter_])
+                last_enrich = enrich_backend.get_last_update_from_es([filter_, filter_raw_dict])
 
         elif offset is not None:
             if offset != 0:
                 last_enrich = offset
             else:
-                last_enrich = enrich_backend.get_last_offset_from_es([filter_])
+                last_enrich = enrich_backend.get_last_offset_from_es([filter_, filter_raw_dict])
 
         else:
-            last_enrich = enrich_backend.get_last_update_from_es([filter_])
+            last_enrich = enrich_backend.get_last_update_from_es([filter_, filter_raw_dict])
     else:
         last_enrich = enrich_backend.get_last_update_from_es()
 


### PR DESCRIPTION
This PR allows to include the `filter-raw` param to identify the last date of enrichment for a given index composed by items having the same origin, but coming from different projects (bugzilla, gerrit, jira). 
In a nutshell, the current way of calculating the last date of enrichment takes into account only the origin and the `metadata_timestamp`, while the proposed solution includes also the `filter-raw` param, thus allowing to identify the last date of enriched items for a given filter (e.g., project).