### PR TITLE
Fix format type for long description of packge.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@
 import codecs
 import os
 import re
-import sys
 
 # Always prefer setuptools over distutils
 from setuptools import setup
@@ -32,18 +31,9 @@ here = os.path.abspath(os.path.dirname(__file__))
 readme_md = os.path.join(here, 'README.md')
 version_py = os.path.join(here, 'grimoire_elk', '_version.py')
 
-# Pypi wants the description to be in reStrcuturedText, but
-# we have it in Markdown. So, let's convert formats.
-# Set up thinkgs so that if pypandoc is not installed, it
-# just issues a warning.
-try:
-    import pypandoc
-    long_description = pypandoc.convert(readme_md, 'rst')
-except (IOError, ImportError):
-    print("Warning: pypandoc module not found, or pandoc not installed. "
-          "Using md instead of rst", file=sys.stderr)
-    with codecs.open(readme_md, encoding='utf-8') as f:
-        long_description = f.read()
+# Get the package description from the README.md file
+with codecs.open(readme_md, encoding='utf-8') as f:
+    long_description = f.read()
 
 with codecs.open(version_py, 'r', encoding='utf-8') as fd:
     version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
@@ -52,6 +42,7 @@ with codecs.open(version_py, 'r', encoding='utf-8') as fd:
 setup(name="grimoire-elk",
       description="GrimoireLab library to produce indexes for ElasticSearch",
       long_description=long_description,
+      long_description_content_type='text/markdown',
       url="https://github.com/grimoirelab/GrimoireELK",
       version=version,
       author="Bitergia",


### PR DESCRIPTION
Pypi now wants that the format of the long description for a package is detailed in the variable long_description_content_type, in setup.py. The good news is that it now supports Markdown, without
any need to convert it to reST.
