### PR TITLE
[enriched-gitlab] Add milestone start and due dates

### DIFF
--- a/schema/gitlab_issues.csv
+++ b/schema/gitlab_issues.csv
@@ -33,6 +33,8 @@ metadata__gelk_version,keyword,true,"Version of the backend used to enrich infor
 metadata__timestamp,date,true,"Date when the item was stored in RAW index."
 metadata__updated_on,date,true,"Date when the item was updated on its original data source."
 milestone,keyword,true,"Assigned milestone."
+milestone_start_date,date,true,"Date when a milestone was started."
+milestone_due_date,date,true,"Date when a milestone was due."
 origin,keyword,true,"Original URL where the repository was retrieved from."
 project,keyword,true,"Project."
 project_1,keyword,true,"Project (if more than one level is allowed in project hierarchy)."

--- a/schema/gitlab_merges.csv
+++ b/schema/gitlab_merges.csv
@@ -33,6 +33,8 @@ metadata__gelk_version,keyword,true,"Version of the backend used to enrich infor
 metadata__timestamp,date,true,"Date when the item was stored in RAW index."
 metadata__updated_on,date,true,"Date when the item was updated on its original data source."
 milestone,keyword,true,"Assigned milestone."
+milestone_start_date,date,true,"Date when a milestone was started."
+milestone_due_date,date,true,"Date when a milestone was due."
 num_notes,long,true,"Number of notes."
 num_versions,long,true,"Number of versions"
 origin,keyword,true,"Original URL where the repository was retrieved from."

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -63,31 +63,43 @@ class TestGitLab(TestBaseBackend):
         item = self.items[0]
         eitem = enrich_backend.get_rich_item(item)
         self.assertEqual(eitem['milestone'], "8.17")
+        self.assertEqual(eitem['milestone_start_date'], "2017-01-07T00:00:00")
+        self.assertEqual(eitem['milestone_due_date'], "2017-02-21T00:00:00")
         self.assertEqual(eitem['labels'], [])
 
         item = self.items[1]
         eitem = enrich_backend.get_rich_item(item)
         self.assertEqual(eitem['milestone'], NO_MILESTONE_TAG)
+        self.assertEqual(eitem['milestone_start_date'], None)
+        self.assertEqual(eitem['milestone_due_date'], None)
         self.assertEqual(eitem['labels'], [])
 
         item = self.items[2]
         eitem = enrich_backend.get_rich_item(item)
         self.assertEqual(eitem['milestone'], NO_MILESTONE_TAG)
+        self.assertEqual(eitem['milestone_start_date'], None)
+        self.assertEqual(eitem['milestone_due_date'], None)
         self.assertEqual(eitem['labels'], ['CI/CD', 'Deliverable'])
 
         item = self.items[4]
         eitem = enrich_backend.get_rich_item(item)
         self.assertEqual(eitem['milestone'], "8.17")
+        self.assertEqual(eitem['milestone_start_date'], "2017-01-07T00:00:00")
+        self.assertEqual(eitem['milestone_due_date'], "2017-02-21T00:00:00")
         self.assertEqual(eitem['labels'], [])
 
         item = self.items[5]
         eitem = enrich_backend.get_rich_item(item)
         self.assertEqual(eitem['milestone'], NO_MILESTONE_TAG)
+        self.assertEqual(eitem['milestone_start_date'], None)
+        self.assertEqual(eitem['milestone_due_date'], None)
         self.assertEqual(eitem['labels'], [])
 
         item = self.items[6]
         eitem = enrich_backend.get_rich_item(item)
         self.assertEqual(eitem['milestone'], NO_MILESTONE_TAG)
+        self.assertEqual(eitem['milestone_start_date'], None)
+        self.assertEqual(eitem['milestone_due_date'], None)
         self.assertEqual(eitem['labels'], ['CI/CD', 'Deliverable'])
 
     def test_raw_to_enrich_sorting_hat(self):


### PR DESCRIPTION
This code includes the attributes `milestone_start_date` and `milestone_due_date` to the enriched items. They are extracted from the milestone information included in issues and merge requests. For milestone not having start or due dates, their corresponding values in the enriched items are set `None`.

Tests and schemas have been updated accordingly.