### PR TITLE
[meetup] Store `group_created` as date

### DIFF
--- a/grimoire_elk/enriched/meetup.py
+++ b/grimoire_elk/enriched/meetup.py
@@ -235,6 +235,9 @@ class MeetupEnrich(Enrich):
                 "lon": group['lon'],
             }
 
+            if eitem['group_created']:
+                eitem['group_created'] = unixtime_to_datetime(eitem['group_created'] / 1000).isoformat()
+
             eitem['group_topics'] = []
             eitem['group_topics_keys'] = []
             if 'topics' in group:

--- a/schema/meetup.csv
+++ b/schema/meetup.csv
@@ -9,7 +9,7 @@ comment,keyword,true
 description_analyzed,text,false
 event_url,keyword,true
 grimoire_creation_date,date,true
-group_created,long,true
+group_created,date,true
 group_geolocation,geo_point,true
 group_id,long,true
 group_join_mode,keyword,true

--- a/tests/test_meetup.py
+++ b/tests/test_meetup.py
@@ -62,6 +62,7 @@ class TestMeetup(TestBaseBackend):
         self.assertEqual(eitem['meetup_created'], '2016-03-22T16:36:44+00:00')
         self.assertEqual(eitem['meetup_time'], '2016-04-07T16:30:00+00:00')
         self.assertEqual(eitem['meetup_updated'], '2016-04-07T21:39:24+00:00')
+        self.assertEqual(eitem['group_created'], '2016-03-20T15:13:47+00:00')
 
     def test_enrich_repo_labels(self):
         """Test whether the field REPO_LABELS is present in the enriched items"""


### PR DESCRIPTION
This code stores the attribute `group_created` as date. Furthermore, corresponding tests and CSV have been updated accordingly.