### PR TITLE
[enriched-aoc] Include origin in AOC items

### DIFF
--- a/grimoire_elk/enriched/study_ceres_aoc.py
+++ b/grimoire_elk/enriched/study_ceres_aoc.py
@@ -201,6 +201,8 @@ class AreasOfCode(CeresBase):
 
             logger.info(self.__log_prefix + " New Filepath events: " + str(len(events_df)))
 
+            events_df['origin'] = events_df['repository']
+
             # Deal with surrogates
             convert = ToUTF8(events_df)
             events_df = convert.enrich(["owner"])


### PR DESCRIPTION
This code includes the `origin` in the items generated by the AOC study. This change is needed to make the incrementality work in ceres, since it relies on this attribute (https://github.com/chaoss/grimoirelab-elk/blob/master/grimoire_elk/enriched/ceres_base.py#L261)