### PR TITLE
[elk] Use grimoirelab-toolkit datetime functions

### DIFF
--- a/grimoire_elk/elastic.py
+++ b/grimoire_elk/elastic.py
@@ -29,9 +29,10 @@ from time import time
 
 import requests
 
+from grimoirelab_toolkit.datetime import unixtime_to_datetime
+
 from grimoire_elk.errors import ELKError
-from grimoire_elk.enriched.utils import (unixtime_to_datetime,
-                                         grimoire_con,
+from grimoire_elk.enriched.utils import (grimoire_con,
                                          get_diff_current_date)
 
 logger = logging.getLogger(__name__)

--- a/grimoire_elk/enriched/askbot.py
+++ b/grimoire_elk/enriched/askbot.py
@@ -22,9 +22,10 @@
 
 import logging
 
-from dateutil import parser
+from grimoirelab_toolkit.datetime import (str_to_datetime,
+                                          unixtime_to_datetime)
 
-from .utils import get_time_diff_days, unixtime_to_datetime
+from .utils import get_time_diff_days
 
 from .enrich import Enrich, metadata
 from ..elastic_mapping import Mapping as BaseMapping
@@ -242,7 +243,7 @@ class AskbotEnrich(Enrich):
         if dfield == 'added_at':
             comment_at = unixtime_to_datetime(float(comment[dfield]))
         else:
-            comment_at = parser.parse(comment[dfield])
+            comment_at = str_to_datetime(comment[dfield])
 
         added_at = unixtime_to_datetime(float(item['data']["added_at"]))
         ecomment['time_from_question'] = get_time_diff_days(added_at, comment_at)

--- a/grimoire_elk/enriched/github.py
+++ b/grimoire_elk/enriched/github.py
@@ -26,9 +26,9 @@ import re
 import time
 
 import requests
-from datetime import datetime
 
-from grimoirelab_toolkit.datetime import str_to_datetime
+from grimoirelab_toolkit.datetime import (datetime_utcnow,
+                                          str_to_datetime)
 
 from .utils import get_time_diff_days
 
@@ -545,7 +545,7 @@ class GitHubEnrich(Enrich):
 
         if pull_request['state'] != 'closed':
             rich_pr['time_open_days'] = \
-                get_time_diff_days(pull_request['created_at'], datetime.utcnow())
+                get_time_diff_days(pull_request['created_at'], datetime_utcnow().replace(tzinfo=None))
         else:
             rich_pr['time_open_days'] = rich_pr['time_to_close_days']
 
@@ -653,7 +653,7 @@ class GitHubEnrich(Enrich):
 
         if issue['state'] != 'closed':
             rich_issue['time_open_days'] = \
-                get_time_diff_days(issue['created_at'], datetime.utcnow())
+                get_time_diff_days(issue['created_at'], datetime_utcnow().replace(tzinfo=None))
         else:
             rich_issue['time_open_days'] = rich_issue['time_to_close_days']
 

--- a/grimoire_elk/enriched/meetup.py
+++ b/grimoire_elk/enriched/meetup.py
@@ -23,9 +23,9 @@
 import copy
 import logging
 
-from .enrich import Enrich, metadata
-
 from grimoirelab_toolkit.datetime import unixtime_to_datetime
+
+from .enrich import Enrich, metadata
 from ..elastic_mapping import Mapping as BaseMapping
 
 

--- a/grimoire_elk/enriched/phabricator.py
+++ b/grimoire_elk/enriched/phabricator.py
@@ -22,12 +22,13 @@
 
 import logging
 
-from datetime import datetime
+from grimoirelab_toolkit.datetime import (datetime_utcnow,
+                                          unixtime_to_datetime)
 
 from .enrich import Enrich, metadata
 from ..elastic_mapping import Mapping as BaseMapping
 
-from .utils import get_time_diff_days, unixtime_to_datetime
+from .utils import get_time_diff_days
 
 
 TASK_OPEN_STATUS = 'Open'
@@ -312,7 +313,8 @@ class PhabricatorEnrich(Enrich):
                 get_time_diff_days(eitem['creation_date'], eitem['update_date'])
         # Time open (time to open -> now): with painless
         # Time open using the enrich date. Field needed for filtering.
-        eitem['time_open_days_enrich'] = get_time_diff_days(eitem['creation_date'], datetime.utcnow())
+        eitem['time_open_days_enrich'] = get_time_diff_days(eitem['creation_date'],
+                                                            datetime_utcnow().replace(tzinfo=None))
         # Time from last update (time last update -> now): with painless
 
         eitem['changes'] = len(phab_item['transactions'])

--- a/grimoire_elk/enriched/stackexchange.py
+++ b/grimoire_elk/enriched/stackexchange.py
@@ -22,10 +22,10 @@
 
 import logging
 
+from grimoirelab_toolkit.datetime import unixtime_to_datetime
+
 from .enrich import Enrich, metadata
 from ..elastic_mapping import Mapping as BaseMapping
-
-from .utils import unixtime_to_datetime
 
 
 logger = logging.getLogger(__name__)

--- a/grimoire_elk/enriched/utils.py
+++ b/grimoire_elk/enriched/utils.py
@@ -21,7 +21,7 @@
 #
 
 import datetime
-from dateutil import parser, tz
+from dateutil import parser
 import inspect
 import json
 import logging
@@ -105,22 +105,6 @@ def get_time_diff_days(start, end):
     diff_days = float('%.2f' % diff_days)
 
     return diff_days
-
-
-# https://github.com/grimoirelab/perceval/blob/master/perceval/utils.py#L149
-def unixtime_to_datetime(ut):
-    """Convert a unixtime timestamp to a datetime object.
-    The function converts a timestamp in Unix format to a
-    datetime object. UTC timezone will also be set.
-    :param ut: Unix timestamp to convert
-    :returns: a datetime object
-    :raises InvalidDateError: when the given timestamp cannot be
-        converted into a valid date
-    """
-
-    dt = datetime.datetime.utcfromtimestamp(ut)
-    dt = dt.replace(tzinfo=tz.tzutc())
-    return dt
 
 
 def grimoire_con(insecure=True, conn_retries=MAX_RETRIES_ON_CONNECT, total=MAX_RETRIES):

--- a/grimoire_elk/raw/elastic.py
+++ b/grimoire_elk/raw/elastic.py
@@ -26,8 +26,10 @@
 import inspect
 import logging
 
+from grimoirelab_toolkit.datetime import unixtime_to_datetime
+
 from datetime import datetime
-from ..enriched.utils import unixtime_to_datetime, get_repository_filter
+from ..enriched.utils import get_repository_filter
 from ..elastic_items import ElasticItems
 from ..elastic_mapping import Mapping
 from ..errors import ELKError


### PR DESCRIPTION
This PR removes the function `unixtime_to_datetime` in enriched/utils.py, which was a copy of `datetime.unixtime_to_datetime` in grimoirelab-toolkit. Furthermore, it replaces the use of datetime and dateutil calls with their equivalent in grimoirelab-toolkit. Other enrichers (e.g., bugzilla) are still using direct datetime and dateutil calls, however they can be addressed in a new PR.