### PR TITLE
Support python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,32 @@ jobs:
         - coveralls
 
     - python:
+        - "3.7"
+
+      name: "Python 3.7 for ES 6.1.0"
+
+      before_install:
+        - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.1.0.deb && sudo dpkg -i --force-confnew elasticsearch-6.1.0.deb && sudo service elasticsearch restart
+        - pip install flake8
+        - pip install coveralls
+        - pip install httpretty==0.8.6
+        - pip install -r "requirements.txt"
+
+      before_script:
+        - sleep 20
+
+      script:
+        - flake8 .
+        - mysqladmin -u root create test_sh
+        - mysqladmin -u root create test_projects
+        - mysql -u root test_projects < tests/test_projects.sql
+        - cd tests
+        - coverage run --source=grimoire_elk run_tests.py
+
+      after_success:
+        - coveralls
+
+    - python:
         - "3.5"
 
       name: "Python 3.5 for ES 7.2.0"
@@ -95,6 +121,38 @@ jobs:
         - "3.6"
 
       name: "Python 3.6 for ES 7.2.0"
+
+      before_install:
+        - curl -s -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.2.0-amd64.deb
+        - sudo dpkg -i --force-confnew elasticsearch-7.2.0-amd64.deb
+        - sudo sed -i.old 's/-Xms1g/-Xms128m/' /etc/elasticsearch/jvm.options
+        - sudo sed -i.old 's/-Xmx1g/-Xmx128m/' /etc/elasticsearch/jvm.options
+        - echo -e '-XX:+DisableExplicitGC\n-Djdk.io.permissionsUseCanonicalPath=true\n-Dlog4j.skipJansi=true\n-server\n' | sudo tee -a /etc/elasticsearch/jvm.options
+        - sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
+        - sudo systemctl start elasticsearch
+        - pip install flake8
+        - pip install coveralls
+        - pip install httpretty==0.8.6
+        - pip install -r "requirements.txt"
+
+      before_script:
+        - sleep 20
+
+      script:
+        - flake8 .
+        - mysqladmin -u root create test_sh
+        - mysqladmin -u root create test_projects
+        - mysql -u root test_projects < tests/test_projects.sql
+        - cd tests
+        - coverage run --source=grimoire_elk run_tests.py
+
+      after_success:
+        - coveralls
+
+    - python:
+        - "3.7"
+
+      name: "Python 3.7 for ES 7.2.0"
 
       before_install:
         - curl -s -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.2.0-amd64.deb

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ urllib3==1.24.3
 PyMySQL>=0.7.0
 redis==3.0.0
 geopy>=1.20.0
-pandas==0.22.0
+pandas>=0.22.0,<=0.25.3
 -e git+https://github.com/chaoss/grimoirelab-sortinghat/#egg=grimoirelab-sortinghat
 -e git+https://github.com/chaoss/grimoirelab-toolkit/#egg=grimoirelab-toolkit
 -e git+https://github.com/chaoss/grimoirelab-cereslib/#egg=grimoirelab-cereslib


### PR DESCRIPTION
This code extends the CI tests to python 3.7. Furthermore, the pandas dependency in the requirements.txt is relaxed and aligned with the corresponding one in the setup.py.