### PR TITLE
[raw-jira] Update raw mapping to avoid immense term errors

### DIFF
--- a/grimoire_elk/raw/jira.py
+++ b/grimoire_elk/raw/jira.py
@@ -67,6 +67,14 @@ class Mapping(BaseMapping):
                                     "properties": {}
                                 }
                             }
+                        },
+                        "comments_data": {
+                            "properties": {
+                                "body": {
+                                    "type": "text",
+                                    "index": true
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This PR modifies the raw mappings to handle comment bodies longer than the maximum length allowed for keywords. Thus, comment bodies are mapped as text.

Signed-off-by: Valerio Cosentino <valcos@bitergia.com>