### PR TITLE
[enriched-enrich] Add geolocation study

### DIFF
--- a/grimoire_elk/enriched/github.py
+++ b/grimoire_elk/enriched/github.py
@@ -92,6 +92,7 @@ class GitHubEnrich(Enrich):
         self.studies = []
         self.studies.append(self.enrich_onion)
         self.studies.append(self.enrich_pull_requests)
+        self.studies.append(self.enrich_geolocation)
         self.studies.append(self.enrich_extra_data)
 
     def set_elastic(self, elastic):

--- a/grimoire_elk/enriched/github.py
+++ b/grimoire_elk/enriched/github.py
@@ -636,35 +636,3 @@ class GitHubEnrich(Enrich):
         rich_repo.update(self.get_grimoire_fields(item['metadata__updated_on'], "repository"))
 
         return rich_repo
-
-
-class GitHubUser(object):
-    """ Helper class to manage data from a Github user """
-
-    users = {}  # cache with users from github
-
-    def __init__(self, user):
-
-        self.login = user['login']
-        self.email = user['email']
-        if 'company' in user:
-            self.company = user['company']
-        self.orgs = user['orgs']
-        self.org = self._getOrg()
-        self.name = user['name']
-        self.location = user['location']
-
-    def _getOrg(self):
-        company = None
-
-        if self.company:
-            company = self.company
-
-        if company is None:
-            company = ''
-            # Return the list of orgs
-            for org in self.orgs:
-                company += org['login'] + ";;"
-            company = company[:-2]
-
-        return company

--- a/grimoire_elk/enriched/github2.py
+++ b/grimoire_elk/enriched/github2.py
@@ -19,7 +19,6 @@
 #   Valerio Cosentino <valcos@bitergia.com>
 #
 
-import json
 import logging
 import re
 
@@ -110,14 +109,8 @@ class GitHubEnrich2(Enrich):
         self.studies = []
         self.studies.append(self.enrich_extra_data)
 
-        self.users = {}  # cache users
-        self.location = {}  # cache users location
-        self.location_not_found = []  # location not found in map api
-
     def set_elastic(self, elastic):
         self.elastic = elastic
-        # Recover cache data from Elastic
-        self.geolocations = self.geo_locationsfrom__es()
 
     def get_field_author(self):
         return "user_data"
@@ -172,121 +165,6 @@ class GitHubEnrich2(Enrich):
         identity['email'] = user.get('email', None)
 
         return identity
-
-    def get_geo_point(self, location):
-        """Get geo point from location. This method is actually not used"""
-
-        geo_point = geo_code = None
-
-        if location is None:
-            return geo_point
-
-        if location in self.geolocations:
-            geo_location = self.geolocations[location]
-            geo_point = {
-                "lat": geo_location['lat'],
-                "lon": geo_location['lon']
-            }
-
-        elif location in self.location_not_found:
-            # Don't call the API.
-            pass
-
-        else:
-            url = 'https://maps.googleapis.com/maps/api/geocode/json'
-            params = {'sensor': 'false', 'address': location}
-            r = self.requests.get(url, params=params)
-
-            try:
-                logger.debug("[github] Using Maps API to find {}".format(
-                             location))
-                r_json = r.json()
-                geo_code = r_json['results'][0]['geometry']['location']
-            except Exception:
-                if location not in self.location_not_found:
-                    logger.debug("[github] Can't find geocode for ".format(
-                                 location))
-                    self.location_not_found.append(location)
-
-            if geo_code:
-                geo_point = {
-                    "lat": geo_code['lat'],
-                    "lon": geo_code['lng']
-                }
-                self.geolocations[location] = geo_point
-
-        return geo_point
-
-    def get_github_cache(self, kind, key_):
-        """ Get cache data for items of _type using key_ as the cache dict key """
-
-        cache = {}
-        res_size = 100  # best size?
-        from_ = 0
-
-        index_github = "github/" + kind
-
-        url = self.elastic.url + "/" + index_github
-        url += "/_search" + "?" + "size=%i" % res_size
-        r = self.requests.get(url)
-        type_items = r.json()
-
-        if 'hits' not in type_items:
-            logger.debug("[github] No github {} data in ES".format(
-                         kind))
-
-        else:
-            while len(type_items['hits']['hits']) > 0:
-                for hit in type_items['hits']['hits']:
-                    item = hit['_source']
-                    cache[item[key_]] = item
-                from_ += res_size
-                r = self.requests.get(url + "&from=%i" % from_)
-                type_items = r.json()
-                if 'hits' not in type_items:
-                    break
-
-        return cache
-
-    def geo_locationsfrom__es(self):
-        return self.get_github_cache("geolocations", "location")
-
-    def geo_locations_to_es(self):
-        max_items = self.elastic.max_items_bulk
-        current = 0
-        total = 0
-        bulk_json = ""
-
-        url = self.elastic.url + GEOLOCATION_INDEX + "geolocations/_bulk"
-
-        logger.debug("[github] Adding geoloc to {} (in {} packs)".format(
-                     self.elastic.anonymize_url(url), max_items))
-
-        for loc in self.geolocations:
-            if current >= max_items:
-                total += self.elastic.safe_put_bulk(url, bulk_json)
-                bulk_json = ""
-                current = 0
-
-            geopoint = self.geolocations[loc]
-            location = geopoint.copy()
-            location["location"] = loc
-            # First upload the raw issue data to ES
-            data_json = json.dumps(location)
-            # Don't include in URL non ascii codes
-            safe_loc = str(loc.encode('ascii', 'ignore'), 'ascii')
-            geo_id = str("%s-%s-%s" % (location["lat"], location["lon"],
-                                       safe_loc))
-            bulk_json += '{"index" : {"_id" : "%s" } }\n' % (geo_id)
-            bulk_json += data_json + "\n"  # Bulk document
-            current += 1
-
-        if current > 0:
-            total += self.elastic.safe_put_bulk(url, bulk_json)
-
-        logger.debug("[github] Adding geoloc to ES Done")
-
-        return total
 
     def get_project_repository(self, eitem):
         repo = eitem['origin']
@@ -529,9 +407,6 @@ class GitHubEnrich2(Enrich):
             logger.error("%s/%s missing items for GitHub", str(missing), str(num_items))
         else:
             logger.info("%s items inserted for GitHub", str(num_items))
-
-        logger.debug("[github] Updating GitHub users geolocations in Elastic")
-        self.geo_locations_to_es()  # Update geolocations in Elastic
 
         return num_items
 

--- a/grimoire_elk/enriched/github2.py
+++ b/grimoire_elk/enriched/github2.py
@@ -107,6 +107,7 @@ class GitHubEnrich2(Enrich):
                          db_user, db_password, db_host)
 
         self.studies = []
+        self.studies.append(self.enrich_geolocation)
         self.studies.append(self.enrich_extra_data)
 
     def set_elastic(self, elastic):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ requests==2.21.0
 urllib3==1.24.3
 PyMySQL>=0.7.0
 redis==3.0.0
+geopy>=1.20.0
 pandas==0.22.0
 -e git+https://github.com/chaoss/grimoirelab-sortinghat/#egg=grimoirelab-sortinghat
 -e git+https://github.com/chaoss/grimoirelab-toolkit/#egg=grimoirelab-toolkit

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,8 @@ setup(name="grimoire-elk",
           'urllib3==1.24.3',
           'PyMySQL>=0.7.0',
           'redis==3.0.0',
-          'pandas>=0.22.0,<=0.25.3'
+          'pandas>=0.22.0,<=0.25.3',
+          'geopy>=1.20.0'
       ],
       zip_safe=False
       )

--- a/tests/data/github.json
+++ b/tests/data/github.json
@@ -39,7 +39,7 @@
                 "hireable": null,
                 "html_url": "https://github.com/zhquan_example",
                 "id": 1,
-                "location": null,
+                "location": "Madrid, Spain",
                 "login": "zhquan_example",
                 "name": "zhquan_example",
                 "organizations": [
@@ -121,7 +121,7 @@
                     "hireable": null,
                     "html_url": "https://github.com/zhquan_example",
                     "id": 1,
-                    "location": null,
+                    "location": "Rome, Italy",
                     "login": "zhquan_example",
                     "name": "zhquan_example",
                     "organizations": [
@@ -227,7 +227,7 @@
                                 "hireable": null,
                                 "html_url": "https://github.com/zhquan_example",
                                 "id": 1,
-                                "location": null,
+                                "location": "Valencia, Spain",
                                 "login": "zhquan_example",
                                 "name": "zhquan_example",
                                 "organizations": [
@@ -311,7 +311,7 @@
                                 "hireable": null,
                                 "html_url": "https://github.com/zhquan_example",
                                 "id": 1,
-                                "location": null,
+                                "location": "Milan, Italy",
                                 "login": "zhquan_example",
                                 "name": "zhquan_example",
                                 "organizations": [
@@ -394,7 +394,7 @@
                         "hireable": null,
                         "html_url": "https://github.com/zhquan_example",
                         "id": 1,
-                        "location": null,
+                        "location": "Getafe, Spain",
                         "login": "zhquan_example",
                         "name": "zhquan_example",
                         "organizations": [
@@ -507,7 +507,7 @@
                 "hireable": null,
                 "html_url": "https://github.com/zhquan_example",
                 "id": 1,
-                "location": null,
+                "location": "Florence, Italy",
                 "login": "zhquan_example",
                 "name": "zhquan_example",
                 "organizations": [
@@ -916,7 +916,7 @@
                 "hireable": null,
                 "html_url": "https://github.com/zhquan_example",
                 "id": 1,
-                "location": null,
+                "location": "Madrid, Spain",
                 "login": "zhquan_example",
                 "name": "zhquan_example",
                 "organizations": [
@@ -1022,7 +1022,7 @@
                     "hireable": null,
                     "html_url": "https://github.com/zhquan_example",
                     "id": 1,
-                    "location": null,
+                    "location": "Madrid, Spain",
                     "login": "zhquan_example",
                     "name": "zhquan_example",
                     "organizations": [
@@ -1125,7 +1125,7 @@
                         "hireable": null,
                         "html_url": "https://github.com/zhquan_example",
                         "id": 1,
-                        "location": null,
+                        "location": "Rome, Italy",
                         "login": "zhquan_example",
                         "name": "zhquan_example",
                         "organizations": [
@@ -1245,7 +1245,7 @@
                                 "hireable": null,
                                 "html_url": "https://github.com/zhquan_example",
                                 "id": 1,
-                                "location": null,
+                                "location": "Madrid, Spain",
                                 "login": "zhquan_example",
                                 "name": "zhquan_example",
                                 "organizations": [
@@ -1329,7 +1329,7 @@
                                 "hireable": null,
                                 "html_url": "https://github.com/zhquan_example",
                                 "id": 1,
-                                "location": null,
+                                "location": "Madrid, Spain",
                                 "login": "zhquan_example",
                                 "name": "zhquan_example",
                                 "organizations": [
@@ -1413,7 +1413,7 @@
                                 "hireable": null,
                                 "html_url": "https://github.com/zhquan_example",
                                 "id": 1,
-                                "location": null,
+                                "location": "Madrid, Spain",
                                 "login": "zhquan_example",
                                 "name": "zhquan_example",
                                 "organizations": [
@@ -1497,7 +1497,7 @@
                                 "hireable": null,
                                 "html_url": "https://github.com/zhquan_example",
                                 "id": 1,
-                                "location": null,
+                                "location": "Madrid, Spain",
                                 "login": "zhquan_example",
                                 "name": "zhquan_example",
                                 "organizations": [
@@ -1581,7 +1581,7 @@
                                 "hireable": null,
                                 "html_url": "https://github.com/zhquan_example",
                                 "id": 1,
-                                "location": null,
+                                "location": "Madrid, Spain",
                                 "login": "zhquan_example",
                                 "name": "zhquan_example",
                                 "organizations": [
@@ -1664,7 +1664,7 @@
                         "hireable": null,
                         "html_url": "https://github.com/zhquan_example",
                         "id": 1,
-                        "location": null,
+                        "location": "Madrid, Spain",
                         "login": "zhquan_example",
                         "name": "zhquan_example",
                         "organizations": [
@@ -3072,7 +3072,7 @@
                 "hireable": null,
                 "html_url": "https://github.com/rikoe",
                 "id": 3295115,
-                "location": null,
+                "location": "Madrid, Spain",
                 "login": "rikoe",
                 "name": "Riko Eksteen",
                 "node_id": "MDQ6VXNlcjMyOTUxMTU=",
@@ -3157,7 +3157,7 @@
                         "hireable": null,
                         "html_url": "https://github.com/rikoe",
                         "id": 3295115,
-                        "location": null,
+                        "location": "Madrid, Spain",
                         "login": "rikoe",
                         "name": "Riko Eksteen",
                         "node_id": "MDQ6VXNlcjMyOTUxMTU=",
@@ -3218,7 +3218,7 @@
                 "hireable": null,
                 "html_url": "https://github.com/maoo",
                 "id": 327285,
-                "location": "Barcelona",
+                "location": "Barcelona, Spain",
                 "login": "maoo",
                 "name": "Maurizio Pillitu",
                 "node_id": "MDQ6VXNlcjMyNzI4NQ==",

--- a/tests/data/github2.json
+++ b/tests/data/github2.json
@@ -39,7 +39,7 @@
                 "hireable": null,
                 "html_url": "https://github.com/zhquan_example",
                 "id": 1,
-                "location": null,
+                "location": "Madrid, Spain",
                 "login": "zhquan_example",
                 "name": "zhquan_example",
                 "organizations": [
@@ -121,7 +121,7 @@
                     "hireable": null,
                     "html_url": "https://github.com/zhquan_example",
                     "id": 1,
-                    "location": null,
+                    "location": "Rome, Italy",
                     "login": "zhquan_example",
                     "name": "zhquan_example",
                     "organizations": [
@@ -227,7 +227,7 @@
                                 "hireable": null,
                                 "html_url": "https://github.com/zhquan_example",
                                 "id": 1,
-                                "location": null,
+                                "location": "Rome, Italy",
                                 "login": "zhquan_example",
                                 "name": "zhquan_example",
                                 "organizations": [
@@ -311,7 +311,7 @@
                                 "hireable": null,
                                 "html_url": "https://github.com/zhquan_example",
                                 "id": 1,
-                                "location": null,
+                                "location": "Rome, Italy",
                                 "login": "zhquan_example",
                                 "name": "zhquan_example",
                                 "organizations": [
@@ -394,7 +394,7 @@
                         "hireable": null,
                         "html_url": "https://github.com/zhquan_example",
                         "id": 1,
-                        "location": null,
+                        "location": "Rome, Italy",
                         "login": "zhquan_example",
                         "name": "zhquan_example",
                         "organizations": [
@@ -507,7 +507,7 @@
                 "hireable": null,
                 "html_url": "https://github.com/zhquan_example",
                 "id": 1,
-                "location": null,
+                "location": "Rome, Italy",
                 "login": "zhquan_example",
                 "name": "zhquan_example",
                 "organizations": [
@@ -916,7 +916,7 @@
                 "hireable": null,
                 "html_url": "https://github.com/zhquan_example",
                 "id": 1,
-                "location": null,
+                "location": "Rome, Italy",
                 "login": "zhquan_example",
                 "name": "zhquan_example",
                 "organizations": [
@@ -1022,7 +1022,7 @@
                     "hireable": null,
                     "html_url": "https://github.com/zhquan_example",
                     "id": 1,
-                    "location": null,
+                    "location": "Rome, Italy",
                     "login": "zhquan_example",
                     "name": "zhquan_example",
                     "organizations": [
@@ -1125,7 +1125,7 @@
                         "hireable": null,
                         "html_url": "https://github.com/zhquan_example",
                         "id": 1,
-                        "location": null,
+                        "location": "Rome, Italy",
                         "login": "zhquan_example",
                         "name": "zhquan_example",
                         "organizations": [
@@ -1245,7 +1245,7 @@
                                 "hireable": null,
                                 "html_url": "https://github.com/zhquan_example",
                                 "id": 1,
-                                "location": null,
+                                "location": "Rome, Italy",
                                 "login": "zhquan_example",
                                 "name": "zhquan_example",
                                 "organizations": [
@@ -1329,7 +1329,7 @@
                                 "hireable": null,
                                 "html_url": "https://github.com/zhquan_example",
                                 "id": 1,
-                                "location": null,
+                                "location": "Rome, Italy",
                                 "login": "zhquan_example",
                                 "name": "zhquan_example",
                                 "organizations": [
@@ -1413,7 +1413,7 @@
                                 "hireable": null,
                                 "html_url": "https://github.com/zhquan_example",
                                 "id": 1,
-                                "location": null,
+                                "location": "Rome, Italy",
                                 "login": "zhquan_example",
                                 "name": "zhquan_example",
                                 "organizations": [
@@ -1497,7 +1497,7 @@
                                 "hireable": null,
                                 "html_url": "https://github.com/zhquan_example",
                                 "id": 1,
-                                "location": null,
+                                "location": "Rome, Italy",
                                 "login": "zhquan_example",
                                 "name": "zhquan_example",
                                 "organizations": [
@@ -1581,7 +1581,7 @@
                                 "hireable": null,
                                 "html_url": "https://github.com/zhquan_example",
                                 "id": 1,
-                                "location": null,
+                                "location": "Rome, Italy",
                                 "login": "zhquan_example",
                                 "name": "zhquan_example",
                                 "organizations": [
@@ -1664,7 +1664,7 @@
                         "hireable": null,
                         "html_url": "https://github.com/zhquan_example",
                         "id": 1,
-                        "location": null,
+                        "location": "Rome, Italy",
                         "login": "zhquan_example",
                         "name": "zhquan_example",
                         "organizations": [
@@ -1751,7 +1751,7 @@
                 "hireable": null,
                 "html_url": "https://github.com/zhquan_example",
                 "id": 1,
-                "location": null,
+                "location": "Madrid, Spain",
                 "login": "zhquan_example",
                 "name": "zhquan_example",
                 "organizations": [

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -20,9 +20,11 @@
 #     Valerio Cosentino <valcos@bitergia.com>
 #
 import logging
+import time
 import unittest
 
 from base import TestBaseBackend
+from grimoire_elk.enriched.enrich import logger
 from grimoire_elk.enriched.utils import REPO_LABELS
 from grimoire_elk.raw.github import GitHubOcean
 
@@ -169,6 +171,35 @@ class TestGit(TestBaseBackend):
             'repository': 'grimoirelab-perceval'
         }
         self.assertDictEqual(GitHubOcean.get_arthur_params_from_url(url), expected_params)
+
+    def test_geolocation_study(self):
+        """ Test that the geolocation study works correctly """
+
+        study, ocean_backend, enrich_backend = self._test_study('enrich_geolocation')
+
+        with self.assertLogs(logger, level='INFO') as cm:
+
+            if study.__name__ == "enrich_geolocation":
+                study(ocean_backend, enrich_backend,
+                      location_field="user_location", geolocation_field="user_geolocation")
+
+            self.assertEqual(cm.output[0], 'INFO:grimoire_elk.enriched.enrich:[github] Geolocation '
+                                           'starting study %s/test_github_enrich'
+                             % enrich_backend.elastic.anonymize_url(self.es_con))
+            self.assertEqual(cm.output[-1], 'INFO:grimoire_elk.enriched.enrich:[github] Geolocation '
+                                            'end %s/test_github_enrich'
+                             % enrich_backend.elastic.anonymize_url(self.es_con))
+
+        time.sleep(5)  # HACK: Wait until github enrich index has been written
+        items = [item for item in enrich_backend.fetch() if 'user_location' in item]
+        self.assertEqual(len(items), 4)
+        for item in items:
+            if item['user_location']:
+                geolocation = item['user_geolocation']
+                self.assertIn('lon', geolocation)
+                self.assertIn('lat', geolocation)
+            else:
+                self.assertIsNone(item['user_geolocation'])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This study includes geo points information (latitude and longitude) based on the value of the `location_field`. The coordinates are retrieved using Nominatim through the geopy package (which required to update the setup.py and requirements.txt), and saved in the `geolocation_field`.

All locations included in the `location_field` are retrieved from
the enriched index. For each location, the geo points are retrieved and saved
to the `geolocation_field`. In case the geo points are not retrieved,
the location is ignored.

The example below shows how to activate the study by modifying
the setup.cfg. The study `enrich_geolocation:user` retrieves location data
from `user_location` and stores the geo points to `user_geolocation`. In a
similar manner, `enrich_geolocation:assignee` takes the data from
`assignee_location` and stores the geo points to `assignee_geolocation`.

```
[github]
raw_index = github_issues_chaoss
enriched_index = github_issues_chaoss_enriched
api-token = ...
sleep-for-rate = true
...
studies = [enrich_geolocation:user, enrich_geolocation:assignee]

[enrich_geolocation:user]
location_field = user_location
geolocation_field = user_geolocation

[enrich_geolocation:assignee]
location_field = assignee_location
geolocation_field = assignee_geolocation
```

The study is enabled for github and github2 enrichers. Tests have been added accordingly.

This PR removes also some dead code found in the github enricher (https://github.com/chaoss/grimoirelab-elk/commit/e810af9b6a5f56465a78916226f0ee2c4956c335)

Related to https://github.com/chaoss/grimoirelab-sirmordred/pull/386