### PR TITLE
[enriched] Add text mapping

### DIFF
--- a/grimoire_elk/enriched/askbot.py
+++ b/grimoire_elk/enriched/askbot.py
@@ -49,10 +49,12 @@ class Mapping(BaseMapping):
         {
             "properties": {
                 "author_badges": {
-                  "type": "text"
+                  "type": "text",
+                  "index": true
                 },
                 "summary": {
-                  "type": "text"
+                  "type": "text",
+                  "index": true
                 },
                 "id": {
                   "type": "keyword"

--- a/grimoire_elk/enriched/bugzilla.py
+++ b/grimoire_elk/enriched/bugzilla.py
@@ -20,12 +20,10 @@
 #   Alvaro del Castillo San Felix <acs@bitergia.com>
 #
 
-
 import logging
 
-from datetime import datetime
-
-from dateutil import parser
+from grimoirelab_toolkit.datetime import (datetime_utcnow,
+                                          str_to_datetime)
 
 from ..elastic_mapping import Mapping as BaseMapping
 from .enrich import Enrich, metadata
@@ -165,7 +163,7 @@ class BugzillaEnrich(Enrich):
                 eitem["reporter_name"] = issue["reporter"][0]["name"]
                 eitem["author_name"] = issue["reporter"][0]["name"]
 
-        date_ts = parser.parse(issue['creation_ts'][0]['__text__'])
+        date_ts = str_to_datetime(issue['creation_ts'][0]['__text__'])
         eitem['creation_date'] = date_ts.strftime('%Y-%m-%dT%H:%M:%S')
 
         eitem["bug_id"] = issue['bug_id'][0]['__text__']
@@ -180,7 +178,7 @@ class BugzillaEnrich(Enrich):
                 eitem["summary_analyzed"] = issue['summary'][0]['__text__']
 
         # Fix dates
-        date_ts = parser.parse(issue['delta_ts'][0]['__text__'])
+        date_ts = str_to_datetime(issue['delta_ts'][0]['__text__'])
         eitem['changeddate_date'] = date_ts.isoformat()
         eitem['delta_ts'] = date_ts.strftime('%Y-%m-%dT%H:%M:%S')
 
@@ -194,7 +192,7 @@ class BugzillaEnrich(Enrich):
         eitem['resolution_days'] = \
             get_time_diff_days(eitem['creation_date'], eitem['delta_ts'])
         eitem['timeopen_days'] = \
-            get_time_diff_days(eitem['creation_date'], datetime.utcnow())
+            get_time_diff_days(eitem['creation_date'], datetime_utcnow().replace(tzinfo=None))
 
         if self.sortinghat:
             eitem.update(self.get_item_sh(item, self.roles))

--- a/grimoire_elk/enriched/bugzillarest.py
+++ b/grimoire_elk/enriched/bugzillarest.py
@@ -24,6 +24,7 @@ import logging
 
 from dateutil import parser
 
+from ..elastic_mapping import Mapping as BaseMapping
 from .enrich import Enrich, metadata
 from .utils import get_time_diff_days
 
@@ -33,8 +34,36 @@ from grimoirelab_toolkit.datetime import datetime_utcnow
 logger = logging.getLogger(__name__)
 
 
+class Mapping(BaseMapping):
+
+    @staticmethod
+    def get_elastic_mappings(es_major):
+        """Get Elasticsearch mapping.
+
+        :param es_major: major version of Elasticsearch, as string
+        :returns: dictionary with a key, 'items', with the mapping
+        """
+
+        mapping = """
+        {
+            "properties": {
+               "main_description_analyzed": {
+                    "type": "text",
+                    "index": true
+               },
+               "summary_analyzed": {
+                    "type": "text",
+                    "index": true
+               }
+           }
+        }"""
+
+        return {"items": mapping}
+
+
 class BugzillaRESTEnrich(Enrich):
 
+    mapping = Mapping
     roles = ['assigned_to_detail', 'qa_contact_detail', 'creator_detail']
 
     def get_field_author(self):
@@ -94,7 +123,11 @@ class BugzillaRESTEnrich(Enrich):
         if "summary" in issue:
             eitem["summary"] = issue['summary'][:self.KEYWORD_MAX_LENGTH]
             # Share the name field with bugzilla and share the panel
-            eitem["main_description"] = eitem["summary"][:self.KEYWORD_MAX_LENGTH]
+            eitem["main_description"] = eitem["summary"]
+
+            eitem["summary_analyzed"] = issue['summary']
+            eitem["main_description_analyzed"] = issue['summary']
+
         # Component and product
         eitem["component"] = issue['component']
         eitem["product"] = issue['product']

--- a/grimoire_elk/enriched/bugzillarest.py
+++ b/grimoire_elk/enriched/bugzillarest.py
@@ -22,13 +22,12 @@
 
 import logging
 
-from dateutil import parser
-
 from ..elastic_mapping import Mapping as BaseMapping
 from .enrich import Enrich, metadata
 from .utils import get_time_diff_days
 
-from grimoirelab_toolkit.datetime import datetime_utcnow
+from grimoirelab_toolkit.datetime import (datetime_utcnow,
+                                          str_to_datetime)
 
 
 logger = logging.getLogger(__name__)
@@ -133,9 +132,9 @@ class BugzillaRESTEnrich(Enrich):
         eitem["product"] = issue['product']
 
         # Fix dates
-        date_ts = parser.parse(issue['creation_time'])
+        date_ts = str_to_datetime(issue['creation_time'])
         eitem['creation_ts'] = date_ts.strftime('%Y-%m-%dT%H:%M:%S')
-        date_ts = parser.parse(issue['last_change_time'])
+        date_ts = str_to_datetime(issue['last_change_time'])
         eitem['changeddate_date'] = date_ts.isoformat()
         eitem['delta_ts'] = date_ts.strftime('%Y-%m-%dT%H:%M:%S')
 

--- a/grimoire_elk/enriched/confluence.py
+++ b/grimoire_elk/enriched/confluence.py
@@ -46,8 +46,9 @@ class Mapping(BaseMapping):
         {
             "properties": {
                 "title_analyzed": {
-                  "type": "text"
-                  }
+                  "type": "text",
+                  "index": true
+                }
            }
         } """
 

--- a/grimoire_elk/enriched/crates.py
+++ b/grimoire_elk/enriched/crates.py
@@ -47,8 +47,9 @@ class Mapping(BaseMapping):
         {
             "properties": {
                 "description_analyzed": {
-                  "type": "text"
-                  }
+                  "type": "text",
+                  "index": true
+                }
            }
         } """
 

--- a/grimoire_elk/enriched/discourse.py
+++ b/grimoire_elk/enriched/discourse.py
@@ -22,6 +22,7 @@
 
 import logging
 
+from ..elastic_mapping import Mapping as BaseMapping
 from .utils import get_time_diff_days, grimoire_con
 
 from .enrich import Enrich, metadata
@@ -32,7 +33,32 @@ MAX_SIZE_BULK_ENRICHED_ITEMS = 200
 logger = logging.getLogger(__name__)
 
 
+class Mapping(BaseMapping):
+
+    @staticmethod
+    def get_elastic_mappings(es_major):
+        """Get Elasticsearch mapping.
+
+        :param es_major: major version of Elasticsearch, as string
+        :returns: dictionary with a key, 'items', with the mapping
+        """
+
+        mapping = """
+        {
+            "properties": {
+               "question_title_analyzed": {
+                    "type": "text",
+                    "index": true
+               }
+           }
+        }"""
+
+        return {"items": mapping}
+
+
 class DiscourseEnrich(Enrich):
+
+    mapping = Mapping
 
     def __init__(self, db_sortinghat=None, db_projects_map=None, json_projects_map=None,
                  db_user='', db_password='', db_host=''):
@@ -212,6 +238,8 @@ class DiscourseEnrich(Enrich):
         first_post = topic['post_stream']['posts'][0]
 
         eitem['question_title'] = eitem['question_title'][:self.KEYWORD_MAX_LENGTH]
+        eitem['question_title_analyzed'] = eitem['question_title']
+
         eitem['category_id'] = topic['category_id']
         eitem['categories'] = self.__related_categories(topic['category_id'])
         if topic['category_id'] in self.categories:

--- a/grimoire_elk/enriched/gerrit.py
+++ b/grimoire_elk/enriched/gerrit.py
@@ -54,16 +54,19 @@ class Mapping(BaseMapping):
         {
             "properties": {
                "approval_description_analyzed": {
-                  "type": "text"
+                  "type": "text",
+                  "index": true
                },
                "comment_message_analyzed": {
-                  "type": "text"
+                  "type": "text",
+                  "index": true
                },
                "status": {
                   "type": "keyword"
                },
                "summary_analyzed": {
-                  "type": "text"
+                  "type": "text",
+                  "index": true
                },
                "timeopen": {
                   "type": "double"

--- a/grimoire_elk/enriched/gerrit.py
+++ b/grimoire_elk/enriched/gerrit.py
@@ -53,6 +53,12 @@ class Mapping(BaseMapping):
         mapping = """
         {
             "properties": {
+               "approval_description_analyzed": {
+                  "type": "text"
+               },
+               "comment_message_analyzed": {
+                  "type": "text"
+               },
                "status": {
                   "type": "keyword"
                },
@@ -289,6 +295,7 @@ class GerritEnrich(Enrich):
             created = str_to_datetime(comment['timestamp'])
             ecomment['comment_created_on'] = created.isoformat()
             ecomment['comment_message'] = comment['message'][:self.KEYWORD_MAX_LENGTH]
+            ecomment['comment_message_analyzed'] = comment['message']
 
             # Add id info to allow to coexistence of items of different types in the same index
             ecomment['type'] = COMMENT_TYPE
@@ -440,6 +447,7 @@ class GerritEnrich(Enrich):
 
             if eapproval['approval_description']:
                 eapproval['approval_description'] = eapproval['approval_description'][:self.KEYWORD_MAX_LENGTH]
+                eapproval['approval_description_analyzed'] = eapproval['approval_description']
 
             # Add id info to allow to coexistence of items of different types in the same index
             eapproval['id'] = '{}_approval_{}'.format(epatchset['id'], created.timestamp())

--- a/grimoire_elk/enriched/github.py
+++ b/grimoire_elk/enriched/github.py
@@ -69,7 +69,8 @@ class Mapping(BaseMapping):
                    "type": "geo_point"
                },
                "title_analyzed": {
-                 "type": "text"
+                 "type": "text",
+                 "index": true
                }
             }
         }

--- a/grimoire_elk/enriched/gitlab.py
+++ b/grimoire_elk/enriched/gitlab.py
@@ -58,7 +58,8 @@ class Mapping(BaseMapping):
         {
             "properties": {
                "title_analyzed": {
-                 "type": "text"
+                 "type": "text",
+                 "index": true
                }
             }
         }

--- a/grimoire_elk/enriched/jira.py
+++ b/grimoire_elk/enriched/jira.py
@@ -55,13 +55,15 @@ class Mapping(BaseMapping):
         {
             "properties": {
                "main_description_analyzed": {
-                 "type": "text"
+                 "type": "text",
+                 "index": true
                },
                "releases": {
                  "type": "keyword"
                },
                "body": {
-                 "type": "text"
+                 "type": "text",
+                 "index": true
                }
             }
         }

--- a/grimoire_elk/enriched/jira.py
+++ b/grimoire_elk/enriched/jira.py
@@ -54,6 +54,9 @@ class Mapping(BaseMapping):
         mapping = """
         {
             "properties": {
+               "main_description_analyzed": {
+                 "type": "text"
+               },
                "releases": {
                  "type": "keyword"
                },
@@ -263,6 +266,7 @@ class JiraEnrich(Enrich):
 
         if 'description' in issue["fields"] and issue["fields"]['description']:
             eitem['main_description'] = issue["fields"]['description'][:self.KEYWORD_MAX_LENGTH]
+            eitem['main_description_analyzed'] = issue["fields"]['description']
 
         eitem['issue_type'] = issue["fields"]['issuetype']['name']
         eitem['issue_description'] = issue["fields"]['issuetype']['description']

--- a/grimoire_elk/enriched/kitsune.py
+++ b/grimoire_elk/enriched/kitsune.py
@@ -47,11 +47,13 @@ class Mapping(BaseMapping):
         {
             "properties": {
                 "content_analyzed": {
-                  "type": "text"
-                  },
+                  "type": "text",
+                  "index": true
+                },
                 "tags_analyzed": {
-                  "type": "text"
-                  }
+                  "type": "text",
+                  "index": true
+                }
            }
         } """
 

--- a/grimoire_elk/enriched/mattermost.py
+++ b/grimoire_elk/enriched/mattermost.py
@@ -45,8 +45,9 @@ class Mapping(BaseMapping):
             "properties": {
                 "text_analyzed": {
                   "type": "text",
-                  "fielddata": true
-                  }
+                  "fielddata": true,
+                  "index": true
+                }
            }
         } """
 

--- a/grimoire_elk/enriched/mbox.py
+++ b/grimoire_elk/enriched/mbox.py
@@ -50,10 +50,12 @@ class Mapping(BaseMapping):
             "properties": {
                  "Subject_analyzed": {
                    "type": "text",
-                   "fielddata": true
+                   "fielddata": true,
+                   "index": true
                  },
                  "body": {
-                   "type": "text"
+                   "type": "text",
+                   "index": true
                  }
            }
         } """

--- a/grimoire_elk/enriched/mediawiki.py
+++ b/grimoire_elk/enriched/mediawiki.py
@@ -23,11 +23,10 @@
 import json
 import logging
 
-from dateutil import parser
+from grimoirelab_toolkit.datetime import str_to_datetime
 
 from .enrich import Enrich, metadata
 from ..elastic_mapping import Mapping as BaseMapping
-
 
 logger = logging.getLogger(__name__)
 
@@ -114,7 +113,7 @@ class MediaWikiEnrich(Enrich):
         """ Add sorting hat enrichment fields for the author of the revision """
 
         identity = self.get_sh_identity(revision)
-        update = parser.parse(item[self.get_field_date()])
+        update = str_to_datetime(item[self.get_field_date()])
         erevision = self.get_item_sh_fields(identity, update)
 
         return erevision
@@ -221,7 +220,7 @@ class MediaWikiEnrich(Enrich):
             eitem[map_fields[fn]] = page[fn]
 
         # Enrich dates
-        eitem["update_date"] = parser.parse(item["metadata__updated_on"]).isoformat()
+        eitem["update_date"] = str_to_datetime(item["metadata__updated_on"]).isoformat()
         # Revisions
         eitem["last_edited_date"] = None
         eitem["nrevisions"] = 0

--- a/grimoire_elk/enriched/mediawiki.py
+++ b/grimoire_elk/enriched/mediawiki.py
@@ -49,10 +49,12 @@ class Mapping(BaseMapping):
         {
             "properties": {
                 "revision_comment_analyzed": {
-                    "type": "text"
+                    "type": "text",
+                    "index": true
                 },
                 "title_analyzed": {
-                    "type": "text"
+                    "type": "text",
+                    "index": true
                 }
            }
         } """

--- a/grimoire_elk/enriched/mediawiki.py
+++ b/grimoire_elk/enriched/mediawiki.py
@@ -49,6 +49,9 @@ class Mapping(BaseMapping):
         mapping = """
         {
             "properties": {
+                "revision_comment_analyzed": {
+                    "type": "text"
+                },
                 "title_analyzed": {
                     "type": "text"
                 }
@@ -151,6 +154,7 @@ class MediaWikiEnrich(Enrich):
 
             if "comment" in rev:
                 erevision["revision_comment"] = rev["comment"][:self.KEYWORD_MAX_LENGTH]
+                erevision["revision_comment_analyzed"] = rev["comment"]
 
             if self.sortinghat:
                 erevision.update(self.get_review_sh(rev, item))

--- a/grimoire_elk/enriched/mozillaclub.py
+++ b/grimoire_elk/enriched/mozillaclub.py
@@ -47,25 +47,29 @@ class Mapping(BaseMapping):
                     "type": "keyword"
                 },
                 "Event_Description_Analyzed": {
-                    "type": "text"
+                    "type": "text",
+                    "index": true
                 },
                 "Event_Creations": {
                     "type": "keyword"
                 },
                 "Event_Creations_Analyzed": {
-                    "type": "text"
+                    "type": "text",
+                    "index": true
                 },
                 "Feedback_from_Attendees": {
                     "type": "keyword"
                 },
                 "Feedback_from_Attendees_Analyzed": {
-                    "type": "text"
+                    "type": "text",
+                    "index": true
                 },
                 "Your_Feedback": {
                     "type": "keyword"
                 },
                 "Your_Feedback_Analyzed": {
-                    "type": "text"
+                    "type": "text",
+                    "index": true
                 },
                 "geolocation": {
                     "type": "geo_point"

--- a/grimoire_elk/enriched/mozillaclub.py
+++ b/grimoire_elk/enriched/mozillaclub.py
@@ -46,14 +46,26 @@ class Mapping(BaseMapping):
                 "Event_Description": {
                     "type": "keyword"
                 },
+                "Event_Description_Analyzed": {
+                    "type": "text"
+                },
                 "Event_Creations": {
                     "type": "keyword"
+                },
+                "Event_Creations_Analyzed": {
+                    "type": "text"
                 },
                 "Feedback_from_Attendees": {
                     "type": "keyword"
                 },
+                "Feedback_from_Attendees_Analyzed": {
+                    "type": "text"
+                },
                 "Your_Feedback": {
                     "type": "keyword"
+                },
+                "Your_Feedback_Analyzed": {
+                    "type": "text"
                 },
                 "geolocation": {
                     "type": "geo_point"
@@ -112,15 +124,19 @@ class MozillaClubEnrich(Enrich):
 
         if "Event Description" in event and event["Event Description"]:
             event["Event Description"] = event["Event Description"][:self.KEYWORD_MAX_LENGTH]
+            event["Event Description Analyzed"] = event["Event Description"]
 
         if "Event Creations" in event and event["Event Creations"]:
             event["Event Creations"] = event["Event Creations"][:self.KEYWORD_MAX_LENGTH]
+            event["Event Creations Analyzed"] = event["Event Creations"]
 
         if "Feedback from Attendees" in event and event["Feedback from Attendees"]:
             event["Feedback from Attendees"] = event["Feedback from Attendees"][:self.KEYWORD_MAX_LENGTH]
+            event["Feedback from Attendees Analyzed"] = event["Feedback from Attendees"]
 
         if "Your Feedback" in event and event["Your Feedback"]:
             event["Your Feedback"] = event["Your Feedback"][:self.KEYWORD_MAX_LENGTH]
+            event["Your Feedback Analyzed"] = event["Your Feedback"]
 
         # just copy all fields converting in field names spaces to _
         for f in event:

--- a/grimoire_elk/enriched/phabricator.py
+++ b/grimoire_elk/enriched/phabricator.py
@@ -49,16 +49,19 @@ class Mapping(BaseMapping):
         {
             "properties": {
                 "main_description_analyzed": {
-                  "type": "text"
+                  "type": "text",
+                  "index": true
                 },
                 "assigned_to_roles": {
                   "type": "text",
-                  "fielddata": true
-                 },
+                  "fielddata": true,
+                  "index": true
+                },
                 "tags_analyzed": {
                   "type": "text",
-                  "fielddata": true
-                 }
+                  "fielddata": true,
+                  "index": true
+                }
            }
         } """
 

--- a/grimoire_elk/enriched/puppetforge.py
+++ b/grimoire_elk/enriched/puppetforge.py
@@ -33,9 +33,9 @@ class PuppetForgeEnrich(Enrich):
         {
             "properties": {
                 "summary_analyzed": {
-                  "type": "string",
-                  "index":"analyzed"
-                  }
+                  "type": "text",
+                  "index":"true"
+                }
            }
         } """
 

--- a/grimoire_elk/enriched/redmine.py
+++ b/grimoire_elk/enriched/redmine.py
@@ -22,7 +22,7 @@
 
 import logging
 
-from datetime import datetime
+from grimoirelab_toolkit.datetime import datetime_utcnow
 
 from .enrich import Enrich, metadata
 from ..elastic_mapping import Mapping as BaseMapping
@@ -160,9 +160,9 @@ class RedmineEnrich(Enrich):
                 get_time_diff_days(eitem['start_date'], eitem['closing_date'])
         else:
             eitem['timeopen_days'] = \
-                get_time_diff_days(eitem['creation_date'], datetime.utcnow())
+                get_time_diff_days(eitem['creation_date'], datetime_utcnow().replace(tzinfo=None))
             eitem['timeworking_days'] = \
-                get_time_diff_days(eitem['start_date'], datetime.utcnow())
+                get_time_diff_days(eitem['start_date'], datetime_utcnow().replace(tzinfo=None))
 
         eitem.update(self.get_grimoire_fields(item["metadata__updated_on"], "job"))
 

--- a/grimoire_elk/enriched/redmine.py
+++ b/grimoire_elk/enriched/redmine.py
@@ -47,10 +47,12 @@ class Mapping(BaseMapping):
         {
             "properties": {
                 "description_analyzed": {
-                    "type": "text"
+                    "type": "text",
+                    "index": true
                 },
                 "subject_analyzed": {
-                    "type": "text"
+                    "type": "text",
+                    "index": true
                 }
            }
         } """

--- a/grimoire_elk/enriched/redmine.py
+++ b/grimoire_elk/enriched/redmine.py
@@ -48,6 +48,9 @@ class Mapping(BaseMapping):
             "properties": {
                 "description_analyzed": {
                     "type": "text"
+                },
+                "subject_analyzed": {
+                    "type": "text"
                 }
            }
         } """
@@ -118,8 +121,9 @@ class RedmineEnrich(Enrich):
             else:
                 eitem[f] = None
         eitem['subject'] = eitem['subject'][:self.KEYWORD_MAX_LENGTH]
-        eitem['description_analyzed'] = eitem['description']
+        eitem['subject_analyzed'] = eitem['subject']
 
+        eitem['description_analyzed'] = eitem['description']
         if eitem['description']:
             eitem['description'] = eitem['description'][:self.KEYWORD_MAX_LENGTH]
 

--- a/grimoire_elk/enriched/remo.py
+++ b/grimoire_elk/enriched/remo.py
@@ -43,7 +43,8 @@ class Mapping(BaseMapping):
         {
             "properties": {
                 "description_analyzed": {
-                  "type": "text"
+                  "type": "text",
+                  "index": true
                 },
                 "geolocation": {
                     "type": "geo_point"

--- a/grimoire_elk/enriched/slack.py
+++ b/grimoire_elk/enriched/slack.py
@@ -47,8 +47,9 @@ class Mapping(BaseMapping):
             "properties": {
                 "text_analyzed": {
                   "type": "text",
-                  "fielddata": true
-                  }
+                  "fielddata": true,
+                  "index": true
+                }
            }
         } """
 

--- a/grimoire_elk/enriched/stackexchange.py
+++ b/grimoire_elk/enriched/stackexchange.py
@@ -45,7 +45,8 @@ class Mapping(BaseMapping):
         {
             "properties": {
                 "title_analyzed": {
-                  "type": "text"
+                  "type": "text",
+                  "index": true
                 }
            }
         } """

--- a/grimoire_elk/enriched/supybot.py
+++ b/grimoire_elk/enriched/supybot.py
@@ -46,8 +46,9 @@ class Mapping(BaseMapping):
             "properties": {
                 "body_analyzed": {
                   "type": "text",
-                  "fielddata": true
-                  }
+                  "fielddata": true,
+                  "index": true
+                }
            }
         } """
 

--- a/grimoire_elk/enriched/telegram.py
+++ b/grimoire_elk/enriched/telegram.py
@@ -44,8 +44,9 @@ class Mapping(BaseMapping):
             "properties": {
                 "text_analyzed": {
                   "type": "text",
-                  "fielddata": true
-                  }
+                  "fielddata": true,
+                  "index": true
+                }
            }
         } """
 

--- a/grimoire_elk/enriched/twitter.py
+++ b/grimoire_elk/enriched/twitter.py
@@ -46,11 +46,12 @@ class Mapping(BaseMapping):
         {
             "properties": {
                 "text_analyzed": {
-                  "type": "text"
-                  },
-                  "geolocation": {
+                  "type": "text",
+                  "index": true
+                },
+                "geolocation": {
                      "type": "geo_point"
-                  }
+                }
            }
         } """
 

--- a/grimoire_elk/raw/gerrit.py
+++ b/grimoire_elk/raw/gerrit.py
@@ -43,7 +43,8 @@ class Mapping(BaseMapping):
                 "data": {
                     "properties": {
                         "commitMessage": {
-                            "type": "text"
+                            "type": "text",
+                            "index": true
                         },
                         "comments": {
                             "properties": {

--- a/grimoire_elk/raw/jenkins.py
+++ b/grimoire_elk/raw/jenkins.py
@@ -66,7 +66,8 @@ class Mapping(BaseMapping):
                                     "items": {
                                         "properties": {
                                             "comment": {
-                                                "type": "text"
+                                                "type": "text",
+                                                "index": true
                                             }
                                         }
                                     }

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -57,6 +57,13 @@ class TestBugzilla(TestBaseBackend):
         self.assertEqual(result['raw'], 7)
         self.assertEqual(result['enrich'], 7)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        item = self.items[0]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertIn('main_description', eitem)
+        self.assertIn('main_description_analyzed', eitem)
+
     def test_enrich_repo_labels(self):
         """Test whether the field REPO_LABELS is present in the enriched items"""
 

--- a/tests/test_bugzillarest.py
+++ b/tests/test_bugzillarest.py
@@ -59,6 +59,15 @@ class TestBugzillaRest(TestBaseBackend):
         self.assertEqual(result['raw'], 7)
         self.assertEqual(result['enrich'], 7)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        item = self.items[0]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertIn('main_description', eitem)
+        self.assertIn('main_description_analyzed', eitem)
+        self.assertIn('summary', eitem)
+        self.assertIn('summary_analyzed', eitem)
+
     def test_enrich_repo_labels(self):
         """Test whether the field REPO_LABELS is present in the enriched items"""
 

--- a/tests/test_discourse.py
+++ b/tests/test_discourse.py
@@ -56,6 +56,13 @@ class TestDiscourse(TestBaseBackend):
         self.assertEqual(result['raw'], 3)
         self.assertEqual(result['enrich'], 35)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        item = self.items[0]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertIn('question_title', eitem)
+        self.assertIn('question_title_analyzed', eitem)
+
     def test_enrich_repo_labels(self):
         """Test whether the field REPO_LABELS is present in the enriched items"""
 

--- a/tests/test_gerrit.py
+++ b/tests/test_gerrit.py
@@ -77,6 +77,8 @@ class TestGerrit(TestBaseBackend):
         self.assertEqual(len(ecomments), 46)
 
         for ecomment in ecomments:
+            self.assertIn('comment_message', ecomment)
+            self.assertIn('comment_message_analyzed', ecomment)
             self.assertIn('metadata__enriched_on', ecomment)
             self.assertIn('metadata__gelk_backend_name', ecomment)
             self.assertIn('metadata__gelk_version', ecomment)
@@ -104,6 +106,8 @@ class TestGerrit(TestBaseBackend):
 
         self.assertEqual(len(eapprovals), 13)
         for eapproval in eapprovals:
+            self.assertIn('approval_description', eapproval)
+            self.assertIn('approval_description_analyzed', eapproval)
             self.assertIn('metadata__enriched_on', eapproval)
             self.assertIn('metadata__gelk_backend_name', eapproval)
             self.assertIn('metadata__gelk_version', eapproval)

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -63,6 +63,8 @@ class TestJira(TestBaseBackend):
         self.assertEqual(item['data']['id'], "10010")
         self.assertEqual(eitem['id'], "fcf4a8418030d95844f0825fb5b1c3bdc0a1d942_issue_10010")
         self.assertEqual(eitem['number_of_comments'], 0)
+        self.assertIn("main_description", eitem)
+        self.assertIn("main_description_analyzed", eitem)
 
         item = self.items[1]
         eitem = enrich_backend.get_rich_item(item)

--- a/tests/test_mediawiki.py
+++ b/tests/test_mediawiki.py
@@ -67,6 +67,8 @@ class TestMediawiki(TestBaseBackend):
             self.assertIn('metadata__gelk_backend_name', ei)
             self.assertIn('metadata__enriched_on', ei)
             self.assertIn('grimoire_creation_date', ei)
+            self.assertIn('revision_comment', ei)
+            self.assertIn('revision_comment_analyzed', ei)
 
     def test_enrich_repo_labels(self):
         """Test whether the field REPO_LABELS is present in the enriched items"""

--- a/tests/test_mozillaclub.py
+++ b/tests/test_mozillaclub.py
@@ -62,7 +62,18 @@ class TestMozillaClub(TestBaseBackend):
             ei = enrich_backend.get_rich_item(i)
             self.assertIn('metadata__gelk_version', ei)
             self.assertIn('metadata__gelk_backend_name', ei)
-            self.assertIn('metadata__enriched_on', ei)
+
+            if 'Event Description' in ei:
+                self.assertIn('Event Description Analyzed', ei)
+
+            if 'Event Creations' in ei:
+                self.assertIn('Event Creations Analyzed', ei)
+
+            if 'Feedback from Attendees' in ei:
+                self.assertIn('Feedback from Attendees Analyzed', ei)
+
+            if 'Your Feedback' in ei:
+                self.assertIn('Your Feedback Analyzed', ei)
 
     def test_enrich_repo_labels(self):
         """Test whether the field REPO_LABELS is present in the enriched items"""

--- a/tests/test_redmine.py
+++ b/tests/test_redmine.py
@@ -64,6 +64,12 @@ class TestRedmine(TestBaseBackend):
             self.assertIn('metadata__gelk_backend_name', ei)
             self.assertIn('metadata__enriched_on', ei)
 
+            if 'description' in ei:
+                self.assertIn('description_analyzed', ei)
+
+            if 'subject' in ei:
+                self.assertIn('subject_analyzed', ei)
+
     def test_enrich_repo_labels(self):
         """Test whether the field REPO_LABELS is present in the enriched items"""
 


### PR DESCRIPTION
This PR add text mappings for some enriched attributes: 
- bugzilla: `summary_analyzed` and `main_description_analyzed`
- bugzillarest:  `summary_analyzed` and `main_description_analyzed`
- discourse: `question_title_analyzed`
- gerrit: `approval_description_analyzed` and `comment_message_analyzed`
- jira: `main_description_analyzed`
- mediawiki: `revision_comment_analyzed`
- mozillaclub: `Event_Description_Analyzed`, `Event_Creations_Analyzed`, `Feedback_from_Attendees_Analyzed` and `Your_Feedback_Analyzed`
- redmine: `description_analyzed` and `subject_analyzed`

Furthermore, it also promotes the use of the grimoirelab-toolkit datetime functions (instead of calls to the datetime/dateutil libraries)

For consistency reasons, the param `index` for all text mappings is now set explictly to `true`