### PR TITLE
[travis] No matching distribution found for pandas==0.24.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ elasticsearch==6.3.1
 elasticsearch-dsl==6.3.1
 requests==2.21.0
 urllib3==1.24.3
+pandas==0.24.2
 -e git+https://github.com/chaoss/grimoirelab-sortinghat/#egg=grimoirelab-sortinghat
 -e git+https://github.com/chaoss/grimoirelab-toolkit/#egg=grimoirelab-toolkit
 -e git+https://github.com/chaoss/grimoirelab-cereslib/#egg=grimoirelab-cereslib


### PR DESCRIPTION
This code updates the requirements.txt by forcing the installation of pandas==0.24.2