### PR TITLE
[raw] Parse filters passed in the projects.json entries

### DIFF
--- a/grimoire_elk/elk.py
+++ b/grimoire_elk/elk.py
@@ -566,29 +566,14 @@ def enrich_backend(url, clean, backend_name, backend_params, cfg_section_name,
         if node_regex:
             enrich_backend.node_regex = node_regex
 
-        # filter_raw must be converted from the string param to a dict
-        filter_raw_dict = {}
         if filter_raw:
             enrich_backend.set_filter_raw(filter_raw)
-            filter_raw_dict['name'] = filter_raw.split(":")[0].replace('"', '')
-            filter_raw_dict['value'] = filter_raw.split(":")[1].replace('"', '')
-        # filters_raw_prefix must be converted from the list param to
-        # DSL query format for a should filter inside a boolean filter
-        filter_raw_should = None
-        if filters_raw_prefix:
-            filter_raw_should = {"should": []}
-            for filter_prefix in filters_raw_prefix:
-                fname = filter_prefix.split(":")[0].replace('"', '')
-                fvalue = filter_prefix.split(":")[1].replace('"', '')
-                filter_raw_should["should"].append(
-                    {
-                        "prefix": {fname: fvalue}
-                    }
-                )
+        elif filters_raw_prefix:
+            enrich_backend.set_filter_raw_should(filters_raw_prefix)
 
         ocean_backend = get_ocean_backend(backend_cmd, enrich_backend,
-                                          no_incremental, filter_raw_dict,
-                                          filter_raw_should)
+                                          no_incremental, filter_raw,
+                                          filters_raw_prefix)
 
         if only_studies:
             logger.info("Running only studies (no SH and no enrichment)")

--- a/grimoire_elk/enriched/utils.py
+++ b/grimoire_elk/enriched/utils.py
@@ -165,28 +165,20 @@ def get_last_enrich(backend_cmd, enrich_backend):
             except AttributeError:
                 offset = backend_cmd.parsed_args.offset
 
-        filter_raw_dict = None
-        if enrich_backend.filter_raw:
-            filter_raw = enrich_backend.filter_raw
-            filter_raw_dict = {
-                'name': filter_raw.split(":")[0].replace('"', ''),
-                'value': filter_raw.split(":")[1].replace('"', '')
-            }
-
         if from_date:
             if from_date.replace(tzinfo=None) != parser.parse("1970-01-01"):
                 last_enrich = from_date
             else:
-                last_enrich = enrich_backend.get_last_update_from_es([filter_, filter_raw_dict])
+                last_enrich = enrich_backend.get_last_update_from_es([filter_])
 
         elif offset is not None:
             if offset != 0:
                 last_enrich = offset
             else:
-                last_enrich = enrich_backend.get_last_offset_from_es([filter_, filter_raw_dict])
+                last_enrich = enrich_backend.get_last_offset_from_es([filter_])
 
         else:
-            last_enrich = enrich_backend.get_last_update_from_es([filter_, filter_raw_dict])
+            last_enrich = enrich_backend.get_last_update_from_es([filter_])
     else:
         last_enrich = enrich_backend.get_last_update_from_es()
 

--- a/grimoire_elk/raw/askbot.py
+++ b/grimoire_elk/raw/askbot.py
@@ -72,19 +72,3 @@ class AskbotOcean(ElasticOcean):
     def _fix_item(self, item):
         # item["ocean-unique-id"] = str(item["data"]["id"])+"_"+item['origin']
         item["ocean-unique-id"] = item["uuid"]
-
-    @classmethod
-    def get_p2o_params_from_url(cls, url):
-        # askbot could include in the URL a  filters-raw-prefix T1721
-        # "https://ask.openstack.org filter-raw=data.tags:rdo"
-        params = {}
-
-        tokens = url.split(' ', 1)  # Just split the URL not the filter
-        params['url'] = tokens[0]
-
-        if len(tokens) > 1:
-            filter_raw = tokens[1].split(" ", 1)[1]
-            # Create a filters array
-            params['filter-raw'] = filter_raw
-
-        return params

--- a/grimoire_elk/raw/bugzilla.py
+++ b/grimoire_elk/raw/bugzilla.py
@@ -77,18 +77,3 @@ class BugzillaOcean(ElasticOcean):
         # Could be used for filtering
         product = item['data']['product'][0]['__text__']
         item['product'] = product
-
-    @classmethod
-    def get_p2o_params_from_url(cls, url):
-        # Bugzilla could include in the URL a filter-raw T1720
-        # https://bugzilla.redhat.com/ filter-raw=product:OpenShift Origin
-        params = {}
-
-        tokens = url.split(' ', 1)  # Just split the URL not the filter
-        params['url'] = tokens[0]
-
-        if len(tokens) > 1:
-            f = tokens[1].split("=")[1]
-            params['filter-raw'] = f
-
-        return params

--- a/grimoire_elk/raw/confluence.py
+++ b/grimoire_elk/raw/confluence.py
@@ -64,16 +64,3 @@ class ConfluenceOcean(ElasticOcean):
     """Confluence Ocean feeder"""
 
     mapping = Mapping
-
-    @classmethod
-    def get_p2o_params_from_url(cls, url):
-        params = {}
-
-        tokens = url.split(' ', 1)  # Just split the URL not the filter
-        params['url'] = tokens[0]
-
-        if len(tokens) > 1:
-            f = tokens[1].split("=")[1]
-            params['filter-raw'] = f
-
-        return params

--- a/grimoire_elk/raw/gerrit.py
+++ b/grimoire_elk/raw/gerrit.py
@@ -81,16 +81,3 @@ class Mapping(BaseMapping):
 class GerritOcean(ElasticOcean):
 
     mapping = Mapping
-
-    @classmethod
-    def get_p2o_params_from_url(cls, url):
-        params = {}
-
-        tokens = url.split(' ', 1)  # Just split the URL not the filter
-        params['url'] = tokens[0]
-
-        if len(tokens) > 1:
-            f = tokens[1].split("=")[1]
-            params['filter-raw'] = f
-
-        return params

--- a/grimoire_elk/raw/git.py
+++ b/grimoire_elk/raw/git.py
@@ -61,23 +61,6 @@ class GitOcean(ElasticOcean):
     mapping = Mapping
 
     @classmethod
-    def get_p2o_params_from_url(cls, url):
-        # Git could include in the URL a  filters-raw-prefix T1722
-        # https://github.com/VizGrimoire/GrimoireLib --filters-raw-prefix \
-        #  data.files.file:grimoirelib_alch data.files.file:README.md
-        params = {}
-
-        tokens = url.split(' ', 1)  # Just split the URL not the filter
-        params['url'] = tokens[0]
-
-        if len(tokens) > 1:
-            f = tokens[1].split(" ", 1)[1]
-            # Create a filters array
-            params['filters-raw-prefix'] = f.split(" ")
-
-        return params
-
-    @classmethod
     def get_perceval_params_from_url(cls, url):
         params = []
         tokens = url.split(' ', 1)  # Just split the URL not the filter

--- a/grimoire_elk/raw/jira.py
+++ b/grimoire_elk/raw/jira.py
@@ -90,19 +90,6 @@ class JiraOcean(ElasticOcean):
 
         return {"url": tokens[0]}
 
-    @classmethod
-    def get_p2o_params_from_url(cls, url):
-        params = {}
-
-        tokens = url.split(' ', 1)
-        params['url'] = tokens[0]
-
-        if len(tokens) > 1:
-            f = tokens[1].split("=")[1]
-            params['filter-raw'] = f
-
-        return params
-
     def _fix_item(self, item):
         # Remove all custom fields to avoid the 1000 fields limit in ES
 

--- a/tests/test_elastic_ocean.py
+++ b/tests/test_elastic_ocean.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2019 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+#
+# Authors:
+#     Valerio Cosentino <valcos@bitergia.com>
+#
+
+import unittest
+
+from grimoire_elk.raw.elastic import ElasticOcean, logger
+from grimoire_elk.errors import ELKError
+
+
+class TestElasticOcean(unittest.TestCase):
+
+    def test_get_p2o_params_from_url(self):
+        """Test whether a URL without params is correctly parsed"""
+
+        params = ElasticOcean.get_p2o_params_from_url("https://finosfoundation.atlassian.net/wiki/")
+
+        self.assertEqual(len(params), 1)
+        self.assertEqual(params['url'], "https://finosfoundation.atlassian.net/wiki/")
+
+    def test_get_p2o_params_from_url_filter(self):
+        """Test whether a URL with a filter is correctly parsed"""
+
+        params = ElasticOcean.get_p2o_params_from_url("https://bugzilla.mozilla.org "
+                                                      "--filter-raw=data.product:Add-on SDK,data.component:General")
+
+        self.assertEqual(len(params), 2)
+        self.assertEqual(params['url'], "https://bugzilla.mozilla.org")
+        self.assertEqual(params['filter-raw'], "data.product:Add-on SDK,data.component:General")
+
+    def test_get_p2o_params_from_url_more_filters(self):
+        """Test whether a warning is logged in """
+
+        with self.assertLogs(logger, level='WARNING') as cm:
+            params = ElasticOcean.get_p2o_params_from_url("https://finosfoundation.atlassian.net/wiki/ "
+                                                          "--filter-raw=data.project:openstack/stx-clients "
+                                                          "--filter-raw-prefix=data.project:https://github.com/")
+
+            self.assertEqual(len(params), 2)
+            self.assertEqual(params['url'], "https://finosfoundation.atlassian.net/wiki/")
+            self.assertEqual(params['filter-raw'], "data.project:openstack/stx-clients")
+
+            self.assertEqual(cm.output[0],
+                             'WARNING:grimoire_elk.raw.elastic:Too many filters defined '
+                             'for https://finosfoundation.atlassian.net/wiki/ '
+                             '--filter-raw=data.project:openstack/stx-clients '
+                             '--filter-raw-prefix=data.project:https://github.com/, '
+                             'only the first one is considered')
+
+    def test_get_p2o_params_from_url_error(self):
+        """Test whether an exception is thrown when the tokens obtained when parsing the filter are not 2"""
+
+        with self.assertRaises(ELKError):
+            _ = ElasticOcean.get_p2o_params_from_url("https://finosfoundation.atlassian.net/wiki/ "
+                                                     "--filter-raw=data.project:openstack/stx-clients=xxx")
+
+        with self.assertRaises(ELKError):
+            _ = ElasticOcean.get_p2o_params_from_url("https://finosfoundation.atlassian.net/wiki/ "
+                                                     "--filter-raw")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR redefines the method `get_p2o_params_from_url` to parse the filters declared in the projects.json entries. Filters are identified by the delimiter `--filter`, while the filter name and values are separated by `=`. For instance:
- `https://bugzilla.mozilla.org --filter-raw=data.product:Add-on SDK,data.component:General`
- `http://finosfoundation.atlassian.net --filter-raw=data.fields.project.key:ODP`
- `https://github.com/chaoss/grimoirelab-elk --filter-raw-prefix=data.files.file:README,data.files.file:perceval`

The code provided applies for the Perceval backends that require only an URL as input parameter, for the others, the method `get_p2o_params_from_url` should be redefined. Unit tests have been provided for the new method and live tests have been executed on the following data source:
- [x] Mediawiki
- [x] Discourse
- [x] Jira
- [x] Gerrit
- [x] Bugzilla
- [x] Git

The method `get_p2o_params_from_url` redefined in the raw connectors for git, gerrit, askbot, jira, confluence and bugzilla   have been deleted. 