### PR TITLE
[elk] Handle project name for filtered repos

### DIFF
--- a/grimoire_elk/elk.py
+++ b/grimoire_elk/elk.py
@@ -580,6 +580,13 @@ def enrich_backend(url, clean, backend_name, backend_params, cfg_section_name,
         if node_regex:
             enrich_backend.node_regex = node_regex
 
+        # The filter raw is needed to be able to assign the project value to an enriched item
+        # see line 544, grimoire_elk/enriched/enrich.py (fltr = eitem['origin'] + ' --filter-raw=' + self.filter_raw)
+        if filter_raw:
+            enrich_backend.set_filter_raw(filter_raw)
+        elif filters_raw_prefix:
+            enrich_backend.set_filter_raw_should(filters_raw_prefix)
+
         ocean_backend = get_ocean_backend(backend_cmd, enrich_backend,
                                           no_incremental, filter_raw,
                                           filters_raw_prefix)

--- a/grimoire_elk/enriched/bugzilla.py
+++ b/grimoire_elk/enriched/bugzilla.py
@@ -70,10 +70,7 @@ class BugzillaEnrich(Enrich):
         return identity
 
     def get_project_repository(self, eitem):
-        repo = eitem['origin']
-        product = eitem['product']
-        repo += "buglist.cgi?product=" + product
-        return repo
+        return eitem['origin']
 
     def get_identities(self, item):
         """Return the identities from an item"""

--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -65,6 +65,7 @@ except ImportError:
     SORTINGHAT_LIBS = False
 
 
+UNKNOWN_PROJECT = 'unknown'
 DEFAULT_PROJECT = 'Main'
 DEFAULT_DB_USER = 'root'
 CUSTOM_META_PREFIX = 'cm'
@@ -544,6 +545,8 @@ class Enrich(ElasticItems):
                 if ds_name in self.prjs_map and fltr in self.prjs_map[ds_name]:
                     project = self.prjs_map[ds_name][fltr]
 
+            if project == UNKNOWN_PROJECT:
+                return None
             if project:
                 return project
 
@@ -558,6 +561,9 @@ class Enrich(ElasticItems):
                         if eitem['origin'] in ds_repo:
                             project = self.prjs_map[ds_name][ds_repo]
                             break
+
+        if project == UNKNOWN_PROJECT:
+            project = None
 
         return project
 

--- a/tests/data/bugzillarest-projects.json
+++ b/tests/data/bugzillarest-projects.json
@@ -1,7 +1,7 @@
 {
     "Localization": {
         "bugzillarest": [
-            "https://bugzilla.mozilla.org/buglist.cgi?product=Mozilla+Localizations&component=bg+/+Bulgarian"
+            "https://bugzilla.mozilla.org --filter-raw=data.product:Mozilla Localizations,data.component=bg / Bulgarian"
         ]
     }
 }

--- a/tests/test_projects.sql
+++ b/tests/test_projects.sql
@@ -60,17 +60,17 @@ CREATE TABLE `project_repositories` (
 LOCK TABLES `project_repositories` WRITE;
 /*!40000 ALTER TABLE `project_repositories` DISABLE KEYS */;
 INSERT INTO `project_repositories` VALUES 
-	(1,'its','https://bugzilla.redhat.com//buglist.cgi?product=Red Hat OpenStack'),
-	(2,'its','https://bugzilla.redhat.com//buglist.cgi?product=ovirt-engine'),
-	(1,'its','https://bugzilla.redhat.com//buglist.cgi?product=Fedora'),
-	(2,'its','https://bugzilla.redhat.com//buglist.cgi?product=OpenShift Container Platform'),
-	(1,'its','https://bugzilla.redhat.com//buglist.cgi?product=Red Hat Enterprise Linux 7'),
-	(1,'its','https://bugzilla.redhat.com//buglist.cgi?product=ovirt-hosted-engine-setup'),
-	(2,'its','https://bugzilla.redhat.com//buglist.cgi?product=Red Hat Gluster Storage');
+	(1,'its','https://bugzilla.redhat.com --filter-raw=product:Red Hat OpenStack'),
+	(2,'its','https://bugzilla.redhat.com --filter-raw=product:ovirt-engine'),
+	(1,'its','https://bugzilla.redhat.com --filter-raw=product:Fedora'),
+	(2,'its','https://bugzilla.redhat.com --filter-raw=product:OpenShift Container Platform'),
+	(1,'its','https://bugzilla.redhat.com --filter-raw=product:Red Hat Enterprise Linux 7'),
+	(1,'its','https://bugzilla.redhat.com --filter-raw=product:ovirt-hosted-engine-setup'),
+	(2,'its','https://bugzilla.redhat.com --filter-raw=product:Red Hat Gluster Storage');
 INSERT INTO `project_repositories` VALUES 
-	(1,'bugzillarest','https://bugzilla.mozilla.org//buglist.cgi?product=Core'),
-	(2,'bugzillarest','https://bugzilla.mozilla.org//buglist.cgi?product=Firefox for Android'),
-	(1,'bugzillarest','https://bugzilla.mozilla.org//buglist.cgi?product=Firefox');
+	(1,'bugzillarest','https://bugzilla.mozilla.org --filter-raw=product:Core'),
+	(2,'bugzillarest','https://bugzilla.mozilla.org --filter-raw=product:Firefox for Android'),
+	(1,'bugzillarest','https://bugzilla.mozilla.org --filter-raw=product:Firefox');
 INSERT INTO `project_repositories` VALUES 
 	(1,'scr','review.openstack.org_openstack/neutron-specs'),
 	(2,'scr','review.openstack.org_openstack/neutron'),


### PR DESCRIPTION
This PR assigns the default project name `Main` to the items coming from the repos included in the `unknown` section within the projects.json. Furthermore, it also removes the method `get_item_project` within the bugzillarest enricher, which logic is not needed anymore (since related to the previous implementation of `--filter-raw`).
