### PR TITLE
[enriched-study-ceres-aoc] Limit search size to 500

### DIFF
--- a/grimoire_elk/enriched/study_ceres_aoc.py
+++ b/grimoire_elk/enriched/study_ceres_aoc.py
@@ -89,13 +89,13 @@ class ESPandasConnector(ESConnector):
         :raises ValueError: `metadata__timestamp` field not found in index
         :raises NotFoundError: index not found in ElasticSearch
         """
-
         search_query = self._build_search_query(from_date)
         logger.debug(self.__log_prefix + str(search_query))
         hits_block = []
         for hit in helpers.scan(self._es_conn,
                                 search_query,
                                 scroll='300m',
+                                size=500,
                                 index=self._es_index,
                                 preserve_order=True):
 


### PR DESCRIPTION
This PR limits the number of items returned by paginated searches to 500. This change should reduce the risk of getting `BytesStreamOutput cannot hold more than 2GB of data` errors when reading data from ElasticSearch.