### PR TITLE
[raw-jenkins] Handle multiple params on repo url

### DIFF
--- a/grimoire_elk/raw/jenkins.py
+++ b/grimoire_elk/raw/jenkins.py
@@ -133,11 +133,22 @@ class JenkinsOcean(ElasticOcean):
         # Jenkins could include in the URL a jenkins-rename-file T1746
         params = {}
 
-        tokens = url.split(' ', 1)  # Just split the URL not the filter
+        tokens = url.split(' ')  # Just split the URL not the filter
         params['url'] = tokens[0]
 
-        if len(tokens) > 1:
-            params['jenkins-rename-file'] = tokens[1].split(" ", 1)[1]
+        if len(tokens) == 0:
+            return params
+
+        for token in tokens[1:]:
+            token = token.strip('--')
+            assignment = token.split('=')
+            fltr_name = assignment[0].strip()
+            fltr_value = assignment[1].strip()
+
+            if token.startswith('jenkins'):
+                params['jenkins-rename-file'] = fltr_value
+            elif token.startswith('filter'):
+                params[fltr_name] = fltr_value
 
         return params
 

--- a/tests/test_jenkins.py
+++ b/tests/test_jenkins.py
@@ -19,7 +19,6 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
-import json
 import logging
 import unittest
 
@@ -114,10 +113,37 @@ class TestJenkins(TestBaseBackend):
     def test_arthur_params(self):
         """Test the extraction of arthur params from an URL"""
 
-        with open("data/projects-release.json") as projects_filename:
-            url = json.load(projects_filename)['grimoire']['jenkins'][0]
-            arthur_params = {'uri': 'https://build.opnfv.org/ci', 'url': 'https://build.opnfv.org/ci'}
-            self.assertDictEqual(arthur_params, JenkinsOcean.get_arthur_params_from_url(url))
+        url = 'https://build.opnfv.org/ci'
+        expected_params = {
+            'uri': 'https://build.opnfv.org/ci',
+            'url': 'https://build.opnfv.org/ci'
+        }
+        self.assertDictEqual(JenkinsOcean.get_arthur_params_from_url(url), expected_params)
+
+    def test_p2o_params(self):
+        """Test the extraction of p2o params from an URL"""
+
+        url = "http://jenkins.onap.info --filter-no-collection=true --jenkins-rename-file=/tmp/jenkins_nodes.csv"
+        expected_params = {
+            'url': 'http://jenkins.onap.info',
+            'filter-no-collection': 'true',
+            'jenkins-rename-file': '/tmp/jenkins_nodes.csv'
+        }
+        self.assertDictEqual(JenkinsOcean.get_p2o_params_from_url(url), expected_params)
+
+        url = "http://jenkins.onap.info --jenkins-rename-file=/tmp/jenkins_nodes.csv"
+        expected_params = {
+            'url': 'http://jenkins.onap.info',
+            'jenkins-rename-file': '/tmp/jenkins_nodes.csv'
+        }
+        self.assertDictEqual(JenkinsOcean.get_p2o_params_from_url(url), expected_params)
+
+        url = "http://jenkins.onap.info --filter-no-collection=true"
+        expected_params = {
+            'url': 'http://jenkins.onap.info',
+            'filter-no-collection': 'true'
+        }
+        self.assertDictEqual(JenkinsOcean.get_p2o_params_from_url(url), expected_params)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This code allows to handle multiple parameters passed via the repo url, defined within the projects.json. This change is needed since the jenkins raw connector is redefining the method `get_p2o_params_from_url`, which contains the logic to handle `--filter`-like parameters.

Tests have been added accordingly.