### PR TITLE
[enriched-gitlab] Fix repository value in merge

### DIFF
--- a/grimoire_elk/enriched/gitlab.py
+++ b/grimoire_elk/enriched/gitlab.py
@@ -311,7 +311,7 @@ class GitLabEnrich(Enrich):
 
         rich_mr['id'] = merge_request['id']
         rich_mr['id_in_repo'] = merge_request['iid']
-        rich_mr['repository'] = merge_request['web_url'].rsplit("/", 2)[0]
+        rich_mr['repository'] = merge_request['web_url'].rsplit("/", 2)[0].split("/-")[0]
         rich_mr['title'] = merge_request['title']
         rich_mr['title_analyzed'] = merge_request['title']
         rich_mr['state'] = merge_request['state']

--- a/tests/data/gitlab.json
+++ b/tests/data/gitlab.json
@@ -779,7 +779,7 @@
                     "state": "without_files"
                 }
             ],
-            "web_url": "https://gitlab.com/fdroid/fdroiddata/merge_requests/3148",
+            "web_url": "https://gitlab.com/fdroid/fdroiddata/-/merge_requests/3148",
             "work_in_progress": false
         },
         "origin": "https://gitlab.com/fdroid/fdroiddata",

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -70,6 +70,7 @@ class TestGitLab(TestBaseBackend):
         self.assertEqual(eitem['milestone_iid'], 34)
         self.assertEqual(eitem['labels'], [])
         self.assertEqual(eitem['author_username'], "redfish64")
+        self.assertEqual(eitem['repository'], "https://gitlab.com/fdroid/fdroiddata")
 
         item = self.items[1]
         eitem = enrich_backend.get_rich_item(item)
@@ -81,6 +82,7 @@ class TestGitLab(TestBaseBackend):
         self.assertEqual(eitem['milestone_iid'], None)
         self.assertEqual(eitem['labels'], [])
         self.assertEqual(eitem['author_username'], "redfish64")
+        self.assertEqual(eitem['repository'], "https://gitlab.com/fdroid/fdroiddata")
 
         item = self.items[2]
         eitem = enrich_backend.get_rich_item(item)
@@ -92,6 +94,7 @@ class TestGitLab(TestBaseBackend):
         self.assertEqual(eitem['milestone_iid'], None)
         self.assertEqual(eitem['labels'], ['CI/CD', 'Deliverable'])
         self.assertEqual(eitem['author_username'], "YoeriNijs")
+        self.assertEqual(eitem['repository'], "https://gitlab.com/fdroid/fdroiddata")
 
         item = self.items[4]
         eitem = enrich_backend.get_rich_item(item)
@@ -103,6 +106,7 @@ class TestGitLab(TestBaseBackend):
         self.assertEqual(eitem['milestone_iid'], None)
         self.assertEqual(eitem['labels'], [])
         self.assertEqual(eitem['author_username'], None)
+        self.assertEqual(eitem['repository'], "https://gitlab.com/gitlab-org/gitlab")
 
         item = self.items[5]
         eitem = enrich_backend.get_rich_item(item)
@@ -114,6 +118,7 @@ class TestGitLab(TestBaseBackend):
         self.assertEqual(eitem['milestone_iid'], 34)
         self.assertEqual(eitem['labels'], [])
         self.assertEqual(eitem['author_username'], "grote")
+        self.assertEqual(eitem['repository'], "https://gitlab.com/fdroid/fdroiddata")
 
         item = self.items[6]
         eitem = enrich_backend.get_rich_item(item)
@@ -125,6 +130,7 @@ class TestGitLab(TestBaseBackend):
         self.assertEqual(eitem['milestone_iid'], None)
         self.assertEqual(eitem['labels'], [])
         self.assertEqual(eitem['author_username'], "Rudloff")
+        self.assertEqual(eitem['repository'], "https://gitlab.com/fdroid/fdroiddata")
 
         item = self.items[7]
         eitem = enrich_backend.get_rich_item(item)
@@ -136,6 +142,7 @@ class TestGitLab(TestBaseBackend):
         self.assertEqual(eitem['milestone_iid'], None)
         self.assertEqual(eitem['labels'], ['CI/CD', 'Deliverable'])
         self.assertEqual(eitem['author_username'], "marc.nause")
+        self.assertEqual(eitem['repository'], "https://gitlab.com/fdroid/fdroiddata")
 
     def test_enrich_repo_labels(self):
         """Test whether the field REPO_LABELS is present in the enriched items"""


### PR DESCRIPTION
This code fixes the 'repository' value of the merge requests URL.
The api add the character '-' before '/merge_requests/'.

Tests data and the corresponding tests have been modified
accordingly.

Signed-off-by: Quan Zhou <zhquan7@gmail.com>