### PR TITLE
[enrich] Prevent timeout when using ElasticSearch DSL

### DIFF
--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -915,7 +915,8 @@ class Enrich(ElasticItems):
         logger.info(log_prefix + "  Starting study - Input: " + in_index + " Output: " + out_index)
 
         # Creating connections
-        es = Elasticsearch([enrich_backend.elastic.url], timeout=100, verify_certs=self.elastic.requests.verify)
+        es = Elasticsearch([enrich_backend.elastic.url], retry_on_timeout=True, timeout=100,
+                           verify_certs=self.elastic.requests.verify)
 
         in_conn = ESOnionConnector(es_conn=es, es_index=in_index,
                                    contribs_field=contribs_field,

--- a/grimoire_elk/enriched/git.py
+++ b/grimoire_elk/enriched/git.py
@@ -607,8 +607,10 @@ class GitEnrich(Enrich):
         logger.info(log_prefix + " Starting study - Input: " + in_index + " Output: " + out_index)
 
         # Creating connections
-        es_in = Elasticsearch([ocean_backend.elastic.url], timeout=100, verify_certs=self.elastic.requests.verify)
-        es_out = Elasticsearch([enrich_backend.elastic.url], timeout=100, verify_certs=self.elastic.requests.verify)
+        es_in = Elasticsearch([ocean_backend.elastic.url], retry_on_timeout=True, timeout=100,
+                              verify_certs=self.elastic.requests.verify)
+        es_out = Elasticsearch([enrich_backend.elastic.url], retry_on_timeout=True,
+                               timeout=100, verify_certs=self.elastic.requests.verify)
         in_conn = ESPandasConnector(es_conn=es_in, es_index=in_index, sort_on_field=sort_on_field)
         out_conn = ESPandasConnector(es_conn=es_out, es_index=out_index, sort_on_field=sort_on_field, read_only=False)
 


### PR DESCRIPTION
This code adds the param `retry_on_timeout` when initializing the ElasticSearch DSL object, thus preventing Gateway Timeout.