### PR TITLE
[enriched-mediawiki] Remove identity/project info in get_rich_item

### DIFF
--- a/grimoire_elk/enriched/mediawiki.py
+++ b/grimoire_elk/enriched/mediawiki.py
@@ -232,12 +232,6 @@ class MediaWikiEnrich(Enrich):
                 eitem["first_editor"] = page["revisions"][0].get('user', HIDDEN_EDITOR)
                 eitem["last_edited_date"] = page["revisions"][-1]["timestamp"]
 
-        if self.sortinghat:
-            eitem.update(self.get_item_sh(item))
-
-        if self.prjs_map:
-            eitem.update(self.get_item_project(eitem))
-
         self.add_repository_labels(eitem)
         self.add_metadata_filter_raw(eitem)
         return eitem


### PR DESCRIPTION
This code removes the calls to add indentity and project information from the method `get_rich_item`. This code has no effect since it was already added in `get_rich_item_reviews`.