### PR TITLE
[enriched-bugzillarest] Change logic to calculate `timeopen_days`

### DIFF
--- a/grimoire_elk/enriched/bugzillarest.py
+++ b/grimoire_elk/enriched/bugzillarest.py
@@ -22,11 +22,12 @@
 
 import logging
 
-from datetime import datetime
 from dateutil import parser
 
 from .enrich import Enrich, metadata
 from .utils import get_time_diff_days
+
+from grimoirelab_toolkit.datetime import datetime_utcnow
 
 
 logger = logging.getLogger(__name__)
@@ -118,8 +119,10 @@ class BugzillaRESTEnrich(Enrich):
         eitem['url'] = item['origin'] + "/show_bug.cgi?id=" + str(issue['id'])
         eitem['time_to_last_update_days'] = \
             get_time_diff_days(eitem['creation_ts'], eitem['delta_ts'])
-        eitem['timeopen_days'] = \
-            get_time_diff_days(eitem['creation_ts'], datetime.utcnow())
+
+        eitem['timeopen_days'] = get_time_diff_days(eitem['creation_ts'], datetime_utcnow().replace(tzinfo=None))
+        if 'is_open' in issue and not issue['is_open']:
+            eitem['timeopen_days'] = eitem['time_to_last_update_days']
 
         eitem['changes'] = 0
         for history in issue['history']:


### PR DESCRIPTION
This code changes the logic to assess the number of days a bug is open. It relies on the attribute `is_open`, if the latter exists and is False, the `timeopen_days` is the diff between the creation time and the date of the last change, in all other cases the `timeopen_days` is set to the diff between the creation time and the date when the enriched item was processed by ELK.

Signed-off-by: Valerio Cosentino <valcos@bitergia.com>