### PR TITLE
[elk] Remove identities

### DIFF
--- a/grimoire_elk/elastic.py
+++ b/grimoire_elk/elastic.py
@@ -32,7 +32,7 @@ import requests
 from grimoire_elk.errors import ELKError
 from grimoire_elk.enriched.utils import (unixtime_to_datetime,
                                          grimoire_con,
-                                         get_current_date_minus_hours)
+                                         get_diff_current_date)
 
 logger = logging.getLogger(__name__)
 
@@ -463,21 +463,21 @@ class ElasticSearch(object):
                             last_value = unixtime_to_datetime(last_value / 1000)
         return last_value
 
-    def delete_items(self, hours_to_retain, time_field="metadata__updated_on"):
+    def delete_items(self, retention_time, time_field="metadata__updated_on"):
         """Delete documents updated before a given date
 
-        :param hours_to_retain: maximum number of hours wrt the current date to retain the data
+        :param retention_time: maximum number of minutes wrt the current date to retain the data
         :param time_field: time field to delete the data
         """
-        if hours_to_retain is None:
+        if retention_time is None:
             logger.debug("[items retention] Retention policy disabled, no items will be deleted.")
             return
 
-        if hours_to_retain <= 0:
-            logger.debug("[items retention] Hours to retain must be greater than 0.")
+        if retention_time <= 0:
+            logger.debug("[items retention] Minutes to retain must be greater than 0.")
             return
 
-        before_date = get_current_date_minus_hours(hours_to_retain)
+        before_date = get_diff_current_date(minutes=retention_time)
         before_date_str = before_date.isoformat()
 
         es_query = '''

--- a/grimoire_elk/elastic.py
+++ b/grimoire_elk/elastic.py
@@ -504,3 +504,21 @@ class ElasticSearch(object):
             logger.error("Error deleted items from %s.", self.anonymize_url(self.index_url))
             logger.error(ex)
             return
+
+    def all_properties(self):
+        """Get all properties of a given index"""
+
+        properties = {}
+        r = self.requests.get(self.index_url + "/_mapping", headers=HEADER_JSON, verify=False)
+        try:
+            r.raise_for_status()
+            r_json = r.json()
+
+            if 'items' in r_json[self.index]['mappings']:
+                properties = r_json[self.index]['mappings']['items']['properties']
+        except requests.exceptions.HTTPError as ex:
+            logger.error("Error all attributes for %s.", self.anonymize_url(self.index_url))
+            logger.error(ex)
+            return
+
+        return properties

--- a/grimoire_elk/elk.py
+++ b/grimoire_elk/elk.py
@@ -486,12 +486,12 @@ def get_ocean_backend(backend_cmd, enrich_backend, no_incremental,
 
 
 def do_studies(ocean_backend, enrich_backend, studies_args, retention_time=None):
-    """Execute studies related to a given enrich backend. If `retention_hours` is not None, the
-    study data is deleted based on the number of `retention_hours`.
+    """Execute studies related to a given enrich backend. If `retention_time` is not None, the
+    study data is deleted based on the number of minutes declared in `retention_time`.
 
     :param ocean_backend: backend to access raw items
     :param enrich_backend: backend to access enriched items
-    :param retention_time: maximum number of hours wrt the current date to retain the data
+    :param retention_time: maximum number of minutes wrt the current date to retain the data
     :param studies_args: list of studies to be executed
     """
     for study in enrich_backend.studies:

--- a/grimoire_elk/enriched/sortinghat_gelk.py
+++ b/grimoire_elk/enriched/sortinghat_gelk.py
@@ -120,6 +120,23 @@ class SortingHat(object):
         logger.info("Total identities added to SH: %i", total)
 
     @classmethod
+    def remove_identity(cls, sh_db, ident_id):
+        """Delete an identity from SortingHat.
+
+        :param sh_db: SortingHat database
+        :param ident_id: identity identifier
+        """
+        success = False
+        try:
+            api.delete_identity(sh_db, ident_id)
+            logger.debug("Identity %s deleted", ident_id)
+            success = True
+        except Exception as e:
+            logger.debug("Identity not deleted due to %s", str(e))
+
+        return success
+
+    @classmethod
     def remove_unique_identity(cls, sh_db, uuid):
         """Delete a unique identity from SortingHat.
 

--- a/grimoire_elk/enriched/sortinghat_gelk.py
+++ b/grimoire_elk/enriched/sortinghat_gelk.py
@@ -118,3 +118,20 @@ class SortingHat(object):
                 continue
 
         logger.info("Total identities added to SH: %i", total)
+
+    @classmethod
+    def remove_unique_identity(cls, sh_db, uuid):
+        """Delete a unique identity from SortingHat.
+
+        :param sh_db: SortingHat database
+        :param uuid: Unique identity identifier
+        """
+        success = False
+        try:
+            api.delete_unique_identity(sh_db, uuid)
+            logger.debug("Unique identity %s deleted", uuid)
+            success = True
+        except Exception as e:
+            logger.debug("Unique identity not deleted due to %s", str(e))
+
+        return success

--- a/grimoire_elk/enriched/sortinghat_gelk.py
+++ b/grimoire_elk/enriched/sortinghat_gelk.py
@@ -152,3 +152,15 @@ class SortingHat(object):
             logger.debug("Unique identity not deleted due to %s", str(e))
 
         return success
+
+    @classmethod
+    def unique_identities(cls, sh_db):
+        """List the unique identities available in SortingHat.
+
+        :param sh_db: SortingHat database
+        """
+        try:
+            for unique_identity in api.unique_identities(sh_db):
+                yield unique_identity
+        except Exception as e:
+            logger.debug("Unique identities not returned from SortingHat due to %s", str(e))

--- a/grimoire_elk/enriched/utils.py
+++ b/grimoire_elk/enriched/utils.py
@@ -30,6 +30,9 @@ import requests
 import urllib3
 
 
+from grimoirelab_toolkit.datetime import datetime_utcnow
+
+
 BACKOFF_FACTOR = 0.2
 MAX_RETRIES = 21
 MAX_RETRIES_ON_REDIRECT = 5
@@ -201,3 +204,9 @@ def get_min_last_enrich(last_enrich, last_enrich_filtered):
         min_enrich = min(last_enrich, last_enrich_filtered.replace(tzinfo=None))
 
     return min_enrich
+
+
+def get_diff_current_date(days=0, hours=0, minutes=0):
+    before_date = datetime_utcnow() - datetime.timedelta(days=days, hours=hours, minutes=minutes)
+
+    return before_date

--- a/grimoire_elk/utils.py
+++ b/grimoire_elk/utils.py
@@ -237,9 +237,8 @@ def get_connectors():
             }  # Will come from Registry
 
 
-def get_elastic(url, es_index, clean=None, backend=None, es_aliases=None):
+def get_elastic(url, es_index, clean=None, backend=None, es_aliases=None, mapping=None):
 
-    mapping = None
     analyzers = None
 
     if backend:


### PR DESCRIPTION
This PR allows to delete unique identities from SortingHat according to a retention time window. The deletion occurs in two ways, the former checks that the deleted unique identities in the enriched indexes are not present in SortingHat, the latter checks that all unique identities in SortingHat are the ones present in the enriched indexes (thus avoiding to store orphan identities which would fall outside the retention time window.)

In a nutshell the proposed code works as follow. For every enrich iteration, the identifiers of the unique identities in the enriched items are retrieved and stored in the index `grimoirelab_identities_cache` together with the time when they were found (`last_seen`). In case the data retention policy is on, the `grimoirelab_identities_cache` index is used to identify the identities not seen before the data retention policy time frame (defined by the param `retention_time`). Such identities are retrieved and deleted from the SortingHat database. 

To detect and remove orphan identities (the ones stored in SortingHat but not present in `grimoirelab_identities_cache`), all unique identites in SortingHat are retrieved and processed in the following way:
- the ones that have all identities in non-active data sources are deleted, while the ones that have some 
  identities in non active data sources are modified in order to remove those identities.
- the unique identities left are compared with the ones in `grimoirelab_identities_cache` and they are deleted if not found.

This PR should be reviewed with https://github.com/chaoss/grimoirelab-sirmordred/pull/283