### PR TITLE
[enriched-jira] Handle enriched items from multiple jiras

### DIFF
--- a/grimoire_elk/enriched/jira.py
+++ b/grimoire_elk/enriched/jira.py
@@ -316,8 +316,8 @@ class JiraEnrich(Enrich):
         eitem['time_to_last_update_days'] = None
         eitem['url'] = None
 
-        # Add id info to allow to cohesistance of comments and issues in the same index
-        eitem['id'] = issue['id']
+        # Add id info to allow to coexistence of comments and issues in the same index
+        eitem['id'] = '{}_issue_{}'.format(eitem['uuid'], issue['id'])
 
         if 'comments_data' in issue:
             eitem['number_of_comments'] = len(issue['comments_data'])
@@ -389,8 +389,8 @@ class JiraEnrich(Enrich):
             ecomment['body'] = comment['body']
             ecomment['comment_id'] = comment['id']
 
-            # Add id info to allow to cohesistance of comments and issues in the same index
-            ecomment['id'] = ecomment['issue_key'] + '_comment_' + comment['id']
+            # Add id info to allow to coexistence of comments and issues in the same index
+            ecomment['id'] = '{}_comment_{}'.format(eitem['id'], comment['id'])
             ecomment['type'] = COMMENT_TYPE
 
             if self.sortinghat:

--- a/tests/data/jira.json
+++ b/tests/data/jira.json
@@ -964,7 +964,7 @@
             },
             "workratio": -1
         },
-        "id": "10009",
+        "id": "10010",
         "key": "CONTRIB-4",
         "operations": {
             "linkGroups": [
@@ -1139,7 +1139,7 @@
         "self": "https://finosfoundation.atlassian.net/rest/api/2/issue/10009",
         "transitions": []
     },
-    "origin": "http://finosfoundation.atlassian.net",
+    "origin": "https://issues.apache.org/jira",
     "perceval_version": "0.12.9",
     "tag": "http://finosfoundation.atlassian.net",
     "timestamp": 1554907659.471441,

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -59,22 +59,32 @@ class TestJira(TestBaseBackend):
 
         item = self.items[0]
         eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(item['data']['id'], "10010")
+        self.assertEqual(eitem['id'], "fcf4a8418030d95844f0825fb5b1c3bdc0a1d942_issue_10010")
         self.assertEqual(eitem['number_of_comments'], 0)
 
         item = self.items[1]
         eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(item['data']['id'], "10010")
+        self.assertEqual(eitem['id'], "7bbd3aaee3adba6b1a1d293c78a385a874419b12_issue_10010")
         self.assertEqual(eitem['number_of_comments'], 0)
 
         item = self.items[2]
         eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(item['data']['id'], "10008")
+        self.assertEqual(eitem['id'], "d6b4168fd458f910fb9af1df0e9edcfaa188cc67_issue_10008")
         self.assertEqual(eitem['number_of_comments'], 0)
 
         item = self.items[3]
         eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(item['data']['id'], "10017")
+        self.assertEqual(eitem['id'], "305dbd15b1f250cb6941d8b9270af3d3a4405084_issue_10017")
         self.assertEqual(eitem['number_of_comments'], 0)
 
         item = self.items[4]
         eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(item['data']['id'], "10018")
+        self.assertEqual(eitem['id'], "929182e386ddb7d290c0dbd2eb34140993c8f567_issue_10018")
         self.assertEqual(eitem['number_of_comments'], 2)
 
     def test_raw_to_enrich_sorting_hat(self):


### PR DESCRIPTION
This code modifies the way of creating ids (which now include the `uuid` of the corresponding raw items) for enriched items to handle data from multiple jira instances.