### PR TITLE
[raw-slack] Remove channel_info.previous_names attribute

### DIFF
--- a/grimoire_elk/raw/slack.py
+++ b/grimoire_elk/raw/slack.py
@@ -80,3 +80,7 @@ class SlackOcean(ElasticOcean):
         params = {"channel": url}
 
         return params
+
+    def _fix_item(self, item):
+        if 'channel_info' in item['data']:
+            item['data']['channel_info'].pop('previous_names', None)

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -49,6 +49,11 @@ class TestSlack(TestBaseBackend):
         self.assertEqual(result['items'], 9)
         self.assertEqual(result['raw'], 9)
 
+        for item in self.items:
+            self.ocean_backend._fix_item(item)
+
+            self.assertNotIn('previous_names', item['data']['channel_info'])
+
     def test_raw_to_enrich(self):
         """Test whether the raw index is properly enriched"""
 


### PR DESCRIPTION
This code prevents to index the field `data.channel_info.previous_names`,
thus avoiding mapping_parsing_exception.

Tests have been added accordingly.