### PR TITLE
[enrich] Add mbox_author_domain to mbox data

### DIFF
--- a/grimoire_elk/enriched/mbox.py
+++ b/grimoire_elk/enriched/mbox.py
@@ -179,6 +179,9 @@ class MBoxEnrich(Enrich):
         except Exception:
             eitem["tz"] = None
 
+        identity = self.get_sh_identity(message['from'])
+        eitem["mbox_author_domain"] = self.get_identity_domain(identity)
+
         if self.sortinghat:
             eitem.update(self.get_item_sh(item))
 

--- a/schema/mbox.csv
+++ b/schema/mbox.csv
@@ -11,6 +11,7 @@ Date,keyword
 email_date,date
 From_bot,boolean
 From_domain,keyword
+mbox_author_domain,keyword
 From_id,keyword
 From_name,keyword
 From_org_name,keyword

--- a/tests/data/mbox.json
+++ b/tests/data/mbox.json
@@ -17,7 +17,7 @@
     "tag": "http://example.com/",
     "timestamp": 1518165519.417628,
     "updated_on": 1291210000.0,
-    "uuid": "86315b479b4debe320b59c881c1e375216cbf333"
+    "uuid": "86315b479b4debe320b59c881c1e375216cbf336"
 },{
     "backend_name": "MBox",
     "backend_version": "0.8.1",

--- a/tests/test_groupsio.py
+++ b/tests/test_groupsio.py
@@ -56,6 +56,12 @@ class TestGrousio(TestBaseBackend):
         self.assertEqual(result['raw'], 50)
         self.assertEqual(result['enrich'], 50)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        item = self.items[0]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['mbox_author_domain'], 'groups.io')
+
     def test_raw_to_enrich_sorting_hat(self):
         """Test enrich with SortingHat"""
 

--- a/tests/test_hyperkitty.py
+++ b/tests/test_hyperkitty.py
@@ -57,6 +57,20 @@ class TestHyperkitty(TestBaseBackend):
         self.assertEqual(result['raw'], 3)
         self.assertEqual(result['enrich'], 3)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        item = self.items[0]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['mbox_author_domain'], 'example.com')
+
+        item = self.items[1]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['mbox_author_domain'], 'example.com')
+
+        item = self.items[2]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['mbox_author_domain'], 'example.com')
+
     def test_raw_to_enrich_sorting_hat(self):
         """Test enrich with SortingHat"""
 

--- a/tests/test_mbox.py
+++ b/tests/test_mbox.py
@@ -56,22 +56,60 @@ class TestMbox(TestBaseBackend):
         """Test whether the raw index is properly enriched"""
 
         result = self._test_raw_to_enrich()
-        self.assertEqual(result['raw'], 8)
-        self.assertEqual(result['enrich'], 8)
+        self.assertEqual(result['raw'], 9)
+        self.assertEqual(result['enrich'], 9)
+
+        enrich_backend = self.connectors[self.connector][2]()
+
+        item = self.items[0]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['mbox_author_domain'], 'domain.com')
+
+        item = self.items[1]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['mbox_author_domain'], 'domain.com')
+
+        item = self.items[2]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['mbox_author_domain'], 'hotmail.com')
+
+        item = self.items[3]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['mbox_author_domain'], 'gnome.org')
+
+        item = self.items[4]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['mbox_author_domain'], 'wellsfargo.com')
+
+        item = self.items[5]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['mbox_author_domain'], 'example.com')
+
+        item = self.items[6]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['mbox_author_domain'], 'example.com')
+
+        item = self.items[7]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['mbox_author_domain'], 'domain.com')
+
+        item = self.items[8]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['mbox_author_domain'], 'example.org')
 
     def test_raw_to_enrich_sorting_hat(self):
         """Test enrich with SortingHat"""
 
         result = self._test_raw_to_enrich(sortinghat=True)
-        self.assertEqual(result['raw'], 8)
-        self.assertEqual(result['enrich'], 8)
+        self.assertEqual(result['raw'], 9)
+        self.assertEqual(result['enrich'], 9)
 
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 
         result = self._test_raw_to_enrich(projects=True)
-        self.assertEqual(result['raw'], 8)
-        self.assertEqual(result['enrich'], 8)
+        self.assertEqual(result['raw'], 9)
+        self.assertEqual(result['enrich'], 9)
 
     def test_refresh_identities(self):
         """Test refresh identities"""

--- a/tests/test_nntp.py
+++ b/tests/test_nntp.py
@@ -56,6 +56,32 @@ class TestNNTP(TestBaseBackend):
         self.assertEqual(result['raw'], 6)
         self.assertEqual(result['enrich'], 6)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        item = self.items[0]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['mbox_author_domain'], 'example.com')
+
+        item = self.items[1]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['mbox_author_domain'], 'mozilla.com')
+
+        item = self.items[2]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['mbox_author_domain'], 'mozilla.com')
+
+        item = self.items[3]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['mbox_author_domain'], 'mozilla.com')
+
+        item = self.items[4]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['mbox_author_domain'], 'mcav.com')
+
+        item = self.items[5]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['mbox_author_domain'], 'example.com')
+
     def test_raw_to_enrich_sorting_hat(self):
         """Test enrich with SortingHat"""
 

--- a/tests/test_pipermail.py
+++ b/tests/test_pipermail.py
@@ -56,6 +56,16 @@ class TestPipermail(TestBaseBackend):
         self.assertEqual(result['raw'], 17)
         self.assertEqual(result['enrich'], 17)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        item = self.items[0]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['mbox_author_domain'], 'acm.org')
+
+        item = self.items[1]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['mbox_author_domain'], 'redhat.com')
+
     def test_raw_to_enrich_sorting_hat(self):
         """Test enrich with SortingHat"""
 


### PR DESCRIPTION
This code includes the new field `mbox_author_domain` in the enrich data. It contains the email address of the sender not processed by SH. Tests and schema have been updated accordingly.
