### PR TITLE
[enrich-github] Add url field to enriched repository items

### DIFF
--- a/grimoire_elk/enriched/github.py
+++ b/grimoire_elk/enriched/github.py
@@ -742,6 +742,7 @@ class GitHubEnrich(Enrich):
         rich_repo['subscribers_count'] = repo['subscribers_count']
         rich_repo['stargazers_count'] = repo['stargazers_count']
         rich_repo['fetched_on'] = repo['fetched_on']
+        rich_repo['url'] = repo['html_url']
 
         if self.prjs_map:
             rich_repo.update(self.get_item_project(rich_repo))

--- a/schema/github_repos.csv
+++ b/schema/github_repos.csv
@@ -12,4 +12,5 @@ origin,keyword,true,"The original URL from which the repository was retrieved fr
 stargazers_count,long,true,"Number of stars of the repository."
 subscribers_count,long,true,"Number of watchers of the repository."
 tag,keyword,true,"Perceval tag."
+url,keyword,true,"Full URL of the repository"
 uuid,keyword,true,"Perceval UUID."

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -77,6 +77,7 @@ class TestGit(TestBaseBackend):
         self.assertEqual(eitem['forks_count'], 16687)
         self.assertEqual(eitem['subscribers_count'], 2904)
         self.assertEqual(eitem['stargazers_count'], 48188)
+        self.assertEqual(eitem['url'], "https://github.com/kubernetes/kubernetes")
 
         item = self.items[3]
         eitem = enrich_backend.get_rich_item(item)
@@ -84,6 +85,7 @@ class TestGit(TestBaseBackend):
         self.assertEqual(eitem['forks_count'], 16687)
         self.assertEqual(eitem['subscribers_count'], 4301)
         self.assertEqual(eitem['stargazers_count'], 47118)
+        self.assertEqual(eitem['url'], "https://github.com/kubernetes/kubernetes")
 
         item = self.items[4]
         eitem = enrich_backend.get_rich_item(item)
@@ -91,6 +93,7 @@ class TestGit(TestBaseBackend):
         self.assertEqual(eitem['forks_count'], 1)
         self.assertEqual(eitem['subscribers_count'], 1)
         self.assertEqual(eitem['stargazers_count'], 1)
+        self.assertEqual(eitem['url'], "https://github.com/kubernetes/kubernetes")
 
     def test_raw_to_enrich_sorting_hat(self):
         """Test enrich with SortingHat"""


### PR DESCRIPTION
This commit adds the missing URL field to GitHub repository items. Thus, it is aligned in data with 'issue' and 'pull_request' category items.