### PR TITLE
[raw] Handle filter raw for jira

### DIFF
--- a/grimoire_elk/raw/jira.py
+++ b/grimoire_elk/raw/jira.py
@@ -85,7 +85,23 @@ class JiraOcean(ElasticOcean):
     @classmethod
     def get_arthur_params_from_url(cls, url):
         """ Get the arthur params given a URL for the data source """
-        return {"url": url}
+
+        tokens = url.split(' ', 1)
+
+        return {"url": tokens[0]}
+
+    @classmethod
+    def get_p2o_params_from_url(cls, url):
+        params = {}
+
+        tokens = url.split(' ', 1)
+        params['url'] = tokens[0]
+
+        if len(tokens) > 1:
+            f = tokens[1].split("=")[1]
+            params['filter-raw'] = f
+
+        return params
 
     def _fix_item(self, item):
         # Remove all custom fields to avoid the 1000 fields limit in ES

--- a/tests/data/projects-release.json
+++ b/tests/data/projects-release.json
@@ -63,7 +63,7 @@
             "https://jira.iotivity.org/"
         ],
         "jira": [
-            "https://jira.opnfv.org"
+            "https://jira.opnfv.org --filter-raw=data.fields.project.key:PROJECT-KEY"
         ],
         "kitsune": [""],
         "mattermost": [

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -25,7 +25,7 @@ import logging
 import unittest
 
 from base import TestBaseBackend
-from grimoire_elk.raw.jenkins import JenkinsOcean
+from grimoire_elk.raw.jira import JiraOcean
 
 
 class TestJira(TestBaseBackend):
@@ -97,12 +97,20 @@ class TestJira(TestBaseBackend):
         # ... ?
 
     def test_arthur_params(self):
-        """Test the extraction of arthur params from an URL"""
+        """Test the extraction of arthur params from the projects.json entry"""
 
         with open("data/projects-release.json") as projects_filename:
-            url = json.load(projects_filename)['grimoire']['jenkins'][0]
-            arthur_params = {'uri': 'https://build.opnfv.org/ci', 'url': 'https://build.opnfv.org/ci'}
-            self.assertDictEqual(arthur_params, JenkinsOcean.get_arthur_params_from_url(url))
+            url = json.load(projects_filename)['grimoire']['jira'][0]
+            arthur_params = {'url': 'https://jira.opnfv.org'}
+            self.assertDictEqual(arthur_params, JiraOcean.get_arthur_params_from_url(url))
+
+    def test_get_p2o_params_from_url(self):
+        """Test the extraction of p2o params from the projects.json entry"""
+
+        with open("data/projects-release.json") as projects_filename:
+            url = json.load(projects_filename)['grimoire']['jira'][0]
+            p2o_params = {'url': 'https://jira.opnfv.org', 'filter-raw': 'data.fields.project.key:PROJECT-KEY'}
+            self.assertDictEqual(p2o_params, JiraOcean.get_p2o_params_from_url(url))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR allows to parse the filter raw information from the entries within the mordred projects.json. The projects.json should be changed to the following way:
`jira-url --filter-raw=data.fields.project.key:TARGET-PROJECT-KEY`

Tests have been added.