### PR TITLE
[enriched] Handle hidden editors in mediawiki revisions

### DIFF
--- a/grimoire_elk/enriched/mediawiki.py
+++ b/grimoire_elk/enriched/mediawiki.py
@@ -32,6 +32,9 @@ from ..elastic_mapping import Mapping as BaseMapping
 logger = logging.getLogger(__name__)
 
 
+HIDDEN_EDITOR = '--hidden--'
+
+
 class Mapping(BaseMapping):
 
     @staticmethod
@@ -219,7 +222,7 @@ class MediaWikiEnrich(Enrich):
         if "revisions" in page:
             eitem["nrevisions"] = len(page["revisions"])
             if len(page["revisions"]) > 0:
-                eitem["first_editor"] = page["revisions"][0]["user"]
+                eitem["first_editor"] = page["revisions"][0].get('user', HIDDEN_EDITOR)
                 eitem["last_edited_date"] = page["revisions"][-1]["timestamp"]
 
         if self.sortinghat:


### PR DESCRIPTION
This code handles revisions which have their editor hidden, which are marked as `HIDDEN_EDITOR`.