### PR TITLE
[enriched-dockerhub] Handle never updated images

### DIFF
--- a/grimoire_elk/enriched/dockerhub.py
+++ b/grimoire_elk/enriched/dockerhub.py
@@ -163,7 +163,7 @@ class DockerHubEnrich(Enrich):
                 images_items[rich_item['id']] = rich_item
             else:
                 image_date = images_items[rich_item['id']]['last_updated']
-                if image_date <= rich_item['last_updated']:
+                if image_date and image_date <= rich_item['last_updated']:
                     # This event is newer for the image
                     rich_item['is_docker_image'] = 1
                     rich_item['is_event'] = 0


### PR DESCRIPTION
This PR addresses https://github.com/chaoss/grimoirelab-elk/issues/767, thus it allows to ignore dockerhub images, which don't have a last updated value. This is the case of https://hub.docker.com/r/hyperledger/sawtooth-next-directory, that doesn't have any activity.
