### PR TITLE
[elk] Handle filter-classified param

### DIFF
--- a/grimoire_elk/enriched/meetup.py
+++ b/grimoire_elk/enriched/meetup.py
@@ -223,10 +223,14 @@ class MeetupEnrich(Enrich):
                 "lat": group['lat'],
                 "lon": group['lon'],
             }
-            group_topics = [topic['name'] for topic in group['topics']]
-            group_topics_keys = [topic['urlkey'] for topic in group['topics']]
-            eitem['group_topics'] = group_topics
-            eitem['group_topics_keys'] = group_topics_keys
+
+            eitem['group_topics'] = []
+            eitem['group_topics_keys'] = []
+            if 'topics' in group:
+                group_topics = [topic['name'] for topic in group['topics']]
+                group_topics_keys = [topic['urlkey'] for topic in group['topics']]
+                eitem['group_topics'] = group_topics
+                eitem['group_topics_keys'] = group_topics_keys
 
         if len(event['rsvps']) > 0:
             eitem['group_members'] = event['rsvps'][0]['group']['members']


### PR DESCRIPTION
This code allows to pass the value of the filter-classifed param defined in the setup.cfg to Perceval. The methods `elk.feed_backend` and `elastic.feed` have been refactored to handle the new parameter.