### PR TITLE
[enriched-jira] Track creator, assignee, reporter in issues

### DIFF
--- a/grimoire_elk/enriched/jira.py
+++ b/grimoire_elk/enriched/jira.py
@@ -35,7 +35,6 @@ MAX_SIZE_BULK_ENRICHED_ITEMS = 200
 ISSUE_TYPE = 'issue'
 COMMENT_TYPE = 'comment'
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -119,6 +118,7 @@ class JiraEnrich(Enrich):
 
         for rol in roles:
             identity = self.get_sh_identity(item, rol)
+
             eitem_sh.update(self.get_item_sh_fields(identity, created, rol=rol))
 
             if not eitem_sh[rol + '_org_name']:
@@ -129,20 +129,6 @@ class JiraEnrich(Enrich):
 
             if not eitem_sh[rol + '_user_name']:
                 eitem_sh[rol + '_user_name'] = SH_UNKNOWN_VALUE
-
-            # Add the author field common in all data sources
-            if rol == self.get_field_author():
-                identity = self.get_sh_identity(item, rol)
-                eitem_sh.update(self.get_item_sh_fields(identity, created, rol="author"))
-
-                if not eitem_sh['author_org_name']:
-                    eitem_sh['author_org_name'] = SH_UNKNOWN_VALUE
-
-                if not eitem_sh['author_name']:
-                    eitem_sh['author_name'] = SH_UNKNOWN_VALUE
-
-                if not eitem_sh['author_user_name']:
-                    eitem_sh['author_user_name'] = SH_UNKNOWN_VALUE
 
         return eitem_sh
 
@@ -231,7 +217,7 @@ class JiraEnrich(Enrich):
                                 eitem['sprint_complete'] = cls.fix_value_null(sprint_complete)
 
     @metadata
-    def get_rich_item(self, item):
+    def get_rich_item(self, item, author_type='creator'):
 
         eitem = {}
 
@@ -253,16 +239,27 @@ class JiraEnrich(Enrich):
 
         eitem['changes'] = issue['changelog']['total']
 
+        if "creator" in issue["fields"] and issue["fields"]["creator"]:
+            eitem['creator_name'] = issue["fields"]["creator"]["displayName"]
+            eitem['creator_login'] = issue["fields"]["creator"]["name"]
+            if "timeZone" in issue["fields"]["creator"]:
+                eitem['creator_tz'] = issue["fields"]["creator"]["timeZone"]
+
         if "assignee" in issue["fields"] and issue["fields"]["assignee"]:
             eitem['assignee'] = issue["fields"]["assignee"]["displayName"]
             if "timeZone" in issue["fields"]["assignee"]:
                 eitem['assignee_tz'] = issue["fields"]["assignee"]["timeZone"]
 
-        if "creator" in issue["fields"] and issue["fields"]["creator"]:
-            eitem['author_name'] = issue["fields"]["creator"]["displayName"]
-            eitem['author_login'] = issue["fields"]["creator"]["name"]
-            if "timeZone" in issue["fields"]["creator"]:
-                eitem['author_tz'] = issue["fields"]["creator"]["timeZone"]
+        if 'reporter' in issue['fields'] and issue['fields']['reporter']:
+            eitem['reporter_name'] = issue['fields']['reporter']['displayName']
+            eitem['reporter_login'] = issue['fields']['reporter']['name']
+            if "timeZone" in issue["fields"]["reporter"]:
+                eitem['reporter_tz'] = issue["fields"]["reporter"]["timeZone"]
+
+        eitem['author_type'] = author_type
+        eitem['author_name'] = eitem.get(author_type + '_name', None)
+        eitem['author_login'] = eitem.get(author_type + '_login', None)
+        eitem['author_tz'] = eitem.get(author_type + '_tz', None)
 
         eitem['creation_date'] = issue["fields"]['created']
 
@@ -286,12 +283,6 @@ class JiraEnrich(Enrich):
         eitem['project_id'] = issue['fields']['project']['id']
         eitem['project_key'] = issue['fields']['project']['key']
         eitem['project_name'] = issue['fields']['project']['name']
-
-        if 'reporter' in issue['fields'] and issue['fields']['reporter']:
-            eitem['reporter_name'] = issue['fields']['reporter']['displayName']
-            eitem['reporter_login'] = issue['fields']['reporter']['name']
-            if "timeZone" in issue["fields"]["reporter"]:
-                eitem['reporter_tz'] = issue["fields"]["reporter"]["timeZone"]
 
         if "resolution" in issue['fields'] and issue['fields']['resolution']:
             eitem['resolution_id'] = issue['fields']['resolution']['id']
@@ -323,7 +314,7 @@ class JiraEnrich(Enrich):
         eitem['url'] = None
 
         # Add id info to allow to coexistence of comments and issues in the same index
-        eitem['id'] = '{}_issue_{}'.format(eitem['uuid'], issue['id'])
+        eitem['id'] = '{}_issue_{}_user_{}'.format(eitem['uuid'], issue['id'], author_type)
 
         if 'comments_data' in issue:
             eitem['number_of_comments'] = len(issue['comments_data'])
@@ -347,6 +338,17 @@ class JiraEnrich(Enrich):
 
         if self.sortinghat:
             eitem.update(self.get_item_sh(item, ["assignee", "reporter", "creator"], issue['fields']['created']))
+
+            # Set the author info to the one identified by author_type
+            eitem['author_id'] = eitem[author_type + '_id']
+            eitem['author_uuid'] = eitem[author_type + '_uuid']
+            eitem['author_name'] = eitem[author_type + '_name']
+            eitem['author_user_name'] = eitem[author_type + '_user_name']
+            eitem['author_domain'] = eitem[author_type + '_domain']
+            eitem['author_gender'] = eitem[author_type + '_gender']
+            eitem['author_gender_acc'] = eitem[author_type + '_gender_acc']
+            eitem['author_org_name'] = eitem[author_type + '_org_name']
+            eitem['author_bot'] = eitem[author_type + '_bot']
 
         if self.prjs_map:
             eitem.update(self.get_item_project(eitem))
@@ -423,13 +425,17 @@ class JiraEnrich(Enrich):
         ins_items = 0
 
         for item in ocean_backend.fetch():
-            eitem = self.get_rich_item(item)
+            eitem_creator = self.get_rich_item(item, author_type='creator')
+            eitem_assignee = self.get_rich_item(item, author_type='assignee')
+            eitem_reporter = self.get_rich_item(item, author_type='reporter')
 
-            items_to_enrich.append(eitem)
+            items_to_enrich.append(eitem_creator)
+            items_to_enrich.append(eitem_assignee)
+            items_to_enrich.append(eitem_reporter)
 
             comments = item['data'].get('comments_data', [])
             if comments:
-                rich_item_comments = self.get_rich_item_comments(comments, eitem)
+                rich_item_comments = self.get_rich_item_comments(comments, eitem_creator)
                 items_to_enrich.extend(rich_item_comments)
 
             if len(items_to_enrich) < MAX_SIZE_BULK_ENRICHED_ITEMS:

--- a/schema/jira.csv
+++ b/schema/jira.csv
@@ -1,4 +1,5 @@
 name,type
+author_type,keyword
 assignee_bot,boolean
 assignee_domain,keyword
 assignee_id,keyword

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -54,41 +54,64 @@ class TestJira(TestBaseBackend):
 
         result = self._test_raw_to_enrich()
         self.assertEqual(result['raw'], 5)
-        self.assertEqual(result['enrich'], 7)
+        self.assertEqual(result['enrich'], 17)
 
         enrich_backend = self.connectors[self.connector][2]()
 
         item = self.items[0]
         eitem = enrich_backend.get_rich_item(item)
         self.assertEqual(item['data']['id'], "10010")
-        self.assertEqual(eitem['id'], "fcf4a8418030d95844f0825fb5b1c3bdc0a1d942_issue_10010")
+        self.assertEqual(eitem['id'], "fcf4a8418030d95844f0825fb5b1c3bdc0a1d942_issue_10010_user_creator")
         self.assertEqual(eitem['number_of_comments'], 0)
         self.assertIn("main_description", eitem)
         self.assertIn("main_description_analyzed", eitem)
+        self.assertEqual(eitem['author_type'], 'creator')
+
+        item = self.items[0]
+        eitem = enrich_backend.get_rich_item(item, author_type='assignee')
+        self.assertEqual(item['data']['id'], "10010")
+        self.assertEqual(eitem['id'], "fcf4a8418030d95844f0825fb5b1c3bdc0a1d942_issue_10010_user_assignee")
+        self.assertEqual(eitem['number_of_comments'], 0)
+        self.assertIn("main_description", eitem)
+        self.assertIn("main_description_analyzed", eitem)
+        self.assertEqual(eitem['author_type'], 'assignee')
+
+        item = self.items[0]
+        eitem = enrich_backend.get_rich_item(item, author_type='reporter')
+        self.assertEqual(item['data']['id'], "10010")
+        self.assertEqual(eitem['id'], "fcf4a8418030d95844f0825fb5b1c3bdc0a1d942_issue_10010_user_reporter")
+        self.assertEqual(eitem['number_of_comments'], 0)
+        self.assertIn("main_description", eitem)
+        self.assertIn("main_description_analyzed", eitem)
+        self.assertEqual(eitem['author_type'], 'reporter')
 
         item = self.items[1]
         eitem = enrich_backend.get_rich_item(item)
         self.assertEqual(item['data']['id'], "10010")
-        self.assertEqual(eitem['id'], "7bbd3aaee3adba6b1a1d293c78a385a874419b12_issue_10010")
+        self.assertEqual(eitem['id'], "7bbd3aaee3adba6b1a1d293c78a385a874419b12_issue_10010_user_creator")
         self.assertEqual(eitem['number_of_comments'], 0)
+        self.assertEqual(eitem['author_type'], 'creator')
 
         item = self.items[2]
         eitem = enrich_backend.get_rich_item(item)
         self.assertEqual(item['data']['id'], "10008")
-        self.assertEqual(eitem['id'], "d6b4168fd458f910fb9af1df0e9edcfaa188cc67_issue_10008")
+        self.assertEqual(eitem['id'], "d6b4168fd458f910fb9af1df0e9edcfaa188cc67_issue_10008_user_creator")
         self.assertEqual(eitem['number_of_comments'], 0)
+        self.assertEqual(eitem['author_type'], 'creator')
 
         item = self.items[3]
         eitem = enrich_backend.get_rich_item(item)
         self.assertEqual(item['data']['id'], "10017")
-        self.assertEqual(eitem['id'], "305dbd15b1f250cb6941d8b9270af3d3a4405084_issue_10017")
+        self.assertEqual(eitem['id'], "305dbd15b1f250cb6941d8b9270af3d3a4405084_issue_10017_user_creator")
         self.assertEqual(eitem['number_of_comments'], 0)
+        self.assertEqual(eitem['author_type'], 'creator')
 
         item = self.items[4]
         eitem = enrich_backend.get_rich_item(item)
         self.assertEqual(item['data']['id'], "10018")
-        self.assertEqual(eitem['id'], "929182e386ddb7d290c0dbd2eb34140993c8f567_issue_10018")
+        self.assertEqual(eitem['id'], "929182e386ddb7d290c0dbd2eb34140993c8f567_issue_10018_user_creator")
         self.assertEqual(eitem['number_of_comments'], 2)
+        self.assertEqual(eitem['author_type'], 'creator')
 
     def test_enrich_repo_labels(self):
         """Test whether the field REPO_LABELS is present in the enriched items"""
@@ -105,29 +128,45 @@ class TestJira(TestBaseBackend):
 
         result = self._test_raw_to_enrich(sortinghat=True)
         self.assertEqual(result['raw'], 5)
-        self.assertEqual(result['enrich'], 7)
+        self.assertEqual(result['enrich'], 17)
 
         enrich_backend = self.connectors[self.connector][2]()
         enrich_backend.sortinghat = True
 
         item = self.items[0]
         eitem = enrich_backend.get_rich_item(item)
-        self.assertEqual(eitem['assignee_name'], 'Peter Monks')
-        self.assertEqual(eitem['assignee_org_name'], 'Unknown')
-        self.assertEqual(eitem['assignee_user_name'], 'peter')
+        self.assertEqual(eitem['author_name'], 'Maurizio Pillitu')
+        self.assertEqual(eitem['author_org_name'], 'Unknown')
+        self.assertEqual(eitem['author_user_name'], 'maoo')
+        self.assertEqual(eitem['author_type'], 'creator')
+
+        item = self.items[0]
+        eitem = enrich_backend.get_rich_item(item, author_type='assignee')
+        self.assertEqual(eitem['author_name'], 'Peter Monks')
+        self.assertEqual(eitem['author_org_name'], 'Unknown')
+        self.assertEqual(eitem['author_user_name'], 'peter')
+        self.assertEqual(eitem['author_type'], 'assignee')
+
+        item = self.items[0]
+        eitem = enrich_backend.get_rich_item(item, author_type='reporter')
+        self.assertEqual(eitem['author_name'], 'Maurizio Pillitu')
+        self.assertEqual(eitem['author_org_name'], 'Unknown')
+        self.assertEqual(eitem['author_user_name'], 'maoo')
+        self.assertEqual(eitem['author_type'], 'reporter')
 
         item = self.items[1]
         eitem = enrich_backend.get_rich_item(item)
-        self.assertNotEqual(eitem['assignee_name'], 'Unknown')
-        self.assertEqual(eitem['assignee_org_name'], 'Unknown')
-        self.assertNotEqual(eitem['assignee_user_name'], 'Unknown')
+        self.assertNotEqual(eitem['author_name'], 'Unknown')
+        self.assertEqual(eitem['author_org_name'], 'Unknown')
+        self.assertNotEqual(eitem['author_user_name'], 'Unknown')
+        self.assertEqual(eitem['author_type'], 'creator')
 
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 
         result = self._test_raw_to_enrich(projects=True)
         self.assertEqual(result['raw'], 5)
-        self.assertEqual(result['enrich'], 7)
+        self.assertEqual(result['enrich'], 17)
 
     def test_refresh_identities(self):
         """Test refresh identities"""


### PR DESCRIPTION
For every issue, this code creates 3 enriched items which contain creator, assignee and reporter data. The enriched items have type issue and one of the following user_type: creator, assignee and reporter. This change eases the way of counting contributions of each user.

Tests have been added accordingly, schema has been updated.