### PR TITLE
[enriched-functest] Handle no float duration times

### DIFF
--- a/schema/functest.csv
+++ b/schema/functest.csv
@@ -4,6 +4,7 @@ build_tag,keyword
 case_name,keyword
 criteria,keyword
 duration,float
+duration_from_api,float
 failures,long
 grimoire_creation_date,date
 installer,keyword

--- a/tests/data/functest.json
+++ b/tests/data/functest.json
@@ -197,7 +197,7 @@
         "case_name": "vping_ssh",
         "criteria": "PASS",
         "details": {
-            "duration": 40.7,
+            "duration": "0:04:23",
             "status": "PASS",
             "timestart": 1496314187.73099
         },
@@ -362,7 +362,7 @@
         "case_name": "vping_userdata",
         "criteria": "PASS",
         "details": {
-            "duration": 41.6,
+            "duration": "0m46s",
             "status": "PASS",
             "timestart": 1496313545.74844
         },

--- a/tests/data/functest.json
+++ b/tests/data/functest.json
@@ -197,7 +197,7 @@
         "case_name": "vping_ssh",
         "criteria": "PASS",
         "details": {
-            "duration": "0:04:23",
+            "duration": "0:00:41",
             "status": "PASS",
             "timestart": 1496314187.73099
         },
@@ -362,7 +362,7 @@
         "case_name": "vping_userdata",
         "criteria": "PASS",
         "details": {
-            "duration": "0m46s",
+            "duration": "0m42s",
             "status": "PASS",
             "timestart": 1496313545.74844
         },
@@ -882,7 +882,7 @@
         "project_name": "functest",
         "scenario": "os-nosdn-kvm_ovs_dpdk_bar-ha",
         "start_date": "2017-06-01 10:01:57",
-        "stop_date": "2017-06-01 10:01:58",
+        "stop_date": "",
         "trust_indicator": null,
         "version": "danube"
     },

--- a/tests/test_functest.py
+++ b/tests/test_functest.py
@@ -57,15 +57,23 @@ class TestFunctest(TestBaseBackend):
 
         enrich_backend = self.connectors[self.connector][2]()
 
-        expected_durations = [None, None, None, 38.0, 263.0,
-                              None, None, None, None, None,
-                              46.0, 32.7, None, None, None,
-                              None, None, None, None, None,
-                              None, None, 81.7, 84.2, None,
+        expected_durations_from_api = [None, None, None, 38.0, 41.0,
+                                       None, None, None, None, None,
+                                       42.0, 32.7, None, None, None,
+                                       None, None, None, None, None,
+                                       None, None, 81.7, 84.2, None,
+                                       None, None]
+
+        expected_durations = [None, 750, 1323, 38, 41,
+                              None, None, None, 864, 902,
+                              42, 33, None, None, None,
+                              768, 193, 2, None, 103,
+                              2, 1380, 82, 85, None,
                               None, None]
 
         for pos, item in enumerate(self.items):
             eitem = enrich_backend.get_rich_item(item)
+            self.assertEqual(eitem['duration_from_api'], expected_durations_from_api[pos])
             self.assertEqual(eitem['duration'], expected_durations[pos])
 
     def test_has_identities(self):

--- a/tests/test_functest.py
+++ b/tests/test_functest.py
@@ -55,6 +55,19 @@ class TestFunctest(TestBaseBackend):
         self.assertEqual(result['raw'], 27)
         self.assertEqual(result['enrich'], 27)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        expected_durations = [None, None, None, 38.0, 263.0,
+                              None, None, None, None, None,
+                              46.0, 32.7, None, None, None,
+                              None, None, None, None, None,
+                              None, None, 81.7, 84.2, None,
+                              None, None]
+
+        for pos, item in enumerate(self.items):
+            eitem = enrich_backend.get_rich_item(item)
+            self.assertEqual(eitem['duration'], expected_durations[pos])
+
     def test_has_identities(self):
         """Test whether has_identities works"""
 


### PR DESCRIPTION
This PR changes the way of assessing the duration time of tests. It relies on `start_date` and `stop_date`, which are used to calculate the duration of a test. The result is stored in the enriched attribute `duration`. To ensure compatibility, the old way (based on the `duration` attribute included in `details`) is stored in the enriched attribute `duration_from_api`.

Tests have been added accordingly.