### PR TITLE
[aoc] Update write method to upload smaller lists

### DIFF
--- a/grimoire_elk/enriched/study_ceres_aoc.py
+++ b/grimoire_elk/enriched/study_ceres_aoc.py
@@ -134,7 +134,10 @@ class ESPandasConnector(ESConnector):
             }
             docs.append(doc)
         # TODO exception and error handling
-        helpers.bulk(self._es_conn, docs)
+        chunk_size = 2000
+        chunks = [docs[i:i + chunk_size] for i in range(0, len(docs), chunk_size)]
+        for chunk in chunks:
+            helpers.bulk(self._es_conn, chunk)
         logger.info(self.__log_prefix + "Written: " + str(len(docs)))
 
 


### PR DESCRIPTION
AOC splits each commit into files and sometimes the number
of resulting events is too big for a single bulk upload.
This change splits the list of resulting documents into chunks
of 2k items to make sure the upload is under control.

Signed-off-by: Alberto Pérez García-Plaza <alpgarcia@bitergia.com>