### PR TITLE
[enrich-gitlab] Handle TypeError: 'NoneType' exception

### DIFF
--- a/grimoire_elk/enriched/gitlab.py
+++ b/grimoire_elk/enriched/gitlab.py
@@ -178,10 +178,9 @@ class GitLabEnrich(Enrich):
         else:
             rich_issue['time_open_days'] = rich_issue['time_to_close_days']
 
-        rich_issue['author_username'] = issue['author']['username']
-        author = issue['author']
-
+        author = issue.get('author', None)
         if author:
+            rich_issue['author_username'] = issue['author']['username']
             rich_issue['author_name'] = author['name']
             if 'email' in author and author['email']:
                 rich_issue["author_domain"] = self.get_email_domain(author['email'])
@@ -277,10 +276,9 @@ class GitLabEnrich(Enrich):
         else:
             rich_mr['time_open_days'] = rich_mr['time_to_close_days']
 
-        rich_mr['author_username'] = merge_request['author']['username']
-        author = merge_request['author']
-
+        author = merge_request.get('author', None)
         if author:
+            rich_mr['author_username'] = merge_request['author']['username']
             rich_mr['author_name'] = author['name']
             if 'email' in author and author['email']:
                 rich_mr["author_domain"] = self.get_email_domain(author['email'])

--- a/tests/data/gitlab.json
+++ b/tests/data/gitlab.json
@@ -1,4 +1,5 @@
-[{
+[
+    {
     "backend_name": "GitLab",
         "backend_version": "0.5.0",
         "category": "issue",
@@ -430,6 +431,75 @@
         "timestamp": 1536860519.489991,
         "updated_on": 1489879265.911,
         "uuid": "f165360164293e94ee2c27af82ffc0fa36a6f5fc"
+    },
+    {
+        "backend_name": "GitLab",
+        "backend_version": "0.11.1",
+        "category": "issue",
+        "data": {
+            "assignee": null,
+            "assignees": [],
+            "author": null,
+            "award_emoji_data": [],
+            "closed_at": null,
+            "confidential": false,
+            "created_at": "2019-12-16T03:46:58.457Z",
+            "description": "Involve benefit mind avoid send them herself. Republican peace bank herself key performance picture. Own it speak minute improve offer attorney.Career company year design student possible people. Other authority whom deal stay rule bag.\nMarket grow guy peace table high power. Girl manage star fast heart including they allow.",
+            "discussion_locked": null,
+            "downvotes": 0,
+            "due_date": null,
+            "id": 28731770,
+            "iid": 106422,
+            "labels": [],
+            "milestone": null,
+            "notes_data": [],
+            "project_id": 278964,
+            "state": "opened",
+            "time_stats": {
+                "human_time_estimate": null,
+                "total_time_spent": 0,
+                "human_total_time_spent": null,
+                "time_estimate": 0
+            },
+            "title": "It student kitchen finally although test.\nThan politics life quite part culture world. Risk right view.\nInvolve yes marriage all boy hundred by. Whatever later happen use social.",
+            "updated_at": "2019-12-16T03:46:58.457Z",
+            "upvotes": 0,
+            "user_notes_count": 0,
+            "web_url": "https://gitlab.com/gitlab-org/gitlab/issues/106422",
+            "weight": null,
+            "epic_iid": null,
+            "merge_requests_count": 0,
+            "moved_to_id": null,
+            "_links": {
+                "award_emoji": "https://gitlab.com/api/v4/projects/278964/issues/106422/award_emoji",
+                "self": "https://gitlab.com/api/v4/projects/278964/issues/106422",
+                "project": "https://gitlab.com/api/v4/projects/278964",
+                "notes": "https://gitlab.com/api/v4/projects/278964/issues/106422/notes"
+            },
+            "closed_by": null,
+            "task_completion_status": {
+                "completed_count": 0,
+                "count": 0
+            },
+            "epic": null,
+            "has_tasks": false
+        },
+        "search_fields": {
+            "owner": "gitlab-org",
+            "item_id": "28731770",
+            "iid": 106422,
+            "project": "gitlab",
+            "groups": null
+        },
+        "origin": "https://gitlab.com/gitlab-org/gitlab",
+        "perceval_version": "0.12.25",
+        "tag": "https://gitlab.com/gitlab-org/gitlab",
+        "timestamp": 1576470015.736746,
+        "updated_on": 1576468018.457,
+        "uuid": "f96a7f2ff3af3e6157b25ccbff231b53df6a3a4a",
+        "classified_fields_filtered": null,
+        "metadata__updated_on": "2019-12-16T03:46:58.457000+00:00",
+        "metadata__timestamp": "2019-12-16T04:20:15.736746+00:00"
     },
     {
         "backend_name": "GitLab",

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -69,6 +69,7 @@ class TestGitLab(TestBaseBackend):
         self.assertEqual(eitem['milestone_id'], 134231)
         self.assertEqual(eitem['milestone_iid'], 34)
         self.assertEqual(eitem['labels'], [])
+        self.assertEqual(eitem['author_username'], "redfish64")
 
         item = self.items[1]
         eitem = enrich_backend.get_rich_item(item)
@@ -79,6 +80,7 @@ class TestGitLab(TestBaseBackend):
         self.assertEqual(eitem['milestone_id'], None)
         self.assertEqual(eitem['milestone_iid'], None)
         self.assertEqual(eitem['labels'], [])
+        self.assertEqual(eitem['author_username'], "redfish64")
 
         item = self.items[2]
         eitem = enrich_backend.get_rich_item(item)
@@ -89,18 +91,9 @@ class TestGitLab(TestBaseBackend):
         self.assertEqual(eitem['milestone_id'], None)
         self.assertEqual(eitem['milestone_iid'], None)
         self.assertEqual(eitem['labels'], ['CI/CD', 'Deliverable'])
+        self.assertEqual(eitem['author_username'], "YoeriNijs")
 
         item = self.items[4]
-        eitem = enrich_backend.get_rich_item(item)
-        self.assertEqual(eitem['milestone'], "8.17")
-        self.assertEqual(eitem['milestone_start_date'], "2017-01-07T00:00:00")
-        self.assertEqual(eitem['milestone_due_date'], "2017-02-21T00:00:00")
-        self.assertEqual(eitem['milestone_url'], "https://gitlab.com/gitlab-org/gitlab-ce/milestones/34")
-        self.assertEqual(eitem['milestone_id'], 134231)
-        self.assertEqual(eitem['milestone_iid'], 34)
-        self.assertEqual(eitem['labels'], [])
-
-        item = self.items[5]
         eitem = enrich_backend.get_rich_item(item)
         self.assertEqual(eitem['milestone'], NO_MILESTONE_TAG)
         self.assertEqual(eitem['milestone_start_date'], None)
@@ -109,6 +102,18 @@ class TestGitLab(TestBaseBackend):
         self.assertEqual(eitem['milestone_id'], None)
         self.assertEqual(eitem['milestone_iid'], None)
         self.assertEqual(eitem['labels'], [])
+        self.assertEqual(eitem['author_username'], None)
+
+        item = self.items[5]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['milestone'], "8.17")
+        self.assertEqual(eitem['milestone_start_date'], "2017-01-07T00:00:00")
+        self.assertEqual(eitem['milestone_due_date'], "2017-02-21T00:00:00")
+        self.assertEqual(eitem['milestone_url'], "https://gitlab.com/gitlab-org/gitlab-ce/milestones/34")
+        self.assertEqual(eitem['milestone_id'], 134231)
+        self.assertEqual(eitem['milestone_iid'], 34)
+        self.assertEqual(eitem['labels'], [])
+        self.assertEqual(eitem['author_username'], "grote")
 
         item = self.items[6]
         eitem = enrich_backend.get_rich_item(item)
@@ -118,7 +123,19 @@ class TestGitLab(TestBaseBackend):
         self.assertEqual(eitem['milestone_url'], None)
         self.assertEqual(eitem['milestone_id'], None)
         self.assertEqual(eitem['milestone_iid'], None)
+        self.assertEqual(eitem['labels'], [])
+        self.assertEqual(eitem['author_username'], "Rudloff")
+
+        item = self.items[7]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['milestone'], NO_MILESTONE_TAG)
+        self.assertEqual(eitem['milestone_start_date'], None)
+        self.assertEqual(eitem['milestone_due_date'], None)
+        self.assertEqual(eitem['milestone_url'], None)
+        self.assertEqual(eitem['milestone_id'], None)
+        self.assertEqual(eitem['milestone_iid'], None)
         self.assertEqual(eitem['labels'], ['CI/CD', 'Deliverable'])
+        self.assertEqual(eitem['author_username'], "marc.nause")
 
     def test_enrich_repo_labels(self):
         """Test whether the field REPO_LABELS is present in the enriched items"""


### PR DESCRIPTION
This code allows to prevent TypeError: 'NoneType' exception
when the issue or merge has no author data.

Signed-off-by: Quan Zhou <zhquan7@gmail.com>