### PR TITLE
[elastic_items] Remove white spaces from repo url with labels

### DIFF
--- a/grimoire_elk/elastic_items.py
+++ b/grimoire_elk/elastic_items.py
@@ -102,7 +102,7 @@ class ElasticItems:
             labels_info = matchObj.group(1)
             labels = matchObj.group(2)
             labels_lst = [l.strip() for l in labels.split(',')]
-            processed_repo = processed_repo.replace(labels_info, '')
+            processed_repo = processed_repo.replace(labels_info, '').strip()
 
         return processed_repo, labels_lst
 


### PR DESCRIPTION
This code strips out white spaces of repo urls having the param `--labels` enabled. This fix is needed to correctly match the url when enriching raw data.