### PR TITLE
[enriched-gerrit] Add elk metadata and enable refresh identities

### DIFF
--- a/grimoire_elk/enriched/gerrit.py
+++ b/grimoire_elk/enriched/gerrit.py
@@ -316,6 +316,8 @@ class GerritEnrich(Enrich):
             ecomment.update(self.get_grimoire_fields(comment['timestamp'], COMMENT_TYPE))
 
             self.add_metadata_filter_raw(ecomment)
+            self.add_gelk_metadata(ecomment)
+
             ecomments.append(ecomment)
 
         return ecomments
@@ -384,6 +386,7 @@ class GerritEnrich(Enrich):
             epatchset.update(self.get_grimoire_fields(patchset['createdOn'], PATCHSET_TYPE))
 
             self.add_metadata_filter_raw(epatchset)
+            self.add_gelk_metadata(epatchset)
 
             eitems.append(epatchset)
 
@@ -462,6 +465,7 @@ class GerritEnrich(Enrich):
             eapproval.update(self.get_grimoire_fields(approval['grantedOn'], APPROVAL_TYPE))
 
             self.add_metadata_filter_raw(eapproval)
+            self.add_gelk_metadata(eapproval)
 
             eapprovals.append(eapproval)
 
@@ -546,3 +550,8 @@ class GerritEnrich(Enrich):
                              sort_on_field=sort_on_field,
                              no_incremental=no_incremental,
                              seconds=seconds)
+
+    def add_gelk_metadata(self, eitem):
+        eitem['metadata__gelk_version'] = self.gelk_version
+        eitem['metadata__gelk_backend_name'] = self.__class__.__name__
+        eitem['metadata__enriched_on'] = datetime_utcnow().isoformat()

--- a/grimoire_elk/enriched/gerrit.py
+++ b/grimoire_elk/enriched/gerrit.py
@@ -82,6 +82,8 @@ class GerritEnrich(Enrich):
         self.studies.append(self.enrich_demography)
         self.studies.append(self.enrich_onion)
 
+    roles = ["author", "by", "changeset_author", "reviewer", "uploader"]
+
     def get_field_author(self):
         return "owner"
 

--- a/tests/test_gerrit.py
+++ b/tests/test_gerrit.py
@@ -66,19 +66,42 @@ class TestGerrit(TestBaseBackend):
         item = self.items[0]
         eitem = enrich_backend.get_rich_item(item)
 
+        self.assertIn('metadata__enriched_on', eitem)
+        self.assertIn('metadata__gelk_backend_name', eitem)
+        self.assertIn('metadata__gelk_version', eitem)
+
         comments = item['data']['comments']
         ecomments = enrich_backend.get_rich_item_comments(comments, eitem)
         self.assertEqual(len(ecomments), 46)
+
+        for ecomment in ecomments:
+            self.assertIn('metadata__enriched_on', ecomment)
+            self.assertIn('metadata__gelk_backend_name', ecomment)
+            self.assertIn('metadata__gelk_version', ecomment)
 
         patchsets = item['data']['patchSets']
         eitems = enrich_backend.get_rich_item_patchsets(patchsets, eitem)
         self.assertEqual(len(eitems), 18)
 
+        for eitem in eitems:
+            self.assertIn('metadata__enriched_on', eitem)
+            self.assertIn('metadata__gelk_backend_name', eitem)
+            self.assertIn('metadata__gelk_version', eitem)
+
         epatchsets = [ei for ei in eitems if 'is_gerrit_patchset' in ei]
         eapprovals = [ei for ei in eitems if 'is_gerrit_approval' in ei]
 
         self.assertEqual(len(epatchsets), 5)
+        for epatchset in epatchsets:
+            self.assertIn('metadata__enriched_on', epatchset)
+            self.assertIn('metadata__gelk_backend_name', epatchset)
+            self.assertIn('metadata__gelk_version', epatchset)
+
         self.assertEqual(len(eapprovals), 13)
+        for eapproval in eapprovals:
+            self.assertIn('metadata__enriched_on', eapproval)
+            self.assertIn('metadata__gelk_backend_name', eapproval)
+            self.assertIn('metadata__gelk_version', eapproval)
 
     def test_demography_study(self):
         """ Test that the demography study works correctly """


### PR DESCRIPTION
This PR allows to include metadata such as backend name, elk version and enriched_on to the enriched items. Furthermore, it allows to refresh identites data for the following roles: "author", "by", "changeset_author", "reviewer", "uploader".