### PR TITLE
[ELK] Add GitHub stats support

### DIFF
--- a/grimoire_elk/enriched/github_stats.py
+++ b/grimoire_elk/enriched/github_stats.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#
+#
+# Copyright (C) 2015 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+#
+# Authors:
+#   Valerio Cosentino <valcos@bitergia.com>
+#
+
+import logging
+
+from .enrich import Enrich, metadata
+
+
+logger = logging.getLogger(__name__)
+
+
+class GitHubStatsEnrich(Enrich):
+
+    def get_identities(self, item):
+        """Return the identities from an item"""
+        identities = []
+
+        return identities
+
+    def has_identities(self):
+        """Return whether the enriched items contains identities"""
+
+        return False
+
+    @metadata
+    def get_rich_item(self, item):
+        eitem = {}
+
+        for f in self.RAW_FIELDS_COPY:
+            if f in item:
+                eitem[f] = item[f]
+            else:
+                eitem[f] = None
+
+        entry = item['data']
+
+        for e in entry.keys():
+            eitem[e] = entry[e]
+
+        if self.prjs_map:
+            eitem.update(self.get_item_project(eitem))
+
+        eitem.update(self.get_grimoire_fields(item["metadata__updated_on"], "repository"))
+
+        return eitem

--- a/grimoire_elk/raw/github_stats.py
+++ b/grimoire_elk/raw/github_stats.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# StackExchange Ocean feeder
+#
+# Copyright (C) 2015 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+#
+# Authors:
+#   Valerio Cosentino <valcos@bitergia.com>
+#
+
+"""GitHubStats Ocean feeder"""
+
+from ..elastic_mapping import Mapping
+from .github import GitHubOcean
+
+
+class GitHubStats(GitHubOcean):
+    """GitHubStats Ocean feeder"""
+
+    mapping = Mapping

--- a/grimoire_elk/utils.py
+++ b/grimoire_elk/utils.py
@@ -80,6 +80,7 @@ from .enriched.functest import FunctestEnrich
 from .enriched.gerrit import GerritEnrich
 from .enriched.git import GitEnrich
 from .enriched.github import GitHubEnrich
+from .enriched.github_stats import GitHubStatsEnrich
 from .enriched.gitlab import GitLabEnrich
 from .enriched.google_hits import GoogleHitsEnrich
 from .enriched.groupsio import GroupsioEnrich
@@ -117,6 +118,7 @@ from .raw.functest import FunctestOcean
 from .raw.gerrit import GerritOcean
 from .raw.git import GitOcean
 from .raw.github import GitHubOcean
+from .raw.github_stats import GitHubStats
 from .raw.gitlab import GitLabOcean
 from .raw.google_hits import GoogleHitsOcean
 from .raw.groupsio import GroupsioOcean
@@ -207,6 +209,7 @@ def get_connectors():
             "gerrit": [Gerrit, GerritOcean, GerritEnrich, GerritCommand],
             "git": [Git, GitOcean, GitEnrich, GitCommand],
             "github": [GitHub, GitHubOcean, GitHubEnrich, GitHubCommand],
+            "githubstats": [GitHub, GitHubStats, GitHubStatsEnrich, GitHubCommand],
             "gitlab": [GitLab, GitLabOcean, GitLabEnrich, GitLabCommand],
             "google_hits": [GoogleHits, GoogleHitsOcean, GoogleHitsEnrich, GoogleHitsCommand],
             "groupsio": [Groupsio, GroupsioOcean, GroupsioEnrich, GroupsioCommand],

--- a/tests/data/githubstats.json
+++ b/tests/data/githubstats.json
@@ -1,0 +1,56 @@
+[
+    {
+        "backend_name": "GitHub",
+        "backend_version": "0.19.0",
+        "category": "repository",
+        "data": {
+            "forks": 16699,
+            "id": "2ecf2b4131e3a239132a5c6f44412ed01f56a43b",
+            "stars": 48218,
+            "updated_at": "2018-02-15T08:58:08Z",
+            "watchers": 2901
+        },
+        "origin": "https://github.com/kubernetes/kubernetes",
+        "perceval_version": "0.12.5",
+        "tag": "https://github.com/kubernetes/kubernetes",
+        "timestamp": 1550221871.014851,
+        "updated_on": 1518685088.0,
+        "uuid": "909d743739e22f9e6b84d73a69b0c9e243915699"
+    },
+    {
+        "backend_name": "GitHub",
+        "backend_version": "0.19.0",
+        "category": "repository",
+        "data": {
+            "forks": 16699,
+            "id": "96899408f318d170efdcb13805f0694234686198",
+            "stars": 47118,
+            "updated_at": "2018-03-15T08:58:08Z",
+            "watchers": 4301
+        },
+        "origin": "https://github.com/kubernetes/kubernetes",
+        "perceval_version": "0.12.5",
+        "tag": "https://github.com/kubernetes/kubernetes",
+        "timestamp": 1550222062.699868,
+        "updated_on": 1521104288.0,
+        "uuid": "d34efc4786e63e74541b37f6f78950c963ca87ab"
+    },
+    {
+        "backend_name": "GitHub",
+        "backend_version": "0.19.0",
+        "category": "repository",
+        "data": {
+            "forks": 1,
+            "id": "1f70c18454765686ce91c4ac9aed67a27d94cfe1",
+            "stars": 1,
+            "updated_at": "2018-10-15T08:58:08Z",
+            "watchers": 1
+        },
+        "origin": "https://github.com/kubernetes/kubernetes",
+        "perceval_version": "0.12.5",
+        "tag": "https://github.com/kubernetes/kubernetes",
+        "timestamp": 1550222122.896528,
+        "updated_on": 1539593888.0,
+        "uuid": "e40118e25d317f1b312ca7161dee8e5063e90c84"
+    }
+]

--- a/tests/test_githubstats.py
+++ b/tests/test_githubstats.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2016 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+#
+# Authors:
+#     Valerio Cosentino <valcos@bitergia.com>
+#
+import json
+import logging
+import unittest
+
+from base import TestBaseBackend
+from grimoire_elk.raw.github_stats import GitHubStats
+
+
+class TestGitHubStats(TestBaseBackend):
+    """Test GitHubStats backend"""
+
+    connector = "githubstats"
+    ocean_index = "test_" + connector
+    enrich_index = "test_" + connector + "_enrich"
+
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertFalse(enrich_backend.has_identities())
+
+    def test_items_to_raw(self):
+        """Test whether JSON items are properly inserted into ES"""
+
+        result = self._test_items_to_raw()
+
+        self.assertGreater(result['items'], 0)
+        self.assertGreater(result['raw'], 0)
+        self.assertEqual(result['items'], result['raw'])
+
+    def test_raw_to_enrich(self):
+        """Test whether the raw index is properly enriched"""
+
+        result = self._test_raw_to_enrich()
+
+        self.assertGreater(result['raw'], 0)
+        self.assertGreater(result['enrich'], 0)
+        self.assertEqual(result['raw'], result['enrich'])
+
+        enrich_backend = self.connectors[self.connector][2]()
+
+        item = self.items[0]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['forks'], 16699)
+        self.assertEqual(eitem['stars'], 48218)
+        self.assertEqual(eitem['watchers'], 2901)
+
+        item = self.items[1]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['forks'], 16699)
+        self.assertEqual(eitem['stars'], 47118)
+        self.assertEqual(eitem['watchers'], 4301)
+
+        item = self.items[2]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['forks'], 1)
+        self.assertEqual(eitem['stars'], 1)
+        self.assertEqual(eitem['watchers'], 1)
+
+    def test_raw_to_enrich_projects(self):
+        """Test enrich with Projects"""
+
+        result = self._test_raw_to_enrich(projects=True)
+        # ... ?
+
+    def test_refresh_project(self):
+        """Test refresh project field for all sources"""
+
+        result = self._test_refresh_project()
+        # ... ?
+
+    def test_arthur_params(self):
+        """Test the extraction of arthur params from an URL"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['github'][0]
+            arthur_params = {'owner': 'chaoss', 'repository': 'grimoirelab-perceval'}
+            self.assertDictEqual(arthur_params, GitHubStats.get_arthur_params_from_url(url))
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+    logging.getLogger("requests").setLevel(logging.WARNING)
+    unittest.main(warnings='ignore')


### PR DESCRIPTION
This PR provides support to track GitHub repository stats such as the evolution of forks, stars and watchers. Test have been included.

Find below an example about how to use it from mordred:
**setup.cfg**
```
[githubstats]
raw_index = test_github-repo-raw
enriched_index = test_github-repo
api-token = ....
sleep-for-rate = true
no-archive = true
category = repository
```

**projects.json**
```
"githubstats": [
   "https://github.com/chaoss/grimoirelab-perceval"
]
```