### PR TITLE
[travis] Support tests for python 3.5 and 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 
 python:
   - "3.4"
+  - "3.5"
+  - "3.6"
 
 sudo: false
 


### PR DESCRIPTION
This code extends the tests executed on ELK to python 3.5 and 3.6.

Signed-off-by: Valerio Cosentino <valcos@bitergia.com>