### PR TITLE
Add support for releasing scroll and waiting for available scroll, fixes #758

### DIFF
--- a/grimoire_elk/elastic_items.py
+++ b/grimoire_elk/elastic_items.py
@@ -182,7 +182,7 @@ class ElasticItems:
                 time.sleep(1)
                 sec -= 1
                 page = self.get_elastic_items(scroll_id, _filter=_filter, ignore_incremental=ignore_incremental)
-                if not 'too_many_scrolls' in page:
+                if 'too_many_scrolls' not in page:
                     logger.debug("Scroll acquired after {} seconds".format(self.scroll_wait - sec))
                     break
 
@@ -324,7 +324,7 @@ class ElasticItems:
         try:
             res = self.requests.post(url, data=query_data, headers=headers)
             if self.too_many_scrolls(res):
-                return { 'too_many_scrolls': True }
+                return {'too_many_scrolls': True}
             res.raise_for_status()
             rjson = res.json()
         except Exception:
@@ -345,4 +345,4 @@ class ElasticItems:
             and len(r['error']['root_cause']) > 0
             and 'reason' in r['error']['root_cause'][0]
             and 'Trying to create too many scroll contexts' in r['error']['root_cause'][0]['reason']
-            )
+        )

--- a/grimoire_elk/elastic_items.py
+++ b/grimoire_elk/elastic_items.py
@@ -182,6 +182,9 @@ class ElasticItems:
                 time.sleep(1)
                 sec -= 1
                 page = self.get_elastic_items(scroll_id, _filter=_filter, ignore_incremental=ignore_incremental)
+                if not page:
+                    logger.debug("Waiting for scroll terminated")
+                    break
                 if 'too_many_scrolls' not in page:
                     logger.debug("Scroll acquired after {} seconds".format(self.scroll_wait - sec))
                     break

--- a/grimoire_elk/elastic_items.py
+++ b/grimoire_elk/elastic_items.py
@@ -175,7 +175,7 @@ class ElasticItems:
 
         scroll_id = None
         page = self.get_elastic_items(scroll_id, _filter=_filter, ignore_incremental=ignore_incremental)
-        if 'too_many_scrolls' in page:
+        if page and 'too_many_scrolls' in page:
             sec = self.scroll_wait
             while sec > 0:
                 logger.debug("Too many scrolls open, waiting up to {} seconds".format(sec))

--- a/grimoire_elk/utils.py
+++ b/grimoire_elk/utils.py
@@ -364,6 +364,7 @@ def get_params_parser():
     parser.add_argument('--only-studies', action='store_true', help="Execute only studies.")
     parser.add_argument('--bulk-size', default=1000, type=int,
                         help="Number of items per bulk request to Elasticsearch.")
+    parser.add_argument('--scroll-wait', default=900, type=int, help="Wait for available scroll (default 900s)")
     parser.add_argument('--scroll-size', default=100, type=int,
                         help="Number of items to get from Elasticsearch when scrolling.")
     parser.add_argument('--arthur', action='store_true', help="Read items from arthur redis queue")

--- a/utils/p2o.py
+++ b/utils/p2o.py
@@ -52,6 +52,8 @@ if __name__ == '__main__':
                 ElasticSearch.max_items_bulk = args.bulk_size
             if args.scroll_size:
                 ElasticItems.scroll_size = args.scroll_size
+            if args.scroll_wait:
+                ElasticItems.scroll_wait = args.scroll_wait
             if not args.enrich_only:
                 feed_backend(url, clean, args.fetch_cache,
                              args.backend, args.backend_args,


### PR DESCRIPTION
Wait a configurable amount of time (in seconds) via `--scrol=wait`, for example `--scroll-wait 30` (default is 900)
Fixes #758 
Signed-off-by: Lukasz Gryglicki <lukaszgryglicki@o2.pl>