### PR TITLE
[discourse] Fix test and remove dead code

### DIFF
--- a/grimoire_elk/enriched/discourse.py
+++ b/grimoire_elk/enriched/discourse.py
@@ -178,13 +178,6 @@ class DiscourseEnrich(Enrich):
                 related.append(self.categories[cat])
         return related
 
-    def __show_categories_tree(self):
-        """ Show the category tree: list of categories and its subcategories """
-        for cat in self.categories_tree:
-            print("%s (%i)" % (self.categories[cat], cat))
-            for subcat in self.categories_tree[cat]:
-                print("-> %s (%i)" % (self.categories[subcat], subcat))
-
     @metadata
     def get_rich_item(self, item):
 

--- a/tests/data/discourse.json
+++ b/tests/data/discourse.json
@@ -689,7 +689,7 @@
         "visible": true,
         "word_count": 190
     },
-    "origin": "https://foro.mozilla-hispano.org/",
+    "origin": "https://forum.mautic.org/",
     "perceval_version": "0.2.0",
     "timestamp": 1469614665.547536,
     "updated_on": 1469009983.89,
@@ -1500,7 +1500,7 @@
         "visible": true,
         "word_count": 12025
     },
-    "origin": "https://foro.mozilla-hispano.org/",
+    "origin": "https://forum.mautic.org/",
     "perceval_version": "0.9.10",
     "tag": "http://example.com",
     "timestamp": 1518164982.60455,
@@ -3538,7 +3538,7 @@
         "visible": true,
         "word_count": 12025
     },
-    "origin": "https://foro.mozilla-hispano.org/",
+    "origin": "https://forum.mautic.org/",
     "perceval_version": "0.9.10",
     "tag": "http://example.com",
     "timestamp": 1518164982.617184,

--- a/tests/data/projects-release.json
+++ b/tests/data/projects-release.json
@@ -17,7 +17,7 @@
         ],
         "crates": [""],
         "discourse": [
-            "https://foro.mozilla-hispano.org/"
+            "https://forum.mautic.org/"
         ],
         "dockerhub": [
             "bitergia kibiter"

--- a/tests/test_discourse.py
+++ b/tests/test_discourse.py
@@ -103,7 +103,7 @@ class TestDiscourse(TestBaseBackend):
 
         with open("data/projects-release.json") as projects_filename:
             url = json.load(projects_filename)['grimoire']['discourse'][0]
-            arthur_params = {'uri': 'https://foro.mozilla-hispano.org/', 'url': 'https://foro.mozilla-hispano.org/'}
+            arthur_params = {'uri': 'https://forum.mautic.org/', 'url': 'https://forum.mautic.org/'}
             self.assertDictEqual(arthur_params, DiscourseOcean.get_arthur_params_from_url(url))
 
 


### PR DESCRIPTION
This PR fixes the tests concerning the enrichment phases for discourse items by replacing the current origin (which isn't accessible) with a new one. Furthermore, the method `__show_categories_tree` is removed since not reachable.