### PR TITLE
[enriched-confluence] Add email data to SH identity

### DIFF
--- a/grimoire_elk/enriched/confluence.py
+++ b/grimoire_elk/enriched/confluence.py
@@ -91,6 +91,8 @@ class ConfluenceEnrich(Enrich):
         identity['name'] = None
         if 'username' in user:
             identity['username'] = user['username']
+        if 'email' in user:
+            identity['email'] = user['email']
         if 'displayName' in user:
             identity['name'] = user['displayName']
 


### PR DESCRIPTION
In some cases, Confluence provides users email addresses. This patch adds that value to the SortingHat indentity.