### PR TITLE
[dependencies] Update pandas dependency to 0.22.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests==2.21.0
 urllib3==1.24.3
 PyMySQL>=0.7.0
 redis>=2.10.0, <=2.10.6
-pandas==0.18.1
+pandas==0.22.0
 -e git+https://github.com/chaoss/grimoirelab-sortinghat/#egg=grimoirelab-sortinghat
 -e git+https://github.com/chaoss/grimoirelab-toolkit/#egg=grimoirelab-toolkit
 -e git+https://github.com/chaoss/grimoirelab-cereslib/#egg=grimoirelab-cereslib

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(name="grimoire-elk",
           'urllib3==1.24.3',
           'PyMySQL>=0.7.0',
           'redis>=2.10.0, <=2.10.6',
-          'pandas==0.18.1'
+          'pandas==0.22.0'
       ],
       zip_safe=False
       )


### PR DESCRIPTION
This change is needed to align the dep version of pandas to the one used in SortingHat. It address https://github.com/chaoss/grimoirelab-sortinghat/issues/209