### PR TITLE
[ELK] Simplify logic to assing project to enriched items

### DIFF
--- a/grimoire_elk/elastic_items.py
+++ b/grimoire_elk/elastic_items.py
@@ -39,7 +39,7 @@ FILTER_SEPARATOR = r",\s*%s" % FILTER_DATA_ATTR
 logger = logging.getLogger(__name__)
 
 
-class ElasticItems():
+class ElasticItems:
 
     mapping = Mapping
 
@@ -57,6 +57,7 @@ class ElasticItems():
         self.filter_raw_dict = []
         self.filter_raw_should = None  # to filter raw items from Ocean
         self.filter_raw_should_dict = []
+        self.projects_json_repo = None
 
         self.requests = grimoire_con(insecure)
         self.elastic = None
@@ -78,6 +79,9 @@ class ElasticItems():
         Field with the date used for incremental analysis.
         """
         return "metadata__timestamp"
+
+    def set_projects_json_repo(self, repo):
+        self.projects_json_repo = repo
 
     @staticmethod
     def __process_filter(fltr_raw):

--- a/grimoire_elk/elk.py
+++ b/grimoire_elk/elk.py
@@ -104,7 +104,7 @@ def feed_backend_arthur(backend_name, backend_params):
 
 def feed_backend(url, clean, fetch_archive, backend_name, backend_params,
                  es_index=None, es_index_enrich=None, project=None, arthur=False,
-                 es_aliases=None):
+                 es_aliases=None, projects_json_repo=None):
     """ Feed Ocean with backend data """
 
     backend = None
@@ -151,6 +151,7 @@ def feed_backend(url, clean, fetch_archive, backend_name, backend_params,
         ocean_backend = connector[1](backend, fetch_archive=fetch_archive, project=project)
         elastic_ocean = get_elastic(url, es_index, clean, ocean_backend, es_aliases)
         ocean_backend.set_elastic(elastic_ocean)
+        ocean_backend.set_projects_json_repo(projects_json_repo)
 
         if fetch_archive:
             signature = inspect.signature(backend.fetch_from_archive)

--- a/grimoire_elk/elk.py
+++ b/grimoire_elk/elk.py
@@ -535,7 +535,7 @@ def enrich_backend(url, clean, backend_name, backend_params, cfg_section_name,
                    filters_raw_prefix=None, jenkins_rename_file=None,
                    unaffiliated_group=None, pair_programming=False,
                    node_regex=False, studies_args=None, es_enrich_aliases=None,
-                   last_enrich_date=None):
+                   last_enrich_date=None, projects_json_repo=None):
     """ Enrich Ocean index """
 
     backend = None
@@ -598,6 +598,7 @@ def enrich_backend(url, clean, backend_name, backend_params, cfg_section_name,
         elif filters_raw_prefix:
             enrich_backend.set_filter_raw_should(filters_raw_prefix)
 
+        enrich_backend.set_projects_json_repo(projects_json_repo)
         ocean_backend = get_ocean_backend(backend_cmd, enrich_backend,
                                           no_incremental, filter_raw,
                                           filters_raw_prefix)

--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -531,11 +531,22 @@ class Enrich(ElasticItems):
         """
         # get the data source name relying on the cfg section name, if null use the connector name
         ds_name = self.cfg_section_name if self.cfg_section_name else self.get_connector_name()
-        repository = self.get_project_repository(eitem)
 
         try:
-            project = (self.prjs_map[ds_name][repository])
-            # logger.debug("Project FOUND for repository %s %s", repository, project)
+            # retrieve the project which includes the repo url in the projects.json,
+            # the variable `projects_json_repo` is passed from mordred to ELK when
+            # iterating over the repos in the projects.json, (see: param
+            # `projects_json_repo` in the functions elk.feed_backend and
+            # elk.enrich_backend)
+            if self.projects_json_repo:
+                project = self.prjs_map[ds_name][self.projects_json_repo]
+            # if `projects_json_repo`, which shouldn't never happen, use the
+            # method `get_project_repository` (defined in each enricher)
+            else:
+                repository = self.get_project_repository(eitem)
+                project = self.prjs_map[ds_name][repository]
+        # With the introduction of `projects_json_repo` the code in the
+        # except should be unreachable, and could be removed
         except KeyError:
             # logger.warning("Project not found for repository %s (data source: %s)", repository, ds_name)
             project = None


### PR DESCRIPTION
This PR proposes to simplify the logic to assign project to enriched items. Currently the assignment is based on the logic of the method `get_project_repository` redefined in each enricher, plus a fallback option based on the inspection of the projects.json, which is passed from mordred to ELK. The new approach passes to ELK also the repo (`projects_json_repo`) in the projects.json (which includes the perceval params plus optionally other params such as filter-raw, filtera-raw-prefix, blacklist-ids, proper of some specific enrichers) currently analyzed. Thus, the assignment of the project is done by looking for a perfect match between the value of the `projects_json_repo` in the projects.json, in case the `projects_json_repo` is None, the previous logic is used.

This PR should be reviewed together with: https://github.com/chaoss/grimoirelab-sirmordred/pull/292