### PR TITLE
[elk] Fix incremental enrichment for filter-raw repos

### DIFF
--- a/grimoire_elk/elastic_items.py
+++ b/grimoire_elk/elastic_items.py
@@ -116,6 +116,9 @@ class ElasticItems():
     def set_cfg_section_name(self, cfg_section_name):
         self.cfg_section_name = cfg_section_name
 
+    def set_from_date(self, last_enrich_date):
+        self.from_date = last_enrich_date
+
     # Items generator
     def fetch(self, _filter=None, ignore_incremental=False):
         """ Fetch the items from raw or enriched index. An optional _filter
@@ -205,6 +208,11 @@ class ElasticItems():
                 filter_str = filter_str.replace("'", "\"")
                 filters += filter_str
 
+            # The code below performs the incremental enrichment based on the last value of `metadata__timestamp`
+            # in the enriched index, which is calculated in the TaskEnrich before enriching the single repos that
+            # belong to a given data source. The old implementation of the incremental enrichment, which consisted in
+            # collecting the last value of `metadata__timestamp` in the enriched index for each repo, didn't work
+            # for global data source (which are collected globally and only partially enriched).
             if self.from_date and not ignore_incremental:
                 date_field = self.get_incremental_date()
                 from_date = self.from_date.isoformat()

--- a/grimoire_elk/elk.py
+++ b/grimoire_elk/elk.py
@@ -525,7 +525,8 @@ def enrich_backend(url, clean, backend_name, backend_params, cfg_section_name,
                    author_id=None, author_uuid=None, filter_raw=None,
                    filters_raw_prefix=None, jenkins_rename_file=None,
                    unaffiliated_group=None, pair_programming=False,
-                   node_regex=False, studies_args=None, es_enrich_aliases=None):
+                   node_regex=False, studies_args=None, es_enrich_aliases=None,
+                   last_enrich_date=None):
     """ Enrich Ocean index """
 
     backend = None
@@ -564,6 +565,7 @@ def enrich_backend(url, clean, backend_name, backend_params, cfg_section_name,
         enrich_backend.set_params(backend_params)
         # store the cfg section name in the enrich backend to recover the corresponding project name in projects.json
         enrich_backend.set_cfg_section_name(cfg_section_name)
+        enrich_backend.set_from_date(last_enrich_date)
         if url_enrich:
             elastic_enrich = get_elastic(url_enrich, enrich_index, clean, enrich_backend, es_enrich_aliases)
         else:

--- a/grimoire_elk/enriched/utils.py
+++ b/grimoire_elk/enriched/utils.py
@@ -168,6 +168,8 @@ def get_last_enrich(backend_cmd, enrich_backend):
         if from_date:
             if from_date.replace(tzinfo=None) != parser.parse("1970-01-01"):
                 last_enrich = from_date
+            elif enrich_backend.from_date:
+                last_enrich = enrich_backend.from_date
             else:
                 last_enrich = enrich_backend.get_last_update_from_es([filter_])
 
@@ -178,7 +180,10 @@ def get_last_enrich(backend_cmd, enrich_backend):
                 last_enrich = enrich_backend.get_last_offset_from_es([filter_])
 
         else:
-            last_enrich = enrich_backend.get_last_update_from_es([filter_])
+            if enrich_backend.from_date:
+                last_enrich = enrich_backend.from_date
+            else:
+                last_enrich = enrich_backend.get_last_update_from_es([filter_])
     else:
         last_enrich = enrich_backend.get_last_update_from_es()
 


### PR DESCRIPTION
This PR fixes the incremental enrichment for repos having the filter-raw param. In a nutshell, the last enriched item is calculated in mordred (TaskEnrich) before starting enriching the single repos which data is copied to the same enriched index.
In case of a faulty enrichment execution, the number of raw and enriched items doesn't match, thus the enriched index should be recreated to avoid losing items. 