### PR TITLE
[enriched-enrich] Decrease max keyword size

### DIFF
--- a/grimoire_elk/enriched/bugzilla.py
+++ b/grimoire_elk/enriched/bugzilla.py
@@ -143,10 +143,10 @@ class BugzillaEnrich(Enrich):
         eitem["status"] = issue['bug_status'][0]['__text__']
         if "short_desc" in issue:
             if "__text__" in issue["short_desc"][0]:
-                eitem["main_description"] = issue['short_desc'][0]['__text__'][:self.KEYWORD_MAX_SIZE]
+                eitem["main_description"] = issue['short_desc'][0]['__text__'][:self.KEYWORD_MAX_LENGTH]
         if "summary" in issue:
             if "__text__" in issue["summary"][0]:
-                eitem["summary"] = issue['summary'][0]['__text__'][:self.KEYWORD_MAX_SIZE]
+                eitem["summary"] = issue['summary'][0]['__text__'][:self.KEYWORD_MAX_LENGTH]
 
         # Fix dates
         date_ts = parser.parse(issue['delta_ts'][0]['__text__'])

--- a/grimoire_elk/enriched/bugzillarest.py
+++ b/grimoire_elk/enriched/bugzillarest.py
@@ -92,9 +92,9 @@ class BugzillaRESTEnrich(Enrich):
         eitem["id"] = issue['id']
         eitem["status"] = issue['status']
         if "summary" in issue:
-            eitem["summary"] = issue['summary'][:self.KEYWORD_MAX_SIZE]
+            eitem["summary"] = issue['summary'][:self.KEYWORD_MAX_LENGTH]
             # Share the name field with bugzilla and share the panel
-            eitem["main_description"] = eitem["summary"][:self.KEYWORD_MAX_SIZE]
+            eitem["main_description"] = eitem["summary"][:self.KEYWORD_MAX_LENGTH]
         # Component and product
         eitem["component"] = issue['component']
         eitem["product"] = issue['product']

--- a/grimoire_elk/enriched/discourse.py
+++ b/grimoire_elk/enriched/discourse.py
@@ -211,7 +211,7 @@ class DiscourseEnrich(Enrich):
         # The first post is the first published, and it is the question
         first_post = topic['post_stream']['posts'][0]
 
-        eitem['question_title'] = eitem['question_title'][:self.KEYWORD_MAX_SIZE]
+        eitem['question_title'] = eitem['question_title'][:self.KEYWORD_MAX_LENGTH]
         eitem['category_id'] = topic['category_id']
         eitem['categories'] = self.__related_categories(topic['category_id'])
         if topic['category_id'] in self.categories:

--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -101,7 +101,7 @@ class Enrich(ElasticItems):
     kibiter_version = None
     RAW_FIELDS_COPY = ["metadata__updated_on", "metadata__timestamp",
                        "offset", "origin", "tag", "uuid"]
-    KEYWORD_MAX_SIZE = 30000  # this control allows to avoid max_bytes_length_exceeded_exception
+    KEYWORD_MAX_SIZE = 1000  # this control allows to avoid max_bytes_length_exceeded_exception
 
     ONION_INTERVAL = seconds = 3600 * 24 * 7
 

--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -101,7 +101,7 @@ class Enrich(ElasticItems):
     kibiter_version = None
     RAW_FIELDS_COPY = ["metadata__updated_on", "metadata__timestamp",
                        "offset", "origin", "tag", "uuid"]
-    KEYWORD_MAX_SIZE = 1000  # this control allows to avoid max_bytes_length_exceeded_exception
+    KEYWORD_MAX_LENGTH = 1000  # this control allows to avoid max_bytes_length_exceeded_exception
 
     ONION_INTERVAL = seconds = 3600 * 24 * 7
 

--- a/grimoire_elk/enriched/gerrit.py
+++ b/grimoire_elk/enriched/gerrit.py
@@ -210,7 +210,7 @@ class GerritEnrich(Enrich):
         # Add id info to allow to coexistence of items of different types in the same index
         eitem['id'] = '{}_changeset_{}'.format(eitem['uuid'], eitem['changeset_number'])
         eitem["summary_analyzed"] = eitem["summary"]
-        eitem["summary"] = eitem["summary"][:self.KEYWORD_MAX_SIZE]
+        eitem["summary"] = eitem["summary"][:self.KEYWORD_MAX_LENGTH]
         eitem["name"] = None
         eitem["domain"] = None
         if 'name' in review['owner']:
@@ -288,7 +288,7 @@ class GerritEnrich(Enrich):
             # Add comment-specific data
             created = str_to_datetime(comment['timestamp'])
             ecomment['comment_created_on'] = created.isoformat()
-            ecomment['comment_message'] = comment['message'][:self.KEYWORD_MAX_SIZE]
+            ecomment['comment_message'] = comment['message'][:self.KEYWORD_MAX_LENGTH]
 
             # Add id info to allow to coexistence of items of different types in the same index
             ecomment['type'] = COMMENT_TYPE
@@ -439,7 +439,7 @@ class GerritEnrich(Enrich):
             eapproval['approval_description'] = approval.get('description', None)
 
             if eapproval['approval_description']:
-                eapproval['approval_description'] = eapproval['approval_description'][:self.KEYWORD_MAX_SIZE]
+                eapproval['approval_description'] = eapproval['approval_description'][:self.KEYWORD_MAX_LENGTH]
 
             # Add id info to allow to coexistence of items of different types in the same index
             eapproval['id'] = '{}_approval_{}'.format(epatchset['id'], created.timestamp())

--- a/grimoire_elk/enriched/git.py
+++ b/grimoire_elk/enriched/git.py
@@ -335,7 +335,7 @@ class GitEnrich(Enrich):
                 eitem[map_fields[fn]] = None
 
         if 'message' in commit:
-            eitem['message'] = commit['message'][:self.KEYWORD_MAX_SIZE]
+            eitem['message'] = commit['message'][:self.KEYWORD_MAX_LENGTH]
 
         eitem['hash_short'] = eitem['hash'][0:6]
         # Enrich dates

--- a/grimoire_elk/enriched/jira.py
+++ b/grimoire_elk/enriched/jira.py
@@ -262,7 +262,7 @@ class JiraEnrich(Enrich):
         eitem['creation_date'] = issue["fields"]['created']
 
         if 'description' in issue["fields"] and issue["fields"]['description']:
-            eitem['main_description'] = issue["fields"]['description'][:self.KEYWORD_MAX_SIZE]
+            eitem['main_description'] = issue["fields"]['description'][:self.KEYWORD_MAX_LENGTH]
 
         eitem['issue_type'] = issue["fields"]['issuetype']['name']
         eitem['issue_description'] = issue["fields"]['issuetype']['description']

--- a/grimoire_elk/enriched/mbox.py
+++ b/grimoire_elk/enriched/mbox.py
@@ -155,7 +155,7 @@ class MBoxEnrich(Enrich):
         eitem["list"] = item["origin"]
 
         if 'Subject' in message and message['Subject']:
-            eitem['Subject'] = eitem['Subject'][:self.KEYWORD_MAX_SIZE]
+            eitem['Subject'] = eitem['Subject'][:self.KEYWORD_MAX_LENGTH]
 
         # Root message
         if 'In-Reply-To' in message:

--- a/grimoire_elk/enriched/mediawiki.py
+++ b/grimoire_elk/enriched/mediawiki.py
@@ -150,7 +150,7 @@ class MediaWikiEnrich(Enrich):
                     erevision["revision_" + f] = None
 
             if "comment" in rev:
-                erevision["revision_comment"] = rev["comment"][:self.KEYWORD_MAX_SIZE]
+                erevision["revision_comment"] = rev["comment"][:self.KEYWORD_MAX_LENGTH]
 
             if self.sortinghat:
                 erevision.update(self.get_review_sh(rev, item))

--- a/grimoire_elk/enriched/mozillaclub.py
+++ b/grimoire_elk/enriched/mozillaclub.py
@@ -111,16 +111,16 @@ class MozillaClubEnrich(Enrich):
         event = item['data']
 
         if "Event Description" in event and event["Event Description"]:
-            event["Event Description"] = event["Event Description"][:self.KEYWORD_MAX_SIZE]
+            event["Event Description"] = event["Event Description"][:self.KEYWORD_MAX_LENGTH]
 
         if "Event Creations" in event and event["Event Creations"]:
-            event["Event Creations"] = event["Event Creations"][:self.KEYWORD_MAX_SIZE]
+            event["Event Creations"] = event["Event Creations"][:self.KEYWORD_MAX_LENGTH]
 
         if "Feedback from Attendees" in event and event["Feedback from Attendees"]:
-            event["Feedback from Attendees"] = event["Feedback from Attendees"][:self.KEYWORD_MAX_SIZE]
+            event["Feedback from Attendees"] = event["Feedback from Attendees"][:self.KEYWORD_MAX_LENGTH]
 
         if "Your Feedback" in event and event["Your Feedback"]:
-            event["Your Feedback"] = event["Your Feedback"][:self.KEYWORD_MAX_SIZE]
+            event["Your Feedback"] = event["Your Feedback"][:self.KEYWORD_MAX_LENGTH]
 
         # just copy all fields converting in field names spaces to _
         for f in event:

--- a/grimoire_elk/enriched/redmine.py
+++ b/grimoire_elk/enriched/redmine.py
@@ -117,11 +117,11 @@ class RedmineEnrich(Enrich):
                 eitem[f] = ticket[f]
             else:
                 eitem[f] = None
-        eitem['subject'] = eitem['subject'][:self.KEYWORD_MAX_SIZE]
+        eitem['subject'] = eitem['subject'][:self.KEYWORD_MAX_LENGTH]
         eitem['description_analyzed'] = eitem['description']
 
         if eitem['description']:
-            eitem['description'] = eitem['description'][:self.KEYWORD_MAX_SIZE]
+            eitem['description'] = eitem['description'][:self.KEYWORD_MAX_LENGTH]
 
         # Fields which names are translated
         map_fields = {"due_date": "estimated_closing_date",


### PR DESCRIPTION
This PR limits the number of chars for a string mapped as keyword to 1000 chars. The change is needed to to avoid max_bytes_length_exceeded_exception errors, which may occur when the UTF8 encoding is longer than the max length allowed for keyword attributes (32766 bytes). Furthermore, this PR updates the name of the variable `KEYWORD_MAX_SIZE` to `KEYWORD_MAX_LENGTH`, which seems to be more appropiated.