### PR TITLE
[p2o] Add None value for param `cfg_section_name` to p2o

### DIFF
--- a/utils/p2o.py
+++ b/utils/p2o.py
@@ -72,7 +72,7 @@ if __name__ == '__main__':
 
             if args.enrich or args.enrich_only:
                 unaffiliated_group = None
-                enrich_backend(url, clean, args.backend, args.backend_args,
+                enrich_backend(url, clean, args.backend, args.backend_args, None,
                                args.index, args.index_enrich,
                                args.db_projects_map, args.json_projects_map,
                                args.db_sortinghat,


### PR DESCRIPTION
This code includes a none value for the param `cfg_section_name`, which was recently added to the method `enrich_backend` in elk.py.