### PR TITLE
[enrich-meetup] Avoid failures when 'rsvps' field is not available

### DIFF
--- a/grimoire_elk/elk.py
+++ b/grimoire_elk/elk.py
@@ -936,6 +936,9 @@ def populate_identities_index(es_enrichment_url, enrich_index):
     for eitem in enriched_items.fetch(ignore_incremental=True):
         for sh_uuid_attr in sh_uuid_attributes:
 
+            if sh_uuid_attr not in eitem:
+                continue
+
             identity = {
                 'sh_uuid': eitem[sh_uuid_attr],
                 'last_seen': datetime_utcnow().isoformat()

--- a/grimoire_elk/enriched/meetup.py
+++ b/grimoire_elk/enriched/meetup.py
@@ -86,9 +86,12 @@ class MeetupEnrich(Enrich):
             yield user
 
         # rsvps
-        for rsvp in item['rsvps']:
+        rsvps = item.get('rsvps', [])
+
+        for rsvp in rsvps:
             user = self.get_sh_identity(rsvp['member'])
             yield user
+
         # Comments
         for comment in item['comments']:
             user = self.get_sh_identity(comment['member'])
@@ -175,7 +178,9 @@ class MeetupEnrich(Enrich):
             else:
                 eitem[f] = None
 
-        eitem['num_rsvps'] = len(event['rsvps'])
+        rsvps = event.get('rsvps', [])
+
+        eitem['num_rsvps'] = len(rsvps)
         eitem['num_comments'] = len(event['comments'])
 
         try:
@@ -232,8 +237,8 @@ class MeetupEnrich(Enrich):
                 eitem['group_topics'] = group_topics
                 eitem['group_topics_keys'] = group_topics_keys
 
-        if len(event['rsvps']) > 0:
-            eitem['group_members'] = event['rsvps'][0]['group']['members']
+        if len(rsvps) > 0:
+            eitem['group_members'] = rsvps[0]['group']['members']
 
         created = unixtime_to_datetime(event['created'] / 1000).isoformat()
         eitem['type'] = "meetup"


### PR DESCRIPTION
Due 'rsvps' is a classified field, it might not be available when items are retrieved. So far, this field is considered as mandatory by the enricher.

With this patch, ELK won't break when this field is not found.

This patch addresses the changes proposed in #599. 

`venue` and `event_hosts` are already skipped when they are not found in a raw item.