### PR TITLE
[enriched-utils] Change `min_enrich` value

### DIFF
--- a/grimoire_elk/enriched/utils.py
+++ b/grimoire_elk/enriched/utils.py
@@ -202,7 +202,7 @@ def get_last_enrich(backend_cmd, enrich_backend, filter_raw=None):
 
 def get_min_last_enrich(last_enrich, last_enrich_filtered):
     if last_enrich_filtered:
-        min_enrich = min(last_enrich, last_enrich_filtered.replace(second=0, microsecond=0, tzinfo=None))
+        min_enrich = min(last_enrich, last_enrich_filtered.replace(tzinfo=None))
     else:
         min_enrich = None
 


### PR DESCRIPTION
This code changes how the value of `min_enrich` is calculated. In particular, the minimum value is based by preventing to set to zero seconds and milliseconds. This change is needed to avoid enriching over and over the last Git items.