### PR TITLE
[enriched-gerrit] Handle missing user information

### DIFF
--- a/tests/data/gerrit.json
+++ b/tests/data/gerrit.json
@@ -1393,11 +1393,6 @@
                         "value": "-1"
                     }
                 ],
-                "author": {
-                    "email": "xianms_at_cn.ibm.com",
-                    "name": "MingShuang Xian",
-                    "username": "MingShuangXian"
-                },
                 "comments": [
                     {
                         "file": "/COMMIT_MSG",

--- a/tests/test_gerrit.py
+++ b/tests/test_gerrit.py
@@ -117,6 +117,16 @@ class TestGerrit(TestBaseBackend):
             self.assertIn('metadata__gelk_version', eapproval)
             self.assertIn(REPO_LABELS, eapproval)
 
+        item = self.items[1]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertIn('metadata__enriched_on', eitem)
+        self.assertIn('metadata__gelk_backend_name', eitem)
+        self.assertIn('metadata__gelk_version', eitem)
+        self.assertIn(REPO_LABELS, eitem)
+
+        self.assertEqual(eitem['time_to_first_review'], 1.1)
+        self.assertEqual(eitem['status_value'], '-1')
+
     def test_demography_study(self):
         """ Test that the demography study works correctly """
 

--- a/tests/test_gerrit.py
+++ b/tests/test_gerrit.py
@@ -145,9 +145,14 @@ class TestGerrit(TestBaseBackend):
                              % enrich_backend.elastic.anonymize_url(self.es_con))
 
         time.sleep(5)  # HACK: Wait until git enrich index has been written
-        for item in enrich_backend.fetch():
-            self.assertTrue('demography_min_date' in item.keys())
-            self.assertTrue('demography_max_date' in item.keys())
+        items = [i for i in enrich_backend.fetch()]
+        for item in items:
+            if item['type'] == 'patchset' and item['patchset_author_name'] is None:
+                self.assertFalse('demography_min_date' in item.keys())
+                self.assertFalse('demography_max_date' in item.keys())
+            else:
+                self.assertTrue('demography_min_date' in item.keys())
+                self.assertTrue('demography_max_date' in item.keys())
 
         r = enrich_backend.elastic.requests.get(enrich_backend.elastic.index_url + "/_alias",
                                                 headers=HEADER_JSON, verify=False)


### PR DESCRIPTION
This code handles missing user information (approvers, patchset and changeset authors) when calculating the time to first review for patchsets and changesets as well as the reviews' last status value.
In case the user information is missing, the aformentioned values are now calculated (before they were set to None).