### PR TITLE
[ELK] Remove reference to ocean-unique-id info

### DIFF
--- a/grimoire_elk/raw/askbot.py
+++ b/grimoire_elk/raw/askbot.py
@@ -67,7 +67,3 @@ class AskbotOcean(ElasticOcean):
     """Askbot Ocean feeder"""
 
     mapping = Mapping
-
-    def _fix_item(self, item):
-        # item["ocean-unique-id"] = str(item["data"]["id"])+"_"+item['origin']
-        item["ocean-unique-id"] = item["uuid"]

--- a/schema/askbot.csv
+++ b/schema/askbot.csv
@@ -25,7 +25,6 @@ metadata__gelk_backend_name,keyword
 metadata__gelk_version,keyword
 metadata__timestamp,date
 metadata__updated_on,date
-ocean-unique-id,keyword
 origin,keyword
 question_accepted_answer_id,long
 question_answer_count,long

--- a/schema/bugzilla.csv
+++ b/schema/bugzilla.csv
@@ -32,7 +32,6 @@ metadata__gelk_backend_name,keyword
 metadata__gelk_version,keyword
 metadata__timestamp,date
 metadata__updated_on,date
-ocean-unique-id,keyword
 op_sys,keyword
 origin,keyword
 platform,keyword

--- a/schema/confluence.csv
+++ b/schema/confluence.csv
@@ -30,7 +30,6 @@ metadata__gelk_backend_name,keyword
 metadata__gelk_version,keyword
 metadata__timestamp,date
 metadata__updated_on,date
-ocean-unique-id,keyword
 origin,keyword
 repository_labels,keyword
 status,keyword

--- a/schema/crates.csv
+++ b/schema/crates.csv
@@ -32,7 +32,6 @@ metadata__enriched_on,date,true
 metadata__gelk_backend_name,text,true
 metadata__gelk_version,text,true
 name,text,true
-ocean-unique-id,text,true
 origin,text,true
 owner_user_data_bot,boolean,true
 owner_user_data_domain,text,true

--- a/schema/discourse.csv
+++ b/schema/discourse.csv
@@ -24,7 +24,6 @@ metadata__gelk_backend_name,keyword
 metadata__gelk_version,keyword
 metadata__timestamp,date
 metadata__updated_on,date
-ocean-unique-id,keyword
 origin,keyword
 project_1,keyword
 project,keyword

--- a/schema/git.csv
+++ b/schema/git.csv
@@ -29,7 +29,6 @@ metadata__gelk_backend_name,keyword,true,"Name of the backend used to enrich inf
 metadata__gelk_version,keyword,true,"Version of the backend used to enrich information."
 metadata__timestamp,date,true,"Date when the item was stored in RAW index."
 metadata__updated_on,date,true,"Date when the item was updated in its original data source."
-ocean-unique-id,keyword,true,"Unique identifier for all of the datasets in the information lake."
 origin,keyword,true,"Original URL where the repository was retrieved from."
 project_1,keyword,true,"Project (if more than one level is allowed in project hierarchy)"
 project,keyword,true,"Project."

--- a/schema/github_issues.csv
+++ b/schema/github_issues.csv
@@ -33,7 +33,6 @@ metadata__gelk_backend_name,keyword,true,"Name of the backend used to enrich the
 metadata__gelk_version,keyword,true,"Version of the backend used to enrich the data."
 metadata__timestamp,date,true,"Date when the item was stored in ElasticSearch raw index."
 metadata__updated_on,date,true,"Date when the item was updated on its original data source."
-ocean-unique-id,keyword,true,"Unique ID for all the datasets contained in the information pool."
 origin,keyword,true,"The original URL from which the repository was retrieved from."
 project_1,keyword,true,"Used if more than one project levels are allowed in the project hierarchy."
 project,keyword,true,"Project name."

--- a/schema/irc.csv
+++ b/schema/irc.csv
@@ -22,7 +22,6 @@ nick_name,keyword
 nick_org_name,keyword
 nick_user_name,keyword
 nick_uuid,keyword
-ocean-unique-id,keyword
 origin,keyword
 repository_labels,keyword
 sent_date,date

--- a/schema/jira.csv
+++ b/schema/jira.csv
@@ -40,7 +40,6 @@ metadata__gelk_version,keyword
 metadata__timestamp,date
 metadata__updated_on,date
 number_of_comments,long
-ocean-unique-id,keyword
 origin,keyword
 priority,keyword
 progress_total,long

--- a/schema/kafka.csv
+++ b/schema/kafka.csv
@@ -43,7 +43,6 @@ metadata__gelk_backend_name,keyword
 metadata__gelk_version,keyword
 metadata__timestamp,date
 metadata__updated_on,date
-ocean-unique-id,keyword
 origin,keyword
 project_1,keyword
 project,keyword

--- a/schema/maniphest.csv
+++ b/schema/maniphest.csv
@@ -43,7 +43,6 @@ metadata__timestamp,date
 metadata__updated_on,date
 modification_date,date
 num_changes,long
-ocean-unique-id,keyword
 origin,keyword
 ownerData_bot,boolean
 ownerData_domain,keyword

--- a/schema/mbox.csv
+++ b/schema/mbox.csv
@@ -26,7 +26,6 @@ metadata__gelk_backend_name,keyword
 metadata__gelk_version,keyword
 metadata__timestamp,date
 metadata__updated_on,date
-ocean-unique-id,keyword
 origin,keyword
 project_1,keyword
 project,keyword

--- a/schema/mediawiki.csv
+++ b/schema/mediawiki.csv
@@ -10,7 +10,6 @@ iscreated,long
 isrevision,long
 metadata__timestamp,date
 metadata__updated_on,date
-ocean-unique-id,long
 origin,keyword
 page_last_edited_date,date
 page_metadata__timestamp,date

--- a/schema/meetup.csv
+++ b/schema/meetup.csv
@@ -51,7 +51,6 @@ metadata__timestamp,date,true
 metadata__updated_on,date,true
 num_comments,long,true
 num_rsvps,long,true
-ocean-unique-id,keyword,true
 origin,keyword,true
 repository_labels,keyword,true
 rsvps_guests,long,true

--- a/schema/redmine.csv
+++ b/schema/redmine.csv
@@ -25,7 +25,6 @@ is_redmine_job,long
 journals,long
 metadata__timestamp,date
 metadata__updated_on,date
-ocean-unique-id,keyword
 origin,keyword
 priority_id,long
 priority_name,keyword

--- a/schema/rss.csv
+++ b/schema/rss.csv
@@ -14,7 +14,6 @@ metadata__gelk_backend_name,keyword
 metadata__gelk_version,keyword
 metadata__timestamp,date
 metadata__updated_on,date
-ocean-unique-id,keyword
 origin,keyword
 publish_date,date
 published,keyword

--- a/schema/stackoverflow.csv
+++ b/schema/stackoverflow.csv
@@ -31,7 +31,6 @@ metadata__gelk_backend_name,keyword
 metadata__gelk_version,keyword
 metadata__timestamp,date
 metadata__updated_on,date
-ocean-unique-id,keyword
 origin,keyword
 owner_bot,boolean
 owner_id,keyword

--- a/tests/base.py
+++ b/tests/base.py
@@ -53,14 +53,6 @@ def load_mapping(enrich_index, csv_name):
 
 def data2es(items, ocean):
     def ocean_item(item):
-        # Hack until we decide the final id to use
-        if 'uuid' in item:
-            item['ocean-unique-id'] = item['uuid']
-        else:
-            # twitter comes from logstash and uses id
-            item['uuid'] = item['id']
-            item['ocean-unique-id'] = item['id']
-
         # Hack until we decide when to drop this field
         if 'updated_on' in item:
             updated = datetime.fromtimestamp(item['updated_on'])

--- a/tests/model.py
+++ b/tests/model.py
@@ -60,8 +60,6 @@ class Schema(object):
     __excluded_props += ['is_askbot_comment']
     # Cache from confluence could not include this field
     __excluded_props += ['is_attachment', 'is_comment', 'is_new_page']
-    # Old ocean unique identifier
-    __excluded_props += ['ocean-unique-id']
 
     def __init__(self, schema_name):
         self.schema_name = schema_name


### PR DESCRIPTION
This PR removes the reference to ocean-unique-id from ELK. This attribute was used before the introduction of the attribute `uuid` in Perceval items. Tests and the schemas below have been updated, furthermore the method `fix_item` from the raw connector of Askbot has been removed.

- askbot
- bugzilla
- confluence
- discourse
- git
- github_issues
- irc
- jira
- kafka
- maniphest
- mbox
- mediawiki
- meetup
- redmine
- rss
- stackoverflow