### PR TITLE
Let pandas be >= 0.22.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(name="grimoire-elk",
           'urllib3==1.24.3',
           'PyMySQL>=0.7.0',
           'redis==3.0.0',
-          'pandas==0.22.0'
+          'pandas>=0.22.0,<=0.25.3'
       ],
       zip_safe=False
       )


### PR DESCRIPTION
If we pin pandas at 0.22.0, it doesn't build
with Python 3.7.x, apparently because of problems
when building numpy for pandas.

Letting pandas be greater or equal than 0.22.0
doesn't seem to break anything, since platforms
having only 0.22.0, as Travis had in July'19,
would still fulfill the dependency.

Signed-off-by: Jesus M. Gonzalez-Barahona <jgb@gsyc.es>