### PR TITLE
[ELK] Constrain elasticsearch-related dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 PyMySQL
-elasticsearch>=6.1.1
-elasticsearch-dsl>=6.1.0
+elasticsearch==6.3.1
+elasticsearch-dsl==6.3.1
 requests>=2.7.0
 -e git+https://github.com/chaoss/grimoirelab-sortinghat/#egg=grimoirelab-sortinghat
 -e git+https://github.com/chaoss/grimoirelab-toolkit/#egg=grimoirelab-toolkit

--- a/setup.py
+++ b/setup.py
@@ -86,8 +86,8 @@ setup(name="grimoire-elk",
           'cereslib>=0.1.0',
           'grimoirelab-toolkit>=0.1.4',
           'sortinghat>=0.6.2',
-          'elasticsearch>=6.1.1',
-          'elasticsearch-dsl>=6.1.0',
+          'elasticsearch==6.3.1',
+          'elasticsearch-dsl==6.3.1',
           'requests>=2.7.0'],
       zip_safe=False
       )


### PR DESCRIPTION
This PR constraints the dependencies to elasticsearch and elasticsearch-dsl which are now:
- elasticsearch==6.3.1
- elasticsearch-dsl==6.3.1