### PR TITLE
[enrich-confluence] Add ancestors data to enriched items

### DIFF
--- a/grimoire_elk/enriched/confluence.py
+++ b/grimoire_elk/enriched/confluence.py
@@ -135,6 +135,20 @@ class ConfluenceEnrich(Enrich):
             eitem['space'] = page['_expandable']['space']
             eitem['space'] = eitem['space'].replace('/rest/api/space/', '')
 
+        # Ancestors enrichment
+        ancestors_titles = []
+        ancestors_links = []
+
+        if 'ancestors' in page:
+            ancestors = page['ancestors']
+            if isinstance(ancestors, list):
+                for ancestor in ancestors:
+                    ancestors_titles.append(ancestor['title'])
+                    ancestors_links.append(ancestor['_links']['webui'])
+
+        eitem['ancestors_titles'] = ancestors_titles
+        eitem['ancestors_links'] = ancestors_links
+
         # Specific enrichment
         if page['type'] == 'page':
             if page['version']['number'] == 1:

--- a/schema/confluence.csv
+++ b/schema/confluence.csv
@@ -1,4 +1,6 @@
 name,type
+ancestors_links,keyword
+ancestors_titles,keyword
 author_bot,boolean
 author_id,keyword
 author_name,keyword

--- a/tests/data/confluence.json
+++ b/tests/data/confluence.json
@@ -20,6 +20,35 @@
             "tinyui": "/x/zx5o",
             "webui": "/pages/viewpage.action?pageId=1"
         },
+        "ancestors": [
+            {
+                "id": "128548867",
+                "type": "page",
+                "status": "current",
+                "title": "Title 1",
+                "_links" : {
+                    "webui" : "/spaces/TEST/title1"
+                }
+            },
+            {
+                "id": "167848895",
+                "type": "page",
+                "status": "current",
+                "title": "Title 2",
+                "_links" : {
+                    "webui" : "/spaces/TEST/title2"
+                }
+            },
+            {
+                "id": "128548921",
+                "type": "page",
+                "status": "current",
+                "title": "Title 3",
+                "_links" : {
+                    "webui" : "/spaces/TEST/title3"
+                }
+            }
+        ],
         "body": {
             "_expandable": {
                 "anonymous_export_view": "",
@@ -115,6 +144,17 @@
             "tinyui": "/x/zB5o",
             "webui": "/display/DEV/Steady+State+Project+-+2016-06-17+Goals"
         },
+        "ancestors": [
+            {
+                "id": "128548867",
+                "type": "page",
+                "status": "current",
+                "title": "Title 1",
+                "_links" : {
+                    "webui" : "/spaces/TEST/title1"
+                }
+            }
+        ],
         "body": {
             "_expandable": {
                 "anonymous_export_view": "",
@@ -210,6 +250,17 @@
             "tinyui": "/x/IgFN",
             "webui": "/pages/viewpage.action?pageId=2"
         },
+        "ancestors":  [
+            {
+                "id": "128548921",
+                "type": "page",
+                "status": "current",
+                "title": "Title 3",
+                "_links" : {
+                    "webui" : "/spaces/TEST/title3"
+                }
+            }
+        ],
         "body": {
             "_expandable": {
                 "anonymous_export_view": "",
@@ -305,6 +356,35 @@
             "self": "http://example.com/rest/api/content/att1",
             "webui": "/pages/viewpage.action?pageId=131079&preview=%2F131079%2F131085%2Fstep05-04.png"
         },
+        "ancestors": [
+            {
+                "id": "128548867",
+                "type": "page",
+                "status": "current",
+                "title": "Title 1",
+                "_links" : {
+                    "webui" : "/spaces/TEST/title1"
+                }
+            },
+            {
+                "id": "167848895",
+                "type": "page",
+                "status": "current",
+                "title": "Title 2",
+                "_links" : {
+                    "webui" : "/spaces/TEST/title2"
+                }
+            },
+            {
+                "id": "128548921",
+                "type": "page",
+                "status": "current",
+                "title": "Title 3",
+                "_links" : {
+                    "webui" : "/spaces/TEST/title3"
+                }
+            }
+        ],
         "content_url": "http://example.com/pages/viewpage.action?pageId=131079&preview=%2F131079%2F131085%2Fstep05-04.png",
         "extensions": {
             "comment": "",

--- a/tests/test_confluence.py
+++ b/tests/test_confluence.py
@@ -49,6 +49,33 @@ class TestConfluence(TestBaseBackend):
         self.assertEqual(result['items'], 4)
         self.assertEqual(result['raw'], 4)
 
+        # Check enriched data
+        enrich_backend = self.connectors[self.connector][2]()
+
+        item = self.items[0]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertListEqual(eitem['ancestors_titles'],
+                             ['Title 1', 'Title 2', 'Title 3'])
+        self.assertListEqual(eitem['ancestors_links'],
+                             ['/spaces/TEST/title1', '/spaces/TEST/title2', '/spaces/TEST/title3'])
+
+        item = self.items[1]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertListEqual(eitem['ancestors_titles'], ['Title 1'])
+        self.assertListEqual(eitem['ancestors_links'], ['/spaces/TEST/title1'])
+
+        item = self.items[2]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertListEqual(eitem['ancestors_titles'], ['Title 3'])
+        self.assertListEqual(eitem['ancestors_links'], ['/spaces/TEST/title3'])
+
+        item = self.items[3]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertListEqual(eitem['ancestors_titles'],
+                             ['Title 1', 'Title 2', 'Title 3'])
+        self.assertListEqual(eitem['ancestors_links'],
+                             ['/spaces/TEST/title1', '/spaces/TEST/title2', '/spaces/TEST/title3'])
+
     def test_raw_to_enrich(self):
         """Test whether the raw index is properly enriched"""
 


### PR DESCRIPTION
This patch enriches Confluence items with two new fields related to ancestors data.

The field 'ancestors_titles' is a list with the titles of each ancestor, and the field 'ancestors_links' which is a list with the relative links to each ancestor page.

This PR fixes #571 