### PR TITLE
[raw] Prevent mapping of data.ancestors.extensions for confluence raw…

### DIFF
--- a/grimoire_elk/raw/confluence.py
+++ b/grimoire_elk/raw/confluence.py
@@ -47,6 +47,14 @@ class Mapping(BaseMapping):
                                 "dynamic":false,
                                 "properties": {}
                             },
+                            "ancestors": {
+                                "properties": {
+                                    "extensions": {
+                                        "dynamic":false,
+                                        "properties": {}
+                                    }
+                                }
+                            },
                             "body": {
                                 "dynamic":false,
                                 "properties": {}


### PR DESCRIPTION
This code prevents to index the data included in data.ancestors.extensions in order to avoid parsing_mapping_errors.