### PR TITLE
[enrich] Update branch info in git commits

### DIFF
--- a/schema/git.csv
+++ b/schema/git.csv
@@ -31,6 +31,7 @@ ocean-unique-id,keyword,true,"Unique identifier for all of the datasets in the i
 origin,keyword,true,"Original URL where the repository was retrieved from."
 project_1,keyword,true,"Project (if more than one level is allowed in project hierarchy)"
 project,keyword,true,"Project."
+branches,keyword,true,"List of branches where the commit appears."
 repo_name,keyword,true,"Repository name."
 tag,keyword,true,"Perceval tag."
 title,keyword,true,"Commit title."


### PR DESCRIPTION
This code allows to update the branch information of the JSON documents representing Git commits. First the list of branches is cleared in the enriched index, then the original repo is queried to retrieve the list of commit hashes for each branch and finally the obtained hashes are added to the branches attribute of the documents.

Git schema and enrich/utils have been updated. The former now includes the `branches` attribute, the latter enables the retry mechanism for 409 HTTP errors, which may occur for the operations `update_by_query` and `delete_by_query`.

Find below some performance tests:
- perceval
  - without branch update: 4 secs
  - with branch update: 5 secs
- mordred
  - without branch update: 4 secs
  - with branch update only for enrich: 1min20secs
- elastic/kibana
  - withouth branch update: 2 mins
  - with branch update: 35 mins
  - wich branch update only for enrich: 12 mins

This PR replaces https://github.com/chaoss/grimoirelab-elk/pull/561