### PR TITLE
[enriched-mediawiki] Add `grimoire_creation_date` field

### DIFF
--- a/grimoire_elk/enriched/mediawiki.py
+++ b/grimoire_elk/enriched/mediawiki.py
@@ -32,6 +32,7 @@ from ..elastic_mapping import Mapping as BaseMapping
 logger = logging.getLogger(__name__)
 
 
+REVISION_TYPE = 'revision'
 HIDDEN_EDITOR = '--hidden--'
 
 
@@ -187,6 +188,7 @@ class MediaWikiEnrich(Enrich):
             erevision['metadata__gelk_version'] = eitem['metadata__gelk_version']
             erevision['metadata__gelk_backend_name'] = eitem['metadata__gelk_backend_name']
             erevision['metadata__enriched_on'] = eitem['metadata__enriched_on']
+            erevision.update(self.get_grimoire_fields(erevision['metadata__updated_on'], REVISION_TYPE))
 
             yield erevision
 

--- a/tests/test_mediawiki.py
+++ b/tests/test_mediawiki.py
@@ -65,6 +65,7 @@ class TestMediawiki(TestBaseBackend):
             self.assertIn('metadata__gelk_version', ei)
             self.assertIn('metadata__gelk_backend_name', ei)
             self.assertIn('metadata__enriched_on', ei)
+            self.assertIn('grimoire_creation_date', ei)
 
     def test_raw_to_enrich_sorting_hat(self):
         """Test enrich with SortingHat"""


### PR DESCRIPTION
This code includes the attribute `grimoire_creation_date` to the enriched items generated by the mediawiki enricher.

Tests have been added accordingly.