### PR TITLE
[enriched-enrich] Set empty item_sh when sortinghat is not set

### DIFF
--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -819,8 +819,10 @@ class Enrich(ElasticItems):
         If there are no roles, just add the author fields.
 
         """
-
         eitem_sh = {}  # Item enriched
+
+        if not self.sortinghat:
+            return eitem_sh
 
         author_field = self.get_field_author()
 

--- a/grimoire_elk/enriched/jira.py
+++ b/grimoire_elk/enriched/jira.py
@@ -113,6 +113,10 @@ class JiraEnrich(Enrich):
         """Add sorting hat enrichment fields"""
 
         eitem_sh = {}
+
+        if not self.sortinghat:
+            return eitem_sh
+
         created = str_to_datetime(date_field)
 
         for rol in roles:

--- a/grimoire_elk/enriched/meetup.py
+++ b/grimoire_elk/enriched/meetup.py
@@ -270,6 +270,9 @@ class MeetupEnrich(Enrich):
 
         sh_fields = {}
 
+        if not self.sortinghat:
+            return sh_fields
+
         # Not shared common get_item_sh because it is pretty specific
         if 'member' in item:
             # comment and rsvp


### PR DESCRIPTION
This code returns an empty item_sh when sortinghat isn't set.
This change is needed to allow ELK working without Sortinghat.