### PR TITLE
[raw] Handle filter raw for confluence

### DIFF
--- a/grimoire_elk/raw/confluence.py
+++ b/grimoire_elk/raw/confluence.py
@@ -64,3 +64,16 @@ class ConfluenceOcean(ElasticOcean):
     """Confluence Ocean feeder"""
 
     mapping = Mapping
+
+    @classmethod
+    def get_p2o_params_from_url(cls, url):
+        params = {}
+
+        tokens = url.split(' ', 1)  # Just split the URL not the filter
+        params['url'] = tokens[0]
+
+        if len(tokens) > 1:
+            f = tokens[1].split("=")[1]
+            params['filter-raw'] = f
+
+        return params


### PR DESCRIPTION
This code allows to parse the filter raw information from the entries within the mordred projects.json.
The projects.json should be changed to the following way:
`"concourse-url --filter-raw=data._expandable.space:/rest/api/space/your-project"`