### PR TITLE
[enriched-enrich] Fix conversion projects.json to map

### DIFF
--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -205,7 +205,16 @@ class Enrich(ElasticItems):
         """
         ds_repo_to_prj = {}
 
-        for project in json:
+        # Sent the unknown project to the end of the list.
+        # This change is needed to avoid assigning repositories to
+        # the `Main` project when they exist in the `unknown`
+        # section and in other sections too.
+        project_names = list(json.keys())
+        if UNKNOWN_PROJECT in json:
+            project_names.remove(UNKNOWN_PROJECT)
+            project_names.append(UNKNOWN_PROJECT)
+
+        for project in project_names:
             for ds in json[project]:
                 if ds == "meta":
                     continue  # not a real data source

--- a/tests/data/projects-release.json
+++ b/tests/data/projects-release.json
@@ -56,12 +56,6 @@
         "jenkins": [
             "https://build.opnfv.org/ci"
         ],
-        "*jira": [
-            "https://tickets.puppetlabs.com"
-        ],
-        "*jira": [
-            "https://jira.iotivity.org/"
-        ],
         "jira": [
             "https://jira.opnfv.org --filter-raw=data.fields.project.key:PROJECT-KEY"
         ],
@@ -118,6 +112,11 @@
         ],
         "twitter": [
             ""
+        ]
+    },
+    "unknown": {
+        "jira": [
+            "https://jira.opnfv.org"
         ]
     }
 }


### PR DESCRIPTION
This code fixes the way the projects map is built by processing the repositories under the `unknown`
section at the very end. This change is needed to avoid assigning repositories to the generic
project `Main` when they are also declared in other projects.

This error appears with Python 3.5, but not with Python 3.6 and it is related to how the dictionary
keys are ordered.