### PR TITLE
[sortinghat_gelk] Fix creation of dict in get_github_commit_username

### DIFF
--- a/grimoire_elk/enriched/sortinghat_gelk.py
+++ b/grimoire_elk/enriched/sortinghat_gelk.py
@@ -53,10 +53,11 @@ class SortingHat(object):
                 filter(Identity.name == identity['name'], Identity.email == identity['email'], Identity.source == source)
             identities = query.all()
             if identities:
-                user = {}
-                user['name'] = identities[0].name
-                user['email'] = identities[0].email
-                user['username'] = identities[0].username
+                user = {
+                    'name': identities[0].name,
+                    'email': identities[0].email,
+                    'username': identities[0].username
+                }
         return user
 
     @classmethod


### PR DESCRIPTION
This code changes the way the dict is created in the `get_github_commit_username`. Thus, the dict is directly initialized with the attributes `name`, `email` and `username`,
instead of creating an empty dict and filling it later on.