### PR TITLE
[enriched-meetup] Store created, time, updated as date

### DIFF
--- a/grimoire_elk/enriched/meetup.py
+++ b/grimoire_elk/enriched/meetup.py
@@ -25,7 +25,7 @@ import logging
 
 from .enrich import Enrich, metadata
 
-from .utils import unixtime_to_datetime
+from grimoirelab_toolkit.datetime import unixtime_to_datetime
 from ..elastic_mapping import Mapping as BaseMapping
 
 
@@ -168,13 +168,20 @@ class MeetupEnrich(Enrich):
 
         # data fields to copy with meetup`prefix
         copy_fields = ["description", "plain_text_description",
-                       "created", "name", "status",
-                       "time", "updated", "utc_offset", "visibility",
+                       "name", "status", "utc_offset", "visibility",
                        "waitlist_count", "yes_rsvp_count", "duration",
                        "featured", "rsvpable"]
+        copy_fields_time = ["time", "updated", "created"]
+
         for f in copy_fields:
             if f in event:
                 eitem["meetup_" + f] = event[f]
+            else:
+                eitem[f] = None
+
+        for f in copy_fields_time:
+            if f in event:
+                eitem["meetup_" + f] = unixtime_to_datetime(event[f] / 1000).isoformat()
             else:
                 eitem[f] = None
 

--- a/tests/test_meetup.py
+++ b/tests/test_meetup.py
@@ -56,6 +56,14 @@ class TestMeetup(TestBaseBackend):
         self.assertEqual(result['raw'], 3)
         self.assertEqual(result['enrich'], 19)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        item = self.items[0]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['meetup_created'], '2016-03-22T16:36:44+00:00')
+        self.assertEqual(eitem['meetup_time'], '2016-04-07T16:30:00+00:00')
+        self.assertEqual(eitem['meetup_updated'], '2016-04-07T21:39:24+00:00')
+
     def test_enrich_repo_labels(self):
         """Test whether the field REPO_LABELS is present in the enriched items"""
 


### PR DESCRIPTION
This code converts the attributes `meetup_time`, `meetup_created` and `meetup_updated` to a date
and store it in isoformat. Tests have been added accordingly.