### PR TITLE
[enriched] Fix missing ancestor title in confluence enriched items

### DIFF
--- a/grimoire_elk/enriched/confluence.py
+++ b/grimoire_elk/enriched/confluence.py
@@ -29,6 +29,9 @@ from ..elastic_mapping import Mapping as BaseMapping
 logger = logging.getLogger(__name__)
 
 
+NO_ANCESTOR_TITLE = "NO_TITLE"
+
+
 class Mapping(BaseMapping):
 
     @staticmethod
@@ -143,7 +146,11 @@ class ConfluenceEnrich(Enrich):
             ancestors = page['ancestors']
             if isinstance(ancestors, list):
                 for ancestor in ancestors:
-                    ancestors_titles.append(ancestor['title'])
+                    if 'title' in ancestor:
+                        ancestors_titles.append(ancestor['title'])
+                    else:
+                        ancestors_titles.append(NO_ANCESTOR_TITLE)
+
                     ancestors_links.append(ancestor['_links']['webui'])
 
         eitem['ancestors_titles'] = ancestors_titles

--- a/tests/data/confluence.json
+++ b/tests/data/confluence.json
@@ -149,7 +149,6 @@
                 "id": "128548867",
                 "type": "page",
                 "status": "current",
-                "title": "Title 1",
                 "_links" : {
                     "webui" : "/spaces/TEST/title1"
                 }

--- a/tests/test_confluence.py
+++ b/tests/test_confluence.py
@@ -26,6 +26,7 @@ import unittest
 
 from base import TestBaseBackend
 from grimoire_elk.raw.confluence import ConfluenceOcean
+from grimoire_elk.enriched.confluence import NO_ANCESTOR_TITLE
 
 
 class TestConfluence(TestBaseBackend):
@@ -61,7 +62,7 @@ class TestConfluence(TestBaseBackend):
 
         item = self.items[1]
         eitem = enrich_backend.get_rich_item(item)
-        self.assertListEqual(eitem['ancestors_titles'], ['Title 1'])
+        self.assertListEqual(eitem['ancestors_titles'], [NO_ANCESTOR_TITLE])
         self.assertListEqual(eitem['ancestors_links'], ['/spaces/TEST/title1'])
 
         item = self.items[2]


### PR DESCRIPTION
This code handles ancestors which miss the title attribute. Tests have been provided accordingly.