### PR TITLE
[elk] Handle empty sh uuid attributes

### DIFF
--- a/grimoire_elk/elk.py
+++ b/grimoire_elk/elk.py
@@ -939,6 +939,9 @@ def populate_identities_index(es_enrichment_url, enrich_index):
             if sh_uuid_attr not in eitem:
                 continue
 
+            if not eitem[sh_uuid_attr]:
+                continue
+
             identity = {
                 'sh_uuid': eitem[sh_uuid_attr],
                 'last_seen': datetime_utcnow().isoformat()


### PR DESCRIPTION
This code allows to ignore the uuid attributes which contain empty values, thus avoiding ES errors when inserting items with empty `_id`.

Signed-off-by: Valerio Cosentino <valcos@bitergia.com>