### PR TITLE
[enriched-utils] Fix last enrich date calculation

### DIFF
--- a/grimoire_elk/elk.py
+++ b/grimoire_elk/elk.py
@@ -443,7 +443,7 @@ def get_ocean_backend(backend_cmd, enrich_backend, no_incremental,
     if no_incremental:
         last_enrich = None
     else:
-        last_enrich = get_last_enrich(backend_cmd, enrich_backend)
+        last_enrich = get_last_enrich(backend_cmd, enrich_backend, filter_raw=filter_raw)
 
     logger.debug("Last enrichment: %s", last_enrich)
 

--- a/grimoire_elk/enriched/askbot.py
+++ b/grimoire_elk/enriched/askbot.py
@@ -192,6 +192,7 @@ class AskbotEnrich(Enrich):
         eitem["type"] = "question"
         eitem.update(self.get_grimoire_fields(added_at.isoformat(), eitem["type"]))
 
+        self.add_metadata_filter_raw(eitem)
         return eitem
 
     def get_field_unique_id(self):

--- a/grimoire_elk/enriched/bugzilla.py
+++ b/grimoire_elk/enriched/bugzilla.py
@@ -173,4 +173,5 @@ class BugzillaEnrich(Enrich):
 
         eitem.update(self.get_grimoire_fields(eitem['creation_date'], "bug"))
 
+        self.add_metadata_filter_raw(eitem)
         return eitem

--- a/grimoire_elk/enriched/bugzillarest.py
+++ b/grimoire_elk/enriched/bugzillarest.py
@@ -137,4 +137,5 @@ class BugzillaRESTEnrich(Enrich):
 
         eitem.update(self.get_grimoire_fields(issue['creation_time'], "bugrest"))
 
+        self.add_metadata_filter_raw(eitem)
         return eitem

--- a/grimoire_elk/enriched/confluence.py
+++ b/grimoire_elk/enriched/confluence.py
@@ -171,4 +171,5 @@ class ConfluenceEnrich(Enrich):
 
         eitem.update(self.get_grimoire_fields(eitem['date'], "confluence"))
 
+        self.add_metadata_filter_raw(eitem)
         return eitem

--- a/grimoire_elk/enriched/crates.py
+++ b/grimoire_elk/enriched/crates.py
@@ -168,4 +168,5 @@ class CratesEnrich(Enrich):
 
         eitem.update(self.get_grimoire_fields(eitem['created_at'], "crates"))
 
+        self.add_metadata_filter_raw(eitem)
         return eitem

--- a/grimoire_elk/enriched/discourse.py
+++ b/grimoire_elk/enriched/discourse.py
@@ -251,6 +251,7 @@ class DiscourseEnrich(Enrich):
         eitem['type'] = 'question'
         eitem.update(self.get_grimoire_fields(topic["created_at"], eitem['type']))
 
+        self.add_metadata_filter_raw(eitem)
         return eitem
 
     def get_field_unique_id(self):

--- a/grimoire_elk/enriched/dockerhub.py
+++ b/grimoire_elk/enriched/dockerhub.py
@@ -119,6 +119,7 @@ class DockerHubEnrich(Enrich):
 
         eitem.update(self.get_grimoire_fields(item["metadata__updated_on"], "dockerhub"))
 
+        self.add_metadata_filter_raw(eitem)
         return eitem
 
     def enrich_items(self, ocean_backend, events=False):

--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -40,7 +40,7 @@ from ..elastic_items import (ElasticItems,
                              HEADER_JSON)
 from .study_ceres_onion import ESOnionConnector, onion_study
 
-from .utils import grimoire_con
+from .utils import grimoire_con, METADATA_FILTER_RAW
 from .. import __version__
 
 logger = logging.getLogger(__name__)
@@ -391,6 +391,11 @@ class Enrich(ElasticItems):
             total += self.elastic.safe_put_bulk(url, bulk_json)
 
         return total
+
+    def add_metadata_filter_raw(self, eitem):
+        """Add filter raw information to the enriched item"""
+
+        eitem[METADATA_FILTER_RAW] = self.filter_raw
 
     def get_connector_name(self):
         """ Find the name for the current connector """

--- a/grimoire_elk/enriched/finosmeetings.py
+++ b/grimoire_elk/enriched/finosmeetings.py
@@ -132,6 +132,7 @@ class FinosMeetingsEnrich(Enrich):
 
         eitem.update(self.get_grimoire_fields(item["metadata__updated_on"], "entry"))
 
+        self.add_metadata_filter_raw(eitem)
         return eitem
 
     def get_item_project(self, eitem):

--- a/grimoire_elk/enriched/functest.py
+++ b/grimoire_elk/enriched/functest.py
@@ -112,4 +112,5 @@ class FunctestEnrich(Enrich):
         if eitem['project'] and eitem['project'].lower() in self.BOOST_PROJECTS:
             eitem['boost_list'] += ['boosted']
 
+        self.add_metadata_filter_raw(eitem)
         return eitem

--- a/grimoire_elk/enriched/gerrit.py
+++ b/grimoire_elk/enriched/gerrit.py
@@ -237,6 +237,7 @@ class GerritEnrich(Enrich):
 
         eitem.update(self.get_grimoire_fields(review['createdOn'], "review"))
 
+        self.add_metadata_filter_raw(eitem)
         return eitem
 
     def enrich_demography(self, ocean_backend, enrich_backend, date_field="grimoire_creation_date",

--- a/grimoire_elk/enriched/git.py
+++ b/grimoire_elk/enriched/git.py
@@ -419,6 +419,7 @@ class GitEnrich(Enrich):
         if self.pair_programming:
             eitem = self.__add_pair_programming_metrics(commit, eitem)
 
+        self.add_metadata_filter_raw(eitem)
         return eitem
 
     def __fix_field_date(self, item, attribute):

--- a/grimoire_elk/enriched/github.py
+++ b/grimoire_elk/enriched/github.py
@@ -314,6 +314,7 @@ class GitHubEnrich(Enrich):
         else:
             logger.error("rich item not defined for GitHub category %s", item['category'])
 
+        self.add_metadata_filter_raw(rich_item)
         return rich_item
 
     def enrich_items(self, items):

--- a/grimoire_elk/enriched/gitlab.py
+++ b/grimoire_elk/enriched/gitlab.py
@@ -153,6 +153,7 @@ class GitLabEnrich(Enrich):
         else:
             logger.error("rich item not defined for GitLab category %s", item['category'])
 
+        self.add_metadata_filter_raw(rich_item)
         return rich_item
 
     def __get_rich_issue(self, item):

--- a/grimoire_elk/enriched/google_hits.py
+++ b/grimoire_elk/enriched/google_hits.py
@@ -61,4 +61,5 @@ class GoogleHitsEnrich(Enrich):
 
         eitem.update(self.get_grimoire_fields(item["metadata__updated_on"], "hits"))
 
+        self.add_metadata_filter_raw(eitem)
         return eitem

--- a/grimoire_elk/enriched/jenkins.py
+++ b/grimoire_elk/enriched/jenkins.py
@@ -248,4 +248,5 @@ class JenkinsEnrich(Enrich):
         if self.prjs_map:
             eitem.update(self.get_item_project(eitem))
 
+        self.add_metadata_filter_raw(eitem)
         return eitem

--- a/grimoire_elk/enriched/jira.py
+++ b/grimoire_elk/enriched/jira.py
@@ -347,6 +347,8 @@ class JiraEnrich(Enrich):
 
         eitem.update(self.get_grimoire_fields(issue['fields']['created'], ISSUE_TYPE))
         eitem["type"] = ISSUE_TYPE
+
+        self.add_metadata_filter_raw(eitem)
         return eitem
 
     def get_rich_item_comments(self, comments, eitem):
@@ -399,6 +401,7 @@ class JiraEnrich(Enrich):
 
             ecomment.update(self.get_grimoire_fields(comment['created'], COMMENT_TYPE))
 
+            self.add_metadata_filter_raw(ecomment)
             ecomments.append(ecomment)
 
         return ecomments

--- a/grimoire_elk/enriched/kitsune.py
+++ b/grimoire_elk/enriched/kitsune.py
@@ -158,6 +158,8 @@ class KitsuneEnrich(Enrich):
             if self.prjs_map:
                 eitem.update(self.get_item_project(eitem))
 
+            self.add_metadata_filter_raw(eitem)
+
         elif kind == 'answer':
             answer = item
             eitem['type'] = kind

--- a/grimoire_elk/enriched/mattermost.py
+++ b/grimoire_elk/enriched/mattermost.py
@@ -213,6 +213,7 @@ class MattermostEnrich(Enrich):
 
         eitem.update(self.get_grimoire_fields(item["metadata__updated_on"], "message"))
 
+        self.add_metadata_filter_raw(eitem)
         return eitem
 
     def __convert_booleans(self, eitem):

--- a/grimoire_elk/enriched/mbox.py
+++ b/grimoire_elk/enriched/mbox.py
@@ -187,6 +187,7 @@ class MBoxEnrich(Enrich):
         if self.prjs_map:
             eitem.update(self.get_item_project(eitem))
 
+        self.add_metadata_filter_raw(eitem)
         eitem.update(self.get_grimoire_fields(message['Date'], "message"))
 
         return eitem

--- a/grimoire_elk/enriched/mediawiki.py
+++ b/grimoire_elk/enriched/mediawiki.py
@@ -231,6 +231,7 @@ class MediaWikiEnrich(Enrich):
         if self.prjs_map:
             eitem.update(self.get_item_project(eitem))
 
+        self.add_metadata_filter_raw(eitem)
         return eitem
 
     def enrich_items(self, items):

--- a/grimoire_elk/enriched/meetup.py
+++ b/grimoire_elk/enriched/meetup.py
@@ -252,6 +252,7 @@ class MeetupEnrich(Enrich):
         if self.prjs_map:
             eitem.update(self.get_item_project(eitem))
 
+        self.add_metadata_filter_raw(eitem)
         return eitem
 
     def get_item_sh(self, item):

--- a/grimoire_elk/enriched/mozillaclub.py
+++ b/grimoire_elk/enriched/mozillaclub.py
@@ -142,6 +142,7 @@ class MozillaClubEnrich(Enrich):
 
         eitem.update(self.get_grimoire_fields(event["Timestamp"], "event"))
 
+        self.add_metadata_filter_raw(eitem)
         return eitem
 
     def enrich_items(self, ocean_backend):

--- a/grimoire_elk/enriched/phabricator.py
+++ b/grimoire_elk/enriched/phabricator.py
@@ -372,4 +372,5 @@ class PhabricatorEnrich(Enrich):
                 assigned_to['assigned_to' + of] = eitem[f]
         eitem.update(assigned_to)
 
+        self.add_metadata_filter_raw(eitem)
         return eitem

--- a/grimoire_elk/enriched/puppetforge.py
+++ b/grimoire_elk/enriched/puppetforge.py
@@ -129,6 +129,7 @@ class PuppetForgeEnrich(Enrich):
 
         eitem.update(self.get_grimoire_fields(entry["created_at"], "module"))
 
+        self.add_metadata_filter_raw(eitem)
         return eitem
 
     def get_rich_events(self, item):

--- a/grimoire_elk/enriched/redmine.py
+++ b/grimoire_elk/enriched/redmine.py
@@ -168,4 +168,5 @@ class RedmineEnrich(Enrich):
         if self.prjs_map:
             eitem.update(self.get_item_project(eitem))
 
+        self.add_metadata_filter_raw(eitem)
         return eitem

--- a/grimoire_elk/enriched/remo.py
+++ b/grimoire_elk/enriched/remo.py
@@ -149,6 +149,7 @@ class ReMoEnrich(Enrich):
             else:
                 eitem[f] = None
 
+        self.add_metadata_filter_raw(eitem)
         return eitem
 
     def __get_rich_item_activities(self, item):

--- a/grimoire_elk/enriched/rss.py
+++ b/grimoire_elk/enriched/rss.py
@@ -125,4 +125,5 @@ class RSSEnrich(Enrich):
 
         eitem.update(self.get_grimoire_fields(eitem["publish_date"], "entry"))
 
+        self.add_metadata_filter_raw(eitem)
         return eitem

--- a/grimoire_elk/enriched/slack.py
+++ b/grimoire_elk/enriched/slack.py
@@ -200,6 +200,7 @@ class SlackEnrich(Enrich):
 
         eitem.update(self.get_grimoire_fields(item["metadata__updated_on"], "message"))
 
+        self.add_metadata_filter_raw(eitem)
         return eitem
 
     def __convert_booleans(self, eitem):

--- a/grimoire_elk/enriched/stackexchange.py
+++ b/grimoire_elk/enriched/stackexchange.py
@@ -167,6 +167,8 @@ class StackExchangeEnrich(Enrich):
             if self.prjs_map:
                 eitem.update(self.get_item_project(eitem))
 
+            self.add_metadata_filter_raw(eitem)
+
         elif kind == 'answer':
             answer = item
 

--- a/grimoire_elk/enriched/supybot.py
+++ b/grimoire_elk/enriched/supybot.py
@@ -120,4 +120,5 @@ class SupybotEnrich(Enrich):
         if self.prjs_map:
             eitem.update(self.get_item_project(eitem))
 
+        self.add_metadata_filter_raw(eitem)
         return eitem

--- a/grimoire_elk/enriched/telegram.py
+++ b/grimoire_elk/enriched/telegram.py
@@ -154,4 +154,5 @@ class TelegramEnrich(Enrich):
 
         eitem.update(self.get_grimoire_fields(item["metadata__updated_on"], "telegram"))
 
+        self.add_metadata_filter_raw(eitem)
         return eitem

--- a/grimoire_elk/enriched/twitter.py
+++ b/grimoire_elk/enriched/twitter.py
@@ -178,4 +178,5 @@ class TwitterEnrich(Enrich):
         if self.prjs_map:
             eitem.update(self.get_item_project(eitem))
 
+        self.add_metadata_filter_raw(eitem)
         return eitem

--- a/grimoire_elk/enriched/utils.py
+++ b/grimoire_elk/enriched/utils.py
@@ -176,7 +176,10 @@ def get_last_enrich(backend_cmd, enrich_backend):
                 last_enrich = None
             else:
                 # if the index is not empty, the last enrich is the minimum between
-                # the last filtered item and the last item in the enriched index
+                # the last filtered item (the last item for a given origin) and the
+                # last item in the enriched index. If `last_enrich_filtered` is empty,
+                # it means that no items for that origin are in the index, thus the
+                # `last_enrich` is set to None
                 last_enrich_filtered = enrich_backend.get_last_update_from_es([filter_])
                 last_enrich = get_min_last_enrich(enrich_backend.from_date, last_enrich_filtered)
 
@@ -199,9 +202,10 @@ def get_last_enrich(backend_cmd, enrich_backend):
 
 
 def get_min_last_enrich(last_enrich, last_enrich_filtered):
-    min_enrich = last_enrich
     if last_enrich_filtered:
-        min_enrich = min(last_enrich, last_enrich_filtered.replace(tzinfo=None))
+        min_enrich = min(last_enrich, last_enrich_filtered.replace(second=0, microsecond=0, tzinfo=None))
+    else:
+        min_enrich = None
 
     return min_enrich
 


### PR DESCRIPTION
This PR fixes the last enrich date calculation. The previous logic was calculating the minimum value between the last enrich global date (the one obtained before starting the enrichment process for all repos of a given data source) and the last enrich date for items of a given origin. If the latter date was empty (i.e., no items of that origin in the index), the last enrich date was set to the last enrich global date, thus only the items of the origin with a timestamp greater than the last enrich global date where processed. Now the last enrich date is set None if no items for a given origin are present in the enriched index.

Signed-off-by: Valerio Cosentino <valcos@bitergia.com>