### PR TITLE
[enriched-git] Remove credentials from Git URLs

### DIFF
--- a/grimoire_elk/enriched/git.py
+++ b/grimoire_elk/enriched/git.py
@@ -34,6 +34,7 @@ from grimoirelab_toolkit.datetime import (datetime_to_utc,
 from perceval.backends.core.git import GitCommand, GitRepository
 from .enrich import Enrich, metadata
 from .study_ceres_aoc import areas_of_code, ESPandasConnector
+from ..elastic import ElasticSearch as elastic
 from ..elastic_mapping import Mapping as BaseMapping
 from ..elastic_items import HEADER_JSON, MAX_BULK_UPDATE_SIZE
 
@@ -356,6 +357,10 @@ class GitEnrich(Enrich):
 
         # Other enrichment
         eitem["repo_name"] = item["origin"]
+
+        if eitem["repo_name"].startswith('http'):
+            eitem["repo_name"] = elastic.anonymize_url(eitem["repo_name"])
+
         # Number of files touched
         eitem["files"] = 0
         # Number of lines added and removed

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -70,6 +70,7 @@ class TestGit(TestBaseBackend):
         enrich_backend = self.connectors[self.connector][2]()
 
         item = self.items[0]
+        item['origin'] = 'https://admin:admin@gittest'
         eitem = enrich_backend.get_rich_item(item)
         self.assertEqual(eitem['committer_name'], '')
 


### PR DESCRIPTION
This code removes possible credentials declared on https URLs for Git repositories. This is the case of private repos on GitHub, which may be accessed by passing the username and token on the URL.

Tests have been provided accordingly.