### PR TITLE
[enriched-bugzillarest] Handle missing user info

### DIFF
--- a/grimoire_elk/enriched/bugzillarest.py
+++ b/grimoire_elk/enriched/bugzillarest.py
@@ -87,9 +87,9 @@ class BugzillaRESTEnrich(Enrich):
         if 'data' in item and type(item) == dict:
             user = item['data'][identity_field]
 
-        identity['username'] = user['name'].split("@")[0]
-        identity['email'] = user['email']
-        identity['name'] = user['real_name']
+        identity['username'] = user['name'].split("@")[0] if user.get('name', None) else None
+        identity['email'] = user.get('email', None)
+        identity['name'] = user.get('real_name', None)
         return identity
 
     @metadata

--- a/tests/data/bugzillarest.json
+++ b/tests/data/bugzillarest.json
@@ -1536,7 +1536,6 @@
         "creation_time": "2016-04-27T07:36:19Z",
         "creator": "shuang",
         "creator_detail": {
-            "email": "shuang",
             "id": 458181,
             "name": "shuang",
             "real_name": "Shawn Huang [:shawnjohnjr]"
@@ -2504,7 +2503,7 @@
         "creation_time": "2016-07-27T09:23:40Z",
         "creator": "cam",
         "creator_detail": {
-            "email": "cam",
+            "email": "cam@example.org",
             "id": 54040,
             "name": "cam",
             "real_name": "Cameron McCormack (:heycam)"

--- a/tests/test_bugzillarest.py
+++ b/tests/test_bugzillarest.py
@@ -84,6 +84,17 @@ class TestBugzillaRest(TestBaseBackend):
         self.assertEqual(result['raw'], 7)
         self.assertEqual(result['enrich'], 7)
 
+        enrich_backend = self.connectors[self.connector][2]()
+        enrich_backend.sortinghat = True
+
+        item = self.items[0]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertIsNone(eitem['author_domain'])
+
+        item = self.items[1]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['author_domain'], 'example.org')
+
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 


### PR DESCRIPTION
This code handles missing user info such as email, name and username by replacing the latter with `None`.

Tests and the corresponding data have been added accordingly.

Fixes https://github.com/chaoss/grimoirelab-elk/issues/729