### PR TITLE
Fix elasticsearch.exceptions.SSLError: ConnectionError

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ before_install:
   - pip install redis
   - pip install PyMySQL
   - pip install httpretty==0.8.6
-  - pip install elasticsearch==6.1.1
-  - pip install elasticsearch-dsl==6.1.0
+  - pip install elasticsearch==6.3.1
+  - pip install elasticsearch-dsl==6.3.0
   - pip install -r "requirements.txt"
 
 #install:

--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -31,7 +31,7 @@ from datetime import timedelta
 import pkg_resources
 from functools import lru_cache
 
-from elasticsearch import Elasticsearch
+from elasticsearch import Elasticsearch, RequestsHttpConnection
 
 from perceval.backend import find_signature_parameters
 from grimoirelab_toolkit.datetime import (datetime_utcnow, str_to_datetime)
@@ -938,7 +938,7 @@ class Enrich(ElasticItems):
 
         # Creating connections
         es = Elasticsearch([enrich_backend.elastic.url], retry_on_timeout=True, timeout=100,
-                           verify_certs=self.elastic.requests.verify)
+                           verify_certs=self.elastic.requests.verify, connection_class=RequestsHttpConnection)
 
         in_conn = ESOnionConnector(es_conn=es, es_index=in_index,
                                    contribs_field=contribs_field,

--- a/grimoire_elk/enriched/git.py
+++ b/grimoire_elk/enriched/git.py
@@ -28,7 +28,7 @@ import time
 
 import pkg_resources
 import requests
-from elasticsearch import Elasticsearch
+from elasticsearch import Elasticsearch, RequestsHttpConnection
 
 from grimoirelab_toolkit.datetime import (datetime_to_utc,
                                           str_to_datetime)
@@ -611,9 +611,11 @@ class GitEnrich(Enrich):
 
         # Creating connections
         es_in = Elasticsearch([ocean_backend.elastic.url], retry_on_timeout=True, timeout=100,
-                              verify_certs=self.elastic.requests.verify)
+                              verify_certs=self.elastic.requests.verify,
+                              connection_class=RequestsHttpConnection)
         es_out = Elasticsearch([enrich_backend.elastic.url], retry_on_timeout=True,
-                               timeout=100, verify_certs=self.elastic.requests.verify)
+                               timeout=100, verify_certs=self.elastic.requests.verify,
+                               connection_class=RequestsHttpConnection)
         in_conn = ESPandasConnector(es_conn=es_in, es_index=in_index, sort_on_field=sort_on_field)
         out_conn = ESPandasConnector(es_conn=es_out, es_index=out_index, sort_on_field=sort_on_field, read_only=False)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 PyMySQL
 elasticsearch==6.3.1
 elasticsearch-dsl==6.3.1
-requests==2.18.2
-urllib3==1.22
+requests==2.21.0
+urllib3==1.24.3
 -e git+https://github.com/chaoss/grimoirelab-sortinghat/#egg=grimoirelab-sortinghat
 -e git+https://github.com/chaoss/grimoirelab-toolkit/#egg=grimoirelab-toolkit
 -e git+https://github.com/chaoss/grimoirelab-cereslib/#egg=grimoirelab-cereslib

--- a/setup.py
+++ b/setup.py
@@ -88,8 +88,8 @@ setup(name="grimoire-elk",
           'sortinghat>=0.6.2',
           'elasticsearch==6.3.1',
           'elasticsearch-dsl==6.3.1',
-          'requests==2.18.2',
-          'urllib3==1.22'
+          'requests==2.21.0',
+          'urllib3==1.24.3'
       ],
       zip_safe=False
       )


### PR DESCRIPTION
This PR updates the statements that initialize the Elasticsearch objects (imported from the library elasticsearch) to use `RequestsHttpConnection` as connection class, thus avoiding `elasticsearch.exceptions.SSLError: ConnectionError` exceptions. Furthermore the dependencies of urllib3 and requests are also updated, since urllib3 1.22 is affected by a high severity security vulnerability.