### PR TITLE
[git-enriched] Remove github commit support

### DIFF
--- a/grimoire_elk/elk.py
+++ b/grimoire_elk/elk.py
@@ -529,8 +529,6 @@ def enrich_backend(url, clean, backend_name, backend_params, cfg_section_name,
         else:
             elastic_enrich = get_elastic(url, enrich_index, clean, enrich_backend, es_enrich_aliases)
         enrich_backend.set_elastic(elastic_enrich)
-        if github_token and backend_name == "git":
-            enrich_backend.set_github_token(github_token)
         if jenkins_rename_file and backend_name == "jenkins":
             enrich_backend.set_jenkins_rename_file(jenkins_rename_file)
         if unaffiliated_group:

--- a/grimoire_elk/enriched/sortinghat_gelk.py
+++ b/grimoire_elk/enriched/sortinghat_gelk.py
@@ -45,21 +45,6 @@ class SortingHat(object):
         return uuid
 
     @classmethod
-    def get_github_commit_username(cls, db, identity, source):
-        user = None
-
-        with db.connect() as session:
-            query = session.query(Identity).\
-                filter(Identity.name == identity['name'], Identity.email == identity['email'], Identity.source == source)
-            identities = query.all()
-            if identities:
-                user = {}
-                user['name'] = identities[0].name
-                user['email'] = identities[0].email
-                user['username'] = identities[0].username
-        return user
-
-    @classmethod
     def add_identity(cls, db, identity, backend):
         """ Load and identity list from backend in Sorting Hat """
         uuid = None


### PR DESCRIPTION
This code removes the support to include author and committer information extracted from github commits, when enriching git data. This feature isn't used, in its current state it won't work for github enterprise instances and it may slow down the enrichment of git data.

Related code present in elk.py and sortinghat_gelk.py has been removed accordingly.

Review together with: https://github.com/chaoss/grimoirelab-sirmordred/pull/390
Deprecates https://github.com/chaoss/grimoirelab-elk/pull/753