### PR TITLE
[enriched-meetup] Fix typo in group url name

### DIFF
--- a/grimoire_elk/enriched/meetup.py
+++ b/grimoire_elk/enriched/meetup.py
@@ -222,7 +222,7 @@ class MeetupEnrich(Enrich):
 
         if 'group' in event:
             group = event['group']
-            copy_fields = ["id", "created", "join_mode", "name", "url_name",
+            copy_fields = ["id", "created", "join_mode", "name", "urlname",
                            "who"]
             for f in copy_fields:
                 if f in group:

--- a/schema/meetup.csv
+++ b/schema/meetup.csv
@@ -17,6 +17,7 @@ group_members,long,true
 group_name,keyword,true
 group_topics_keys,keyword,true
 group_topics,keyword,true
+group_urlname,keyword,true
 group_who,keyword,true
 id,keyword,true
 is_meetup_comment,long,true

--- a/tests/test_meetup.py
+++ b/tests/test_meetup.py
@@ -62,6 +62,7 @@ class TestMeetup(TestBaseBackend):
         self.assertEqual(eitem['meetup_time'], '2016-04-07T16:30:00+00:00')
         self.assertEqual(eitem['meetup_updated'], '2016-04-07T21:39:24+00:00')
         self.assertEqual(eitem['group_created'], '2016-03-20T15:13:47+00:00')
+        self.assertEqual(eitem['group_urlname'], 'sqlpass-es')
 
     def test_enrich_repo_labels(self):
         """Test whether the field REPO_LABELS is present in the enriched items"""


### PR DESCRIPTION
This code fixes a typo in the attribute containing the url name of a meetup group. The correct attribute is `urlname`.

Tests data and the corresponding tests have been modified accordingly.

Fixes https://github.com/chaoss/grimoirelab-elk/issues/725