### PR TITLE
[elk] Replace ElasticConnect, ElasticWriter exceptions with ElasticError

### DIFF
--- a/grimoire_elk/errors.py
+++ b/grimoire_elk/errors.py
@@ -40,3 +40,9 @@ class ELKError(BaseError):
     """Generic error for elk error"""
 
     message = "%(cause)s"
+
+
+class ElasticError(BaseError):
+    """Generic error for elastic"""
+
+    message = "%(cause)s"

--- a/grimoire_elk/utils.py
+++ b/grimoire_elk/utils.py
@@ -26,7 +26,7 @@ import sys
 import requests
 from dateutil import parser
 
-from grimoire_elk.elastic import ElasticConnectException
+from grimoire_elk.errors import ElasticError
 from grimoire_elk.elastic import ElasticSearch
 # Connectors for Graal
 from graal.backends.core.cocom import CoCom, CoComCommand
@@ -261,8 +261,9 @@ def get_elastic(url, es_index, clean=None, backend=None, es_aliases=None, mappin
                                 clean=clean, insecure=insecure,
                                 analyzers=analyzers, aliases=es_aliases)
 
-    except ElasticConnectException:
-        logger.error("Can't connect to Elastic Search. Is it running?")
+    except ElasticError:
+        msg = "Can't connect to Elastic Search. Is it running?"
+        logger.error(msg)
         sys.exit(1)
 
     return elastic

--- a/tests/test_elk_elsticsearch.py
+++ b/tests/test_elk_elsticsearch.py
@@ -28,7 +28,8 @@ import httpretty
 if '..' not in sys.path:
     sys.path.insert(0, '..')
 
-from grimoire_elk.elastic import ElasticSearch, ElasticConnectException
+from grimoire_elk.elastic import ElasticSearch
+from grimoire_elk.errors import ElasticError
 
 
 class TestElasticSearch(unittest.TestCase):
@@ -93,7 +94,7 @@ class TestElasticSearch(unittest.TestCase):
         major = ElasticSearch._check_instance(self.url_es6, False)
         self.assertEqual(major, '6')
 
-        with self.assertRaises(ElasticConnectException):
+        with self.assertRaises(ElasticError):
             major = ElasticSearch._check_instance(self.url_es6_err, False)
 
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -71,5 +71,14 @@ class TestELKError(unittest.TestCase):
         self.assertEqual('key error on item', str(e))
 
 
+class TestElasticError(unittest.TestCase):
+
+    def test_message(self):
+        """Make sure that prints the correct error"""
+
+        e = errors.ElasticError(cause='ES not reachable')
+        self.assertEqual('ES not reachable', str(e))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/utils/gelk.py
+++ b/utils/gelk.py
@@ -29,7 +29,7 @@ from perceval.backends.bugzilla import Bugzilla
 from perceval.backends.gerrit import Gerrit
 from perceval.backends.github import GitHub
 
-from grimoire_elk.elastic import ElasticConnectException
+from grimoire_elk.errors import ElasticError
 from grimoire_elk.elastic import ElasticSearch
 from grimoire_elk.enriched.bugzilla import BugzillaEnrich
 from grimoire_elk.enriched.gerrit import GerritEnrich
@@ -115,7 +115,7 @@ if __name__ == '__main__':
                                 enrich_backend.get_elastic_mappings(),
                                 clean)
 
-    except ElasticConnectException:
+    except ElasticError:
         logging.error("Can't connect to Elastic Search. Is it running?")
         sys.exit(1)
 

--- a/utils/gh2arthur.py
+++ b/utils/gh2arthur.py
@@ -32,7 +32,8 @@ import MySQLdb
 import requests
 from dateutil import parser
 
-from grimoire_elk.elastic import ElasticSearch, ElasticConnectException
+from grimoire_elk.elastic import ElasticSearch
+from grimoire_elk.errors import ElasticError
 from grimoire_elk.utils import config_logging
 
 GITHUB_URL = "https://github.com/"
@@ -240,7 +241,7 @@ if __name__ == '__main__':
     es_enrich = None
     try:
         es_enrich = ElasticSearch(args.elastic_url, index_enrich)
-    except ElasticConnectException:
+    except ElasticError:
         logging.error("Can't connect to Elastic Search. Is it running?")
 
     # The owner could be an org or an user.


### PR DESCRIPTION
This code models the errors coming from the Elastic class by defining the exception `ElasticError`. This new error replaces the exceptions ElasticConnectException and ElasticWriteException.

Tests have been added accordingly.