### PR TITLE
[dependencies] Update redis to 3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ elasticsearch-dsl==6.3.1
 requests==2.21.0
 urllib3==1.24.3
 PyMySQL>=0.7.0
-redis>=2.10.0, <=2.10.6
+redis==3.0.0
 pandas==0.22.0
 -e git+https://github.com/chaoss/grimoirelab-sortinghat/#egg=grimoirelab-sortinghat
 -e git+https://github.com/chaoss/grimoirelab-toolkit/#egg=grimoirelab-toolkit

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(name="grimoire-elk",
           'requests==2.21.0',
           'urllib3==1.24.3',
           'PyMySQL>=0.7.0',
-          'redis>=2.10.0, <=2.10.6',
+          'redis==3.0.0',
           'pandas==0.22.0'
       ],
       zip_safe=False


### PR DESCRIPTION
This code updates the dependecy for redis package, which is now pinned to 3.0.0

Related to https://github.com/chaoss/grimoirelab-elk/issues/726