### PR TITLE
[dependencies] Pin urllib3 and requests dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 PyMySQL
 elasticsearch==6.3.1
 elasticsearch-dsl==6.3.1
-requests>=2.7.0
+requests==2.18.2
+urllib3==1.22
 -e git+https://github.com/chaoss/grimoirelab-sortinghat/#egg=grimoirelab-sortinghat
 -e git+https://github.com/chaoss/grimoirelab-toolkit/#egg=grimoirelab-toolkit
 -e git+https://github.com/chaoss/grimoirelab-cereslib/#egg=grimoirelab-cereslib

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,8 @@ setup(name="grimoire-elk",
           'sortinghat>=0.6.2',
           'elasticsearch==6.3.1',
           'elasticsearch-dsl==6.3.1',
-          'requests>=2.7.0'],
+          'requests==2.18.2',
+          'urllib3==1.22'
+      ],
       zip_safe=False
       )


### PR DESCRIPTION
This code fixes the urllib3 version used by ELK to 1.22, since in the later versions urllib3.exceptions.SSLError exceptions may be thrown due to CERTIFICATE_VERIFY_FAILED. Furthermore, it also sets the version of requests to 2.18.2, which is compatible with urllib3 1.22.