### PR TITLE
Kiwix GitHub evolution backlog+commit tags

### DIFF
--- a/grimoire_elk/_version.py
+++ b/grimoire_elk/_version.py
@@ -1,2 +1,2 @@
 # Versions compliant with PEP 440 https://www.python.org/dev/peps/pep-0440
-__version__ = "0.68.0"
+__version__ = "0.69.0"

--- a/grimoire_elk/_version.py
+++ b/grimoire_elk/_version.py
@@ -1,2 +1,2 @@
 # Versions compliant with PEP 440 https://www.python.org/dev/peps/pep-0440
-__version__ = "0.69.0"
+__version__ = "0.68.0"

--- a/grimoire_elk/enriched/git.py
+++ b/grimoire_elk/enriched/git.py
@@ -223,7 +223,7 @@ class GitEnrich(Enrich):
             eitem['message'] = commit['message'][:self.KEYWORD_MAX_LENGTH]
 
         if 'refs' in commit:
-            eitem["commit_tags"] = list(filter(lambda r: "tag: " in r,commit['refs']))
+            eitem["commit_tags"] = list(filter(lambda r: "tag: " in r, commit['refs']))
 
         eitem['hash_short'] = eitem['hash'][0:6]
         # Enrich dates

--- a/grimoire_elk/enriched/git.py
+++ b/grimoire_elk/enriched/git.py
@@ -222,6 +222,9 @@ class GitEnrich(Enrich):
         if 'message' in commit:
             eitem['message'] = commit['message'][:self.KEYWORD_MAX_LENGTH]
 
+        if 'refs' in commit:
+            eitem["commit_tags"] = list(filter(lambda r: "tag: " in r,commit['refs']))
+
         eitem['hash_short'] = eitem['hash'][0:6]
         # Enrich dates
         author_date = str_to_datetime(commit["AuthorDate"])

--- a/grimoire_elk/enriched/github.py
+++ b/grimoire_elk/enriched/github.py
@@ -40,14 +40,12 @@ from .utils import get_time_diff_days
 from .enrich import Enrich, metadata
 from ..elastic_mapping import Mapping as BaseMapping
 
-from .github_study_evolution import (
-                                    get_unique_repository_with_project_name,
-                                    get_issues_dates,
-                                    get_issues_not_closed_by_label,
-                                    get_issues_open_at_by_label,
-                                    get_issues_not_closed_other_label,
-                                    get_issues_open_at_other_label
-                                    )
+from .github_study_evolution import (get_unique_repository_with_project_name,
+                                     get_issues_dates,
+                                     get_issues_not_closed_by_label,
+                                     get_issues_open_at_by_label,
+                                     get_issues_not_closed_other_label,
+                                     get_issues_open_at_other_label)
 
 
 GITHUB = 'https://github.com/'
@@ -680,13 +678,13 @@ class GitHubEnrich(Enrich):
             average_opened_time = sum(issues) / len(issues)
 
         evolution_item = {
-          "uuid": "{}_{}_{}".format(date, repository_name, label),
-          "opened": len(issues),
-          "average_opened_time": average_opened_time,
-          "origin": repository_url,
-          "labels": label,
-          "project": project,
-          "study_creation_date": date
+            "uuid": "{}_{}_{}".format(date, repository_name, label),
+            "opened": len(issues),
+            "average_opened_time": average_opened_time,
+            "origin": repository_url,
+            "labels": label,
+            "project": project,
+            "study_creation_date": date
         }
 
         evolution_item.update(self.get_grimoire_fields(date, "stats"))
@@ -699,30 +697,29 @@ class GitHubEnrich(Enrich):
                      ).strftime('%Y-%m-%dT%H:%M:%S.000Z')
         if(other):
             issues = es_in.search(
-              index=in_index,
-              body=get_issues_not_closed_other_label(repository_url, next_date, REDUCED_LABELS)
+                index=in_index,
+                body=get_issues_not_closed_other_label(repository_url, next_date, REDUCED_LABELS)
             )['hits']['hits']
 
             issues = issues + es_in.search(
-              index=in_index,
-              body=get_issues_open_at_other_label(repository_url, next_date, REDUCED_LABELS)
+                index=in_index,
+                body=get_issues_open_at_other_label(repository_url, next_date, REDUCED_LABELS)
             )['hits']['hits']
         else:
             issues = es_in.search(
-              index=in_index,
-              body=get_issues_not_closed_by_label(repository_url, next_date, label)
+                index=in_index,
+                body=get_issues_not_closed_by_label(repository_url, next_date, label)
             )['hits']['hits']
 
             issues = issues + es_in.search(
-              index=in_index,
-              body=get_issues_open_at_by_label(repository_url, next_date, label)
+                index=in_index,
+                body=get_issues_open_at_by_label(repository_url, next_date, label)
             )['hits']['hits']
 
         return list(map(lambda i: get_time_diff_days(
-                            str_to_datetime(i['_source']['created_at']),
-                            str_to_datetime(next_date)
-                            ),
-                        issues)
+                        str_to_datetime(i['_source']['created_at']),
+                        str_to_datetime(next_date)
+                        ), issues)
                     )
 
     def enrich_backlog_analysis(self, ocean_backend, enrich_backend, no_incremental=False,

--- a/grimoire_elk/enriched/github.py
+++ b/grimoire_elk/enriched/github.py
@@ -655,7 +655,7 @@ class GitHubEnrich(Enrich):
 
         return rich_repo
 
-    def __create_backlog_item(self, repository_url, repository_name, project, date, interval, label, map_label, issues):
+    def __create_backlog_item(self, repository_url, repository_name, project, date, org_name, interval, label, map_label, issues):
 
         average_opened_time = 0
         if (len(issues) > 0):
@@ -670,7 +670,8 @@ class GitHubEnrich(Enrich):
             "project": project,
             "interval_days": interval,
             "study_creation_date": date,
-            "metadata__enriched_on": date
+            "metadata__enriched_on": date,
+            "author_org_name": org_name
         }
 
         evolution_item.update(self.get_grimoire_fields(date, "stats"))
@@ -767,6 +768,7 @@ class GitHubEnrich(Enrich):
         for repository in repositories:
             repository_url = repository["origin"]
             project = repository["project"]
+            org_name = repository["author_org_name"]
             repository_name = repository_url.split("/")[-1]
 
             logger.info("[enrich-backlog-analysis] Start analysis for {}".format(repository_url))
@@ -783,7 +785,7 @@ class GitHubEnrich(Enrich):
                 evolution_items = []
                 for date in map(lambda i: i['key_as_string'], dates):
                     evolution_item = self.__create_backlog_item(
-                        repository_url, repository_name, project, date, interval_days, label, map_label,
+                        repository_url, repository_name, project, date, org_name, interval_days, label, map_label,
                         self.__get_opened_issues(es_in, in_index, repository_url, date, interval_days,
                                                  other, label, reduced_labels)
                     )

--- a/grimoire_elk/enriched/github.py
+++ b/grimoire_elk/enriched/github.py
@@ -671,7 +671,7 @@ class GitHubEnrich(Enrich):
             "interval_days": interval,
             "study_creation_date": date,
             "metadata__enriched_on": date,
-            "author_org_name": org_name
+            "organization": org_name
         }
 
         evolution_item.update(self.get_grimoire_fields(date, "stats"))
@@ -768,7 +768,7 @@ class GitHubEnrich(Enrich):
         for repository in repositories:
             repository_url = repository["origin"]
             project = repository["project"]
-            org_name = repository["author_org_name"]
+            org_name = repository["organization"]
             repository_name = repository_url.split("/")[-1]
 
             logger.info("[enrich-backlog-analysis] Start analysis for {}".format(repository_url))

--- a/grimoire_elk/enriched/github.py
+++ b/grimoire_elk/enriched/github.py
@@ -722,8 +722,24 @@ class GitHubEnrich(Enrich):
      def enrich_backlog_analysis(self, ocean_backend, enrich_backend, no_incremental=False,
                               out_index="github_enrich_backlog",
                               date_field="grimoire_creation_date"):
+        """
+        The purpose of this study is to add additional index to compute the
+        chronological evolution of opened issues and average opened time issues.
 
-         logger.info("[enrich-backlog-analysis] Start enrich_backlog_analysis study")
+        For each repository and label, we start the study on repository
+        creation date until today with a day interval (default). For each date
+        we retrieve the number of open issue at this date by difference between
+        number of opened issues and number of closed issues. In addition, we
+        compute the average opened time for all issues open at this date.
+
+        To differenciate by label, we compute evolution for bugs and all others
+        labels (like "enhancement","good first issue" ... ), we call this
+        "reduced labels". We need to use theses reduced labels because the
+        complixity to compute evolution for each combinaison of labels would be
+        too big. In addition, we rename "bug" label to "bugs" in reduced labels.
+        """
+
+        logger.info("[enrich-backlog-analysis] Start enrich_backlog_analysis study")
 
          # connect to ES
         es_in = ES([enrich_backend.elastic_url], retry_on_timeout=True, timeout=100,

--- a/grimoire_elk/enriched/github.py
+++ b/grimoire_elk/enriched/github.py
@@ -672,25 +672,25 @@ class GitHubEnrich(Enrich):
 
     def __create_backlog_item(self, repository_url, repository_name, project, date, label, issues):
 
-         average_opened_time = 0
+        average_opened_time = 0
         if (len(issues) > 0):
-            average_opened_time = sum(issues) / len(issues)
+          average_opened_time = sum(issues) / len(issues)
 
-         evolution_item = {
-            "uuid": "{}_{}_{}".format(date, repository_name, label),
-            "opened": len(issues),
-            "average_opened_time" : average_opened_time,
-            "origin": repository_url,
-            "labels" : label,
-            "project" : project,
-            "study_creation_date":date
+        evolution_item = {
+          "uuid": "{}_{}_{}".format(date, repository_name, label),
+          "opened": len(issues),
+          "average_opened_time" : average_opened_time,
+          "origin": repository_url,
+          "labels" : label,
+          "project" : project,
+          "study_creation_date":date
         }
 
-         evolution_item.update(self.get_grimoire_fields(date, "stats"))
+        evolution_item.update(self.get_grimoire_fields(date, "stats"))
 
-         return evolution_item
+        return evolution_item
 
-     def __get_opened_issues(self, es_in, in_index, repository_url, date, other,label):
+    def __get_opened_issues(self, es_in, in_index, repository_url, date, other,label):
         next_date = (str_to_datetime(date).replace(tzinfo=None) + relativedelta(days=int(BACKLOG_INTERVAL_STUDY))).strftime('%Y-%m-%dT%H:%M:%S.000Z')
         if(other):
             issues = es_in.search(
@@ -698,7 +698,7 @@ class GitHubEnrich(Enrich):
               body=get_issues_not_closed_other_label(repository_url,next_date,REDUCED_LABELS)
             )['hits']['hits']
 
-             issues = issues + es_in.search(
+            issues = issues + es_in.search(
               index=in_index,
               body=get_issues_open_at_other_label(repository_url,next_date,REDUCED_LABELS)
             )['hits']['hits']
@@ -708,18 +708,18 @@ class GitHubEnrich(Enrich):
               body=get_issues_not_closed_by_label(repository_url,next_date,label)
             )['hits']['hits']
 
-             issues = issues + es_in.search(
+            issues = issues + es_in.search(
               index=in_index,
               body=get_issues_open_at_by_label(repository_url,next_date,label)
             )['hits']['hits']
 
-         return list(map(
+        return list(map(
                 lambda i : get_time_diff_days(
                             str_to_datetime(i['_source']['created_at']),
                                             str_to_datetime(next_date)),
                             issues))
 
-     def enrich_backlog_analysis(self, ocean_backend, enrich_backend, no_incremental=False,
+    def enrich_backlog_analysis(self, ocean_backend, enrich_backend, no_incremental=False,
                               out_index="github_enrich_backlog",
                               date_field="grimoire_creation_date"):
         """
@@ -752,7 +752,7 @@ class GitHubEnrich(Enrich):
             body=get_unique_repository_with_project_name())
         repositories = [repo['key'] for repo in unique_repos['aggregations']['unique_repos'].get('buckets', [])]
 
-         logger.info("[enrich-backlog-analysis] {} repositories to process".format(len(repositories)))
+        logger.info("[enrich-backlog-analysis] {} repositories to process".format(len(repositories)))
 
          # create the index
         es_out = ElasticSearch(enrich_backend.elastic.url, out_index, mappings=Mapping)
@@ -766,7 +766,7 @@ class GitHubEnrich(Enrich):
             project = repository["project"]
             repository_name = repository_url.split("/")[-1]
 
-             logger.info("[enrich-backlog-analysis] Start analysis for {}".format(repository_url))
+            logger.info("[enrich-backlog-analysis] Start analysis for {}".format(repository_url))
 
              # get each day since repository creation
             dates = es_in.search(
@@ -810,7 +810,7 @@ class GitHubEnrich(Enrich):
                     num_items += len(evolution_items)
                     ins_items += es_out.bulk_upload(evolution_items, self.get_field_unique_id())
 
-                 if num_items != ins_items:
+                if num_items != ins_items:
                     missing = num_items - ins_items
                     logger.error(
                         "[enrich-backlog-analysis] %s/%s missing items for Graal Backlog Analysis Study", str(missing), str(num_items)
@@ -819,4 +819,4 @@ class GitHubEnrich(Enrich):
                     logger.info("[enrich-backlog-analysis] %s items inserted for Graal Backlog Analysis Study", str(num_items))
 
 
-         logger.info("[enrich-backlog-analysis] End enrich_backlog_analysis study")
+        logger.info("[enrich-backlog-analysis] End enrich_backlog_analysis study")

--- a/grimoire_elk/enriched/github_study_evolution.py
+++ b/grimoire_elk/enriched/github_study_evolution.py
@@ -64,7 +64,7 @@ def get_issues_not_closed_by_label(repository_url, to_date, label):
                       "origin": "%s"
                   }},{
                   "term": {
-                      "reduced_labels": "%s"
+                      "labels": "%s"
                   }},{
                   "range" : {
                      "created_at": {"lt" : "%s"}
@@ -90,7 +90,7 @@ def get_issues_open_at_by_label(repository_url, to_date, label):
                       "origin": "%s"
                   }},{
                   "term": {
-                      "reduced_labels": "%s"
+                      "labels": "%s"
                   }},{
                   "range" : {
                      "closed_at": {"gt" : "%s"}
@@ -116,7 +116,7 @@ def get_issues_not_closed_other_label(repository_url, to_date, exclude_labels):
           "bool": {
               "must_not":[{
                 "terms": {
-                  "reduced_labels": %s
+                  "labels": %s
                 }
               },{
                   "exists": {
@@ -148,7 +148,7 @@ def get_issues_open_at_other_label(repository_url, to_date, exclude_labels):
           "bool": {
               "must_not":{
                 "terms": {
-                  "reduced_labels": %s
+                  "labels": %s
                 }
               },
               "filter": [{

--- a/grimoire_elk/enriched/github_study_evolution.py
+++ b/grimoire_elk/enriched/github_study_evolution.py
@@ -20,7 +20,6 @@
 # In this file, we have the ES requests used by backlog evolution github study
 #
 
-from grimoirelab_toolkit.datetime import str_to_datetime
 
 def get_unique_repository_with_project_name():
     """ Retrieve all the repository names from the index. """
@@ -48,9 +47,10 @@ def get_unique_repository_with_project_name():
 
     return query_unique_repository
 
+
 def get_issues_not_closed_by_label(repository_url, to_date, label):
-  issues_not_closed = """
-  {
+    issues_not_closed = """
+    {
       "size": 10000,
       "query": {
           "bool": {
@@ -73,14 +73,15 @@ def get_issues_not_closed_by_label(repository_url, to_date, label):
               ]
           }
       }
-  }
-  """ % (repository_url, label, to_date)
+    }
+    """ % (repository_url, label, to_date)
 
-  return issues_not_closed
+    return issues_not_closed
+
 
 def get_issues_open_at_by_label(repository_url, to_date, label):
-  issues_open_at = """
-  {
+    issues_open_at = """
+    {
       "size": 10000,
       "query": {
           "bool": {
@@ -101,15 +102,15 @@ def get_issues_open_at_by_label(repository_url, to_date, label):
               ]
           }
       }
-  }
-  """ % (repository_url, label, to_date, to_date)
-  
-  return issues_open_at
-  
-  
+    }
+    """ % (repository_url, label, to_date, to_date)
+
+    return issues_open_at
+
+
 def get_issues_not_closed_other_label(repository_url, to_date, exclude_labels):
-  issues_not_closed = """
-  {
+    issues_not_closed = """
+    {
       "size": 10000,
       "query": {
           "bool": {
@@ -133,14 +134,15 @@ def get_issues_not_closed_other_label(repository_url, to_date, exclude_labels):
               ]
           }
       }
-  }
-  """ % (str(exclude_labels).replace("'","\""),repository_url, to_date)
+    }
+    """ % (str(exclude_labels).replace("'", "\""), repository_url, to_date)
 
-  return issues_not_closed
+    return issues_not_closed
+
 
 def get_issues_open_at_other_label(repository_url, to_date, exclude_labels):
-  issues_open_at = """
-  {
+    issues_open_at = """
+    {
       "size": 10000,
       "query": {
           "bool": {
@@ -163,15 +165,14 @@ def get_issues_open_at_other_label(repository_url, to_date, exclude_labels):
               ]
           }
       }
-  }
-  """ % (str(exclude_labels).replace("'","\""),repository_url, to_date, to_date)
-  
-  return issues_open_at
-  
-  
+    }
+    """ % (str(exclude_labels).replace("'", "\""),
+           repository_url, to_date, to_date)
+
+    return issues_open_at
 
 
-def get_issues_dates(interval,repository_url):
+def get_issues_dates(interval, repository_url):
 
     query_issues_dates = """
 {
@@ -206,6 +207,6 @@ def get_issues_dates(interval,repository_url):
             }
         }
     }
-    """ % (interval,repository_url)
-    
+    """ % (interval, repository_url)
+
     return query_issues_dates

--- a/grimoire_elk/enriched/github_study_evolution.py
+++ b/grimoire_elk/enriched/github_study_evolution.py
@@ -17,6 +17,8 @@
 # Authors:
 #   Florent Kaisser <florent.pro@kaisser.name>
 #
+# In this file, we have the ES requests used by backlog evolution github study
+#
 
 from grimoirelab_toolkit.datetime import str_to_datetime
 

--- a/grimoire_elk/enriched/github_study_evolution.py
+++ b/grimoire_elk/enriched/github_study_evolution.py
@@ -37,6 +37,9 @@ def get_unique_repository_with_project_name():
                   }}},
                   {"project" : {"terms": {
                       "field": "project"
+                  }}},
+                  {"author_org_name" : {"terms": {
+                      "field": "author_org_name"
                   }}}
               ]
             }

--- a/grimoire_elk/enriched/github_study_evolution.py
+++ b/grimoire_elk/enriched/github_study_evolution.py
@@ -1,0 +1,209 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2000 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+#
+# Authors:
+#   Florent Kaisser <florent.pro@kaisser.name>
+#
+
+from grimoirelab_toolkit.datetime import str_to_datetime
+
+def get_unique_repository_with_project_name():
+    """ Retrieve all the repository names from the index. """
+
+    query_unique_repository = """
+    {
+        "size": 0,
+        "aggs": {
+            "unique_repos": {
+              "composite" : {
+                "size": 5000,
+                "sources" : [
+                  {"origin" : {"terms": {
+                      "field": "origin"
+                  }}},
+                  {"project" : {"terms": {
+                      "field": "project"
+                  }}}
+              ]
+            }
+          }
+        }
+    }
+    """
+
+    return query_unique_repository
+
+def get_issues_not_closed_by_label(repository_url, to_date, label):
+  issues_not_closed = """
+  {
+      "size": 10000,
+      "query": {
+          "bool": {
+              "must_not": {
+                  "exists": {
+                      "field": "closed_at"
+                  }
+              },
+      "filter": [{
+                  "term": {
+                      "origin": "%s"
+                  }},{
+                  "term": {
+                      "reduced_labels": "%s"
+                  }},{
+                  "range" : {
+                     "created_at": {"lt" : "%s"}
+                  }
+              }
+              ]
+          }
+      }
+  }
+  """ % (repository_url, label, to_date)
+
+  return issues_not_closed
+
+def get_issues_open_at_by_label(repository_url, to_date, label):
+  issues_open_at = """
+  {
+      "size": 10000,
+      "query": {
+          "bool": {
+              "filter": [{
+                  "term": {
+                      "origin": "%s"
+                  }},{
+                  "term": {
+                      "reduced_labels": "%s"
+                  }},{
+                  "range" : {
+                     "closed_at": {"gt" : "%s"}
+                  }},{
+                  "range" : {
+                     "created_at": {"lt" : "%s"}
+                  }
+              }
+              ]
+          }
+      }
+  }
+  """ % (repository_url, label, to_date, to_date)
+  
+  return issues_open_at
+  
+  
+def get_issues_not_closed_other_label(repository_url, to_date, exclude_labels):
+  issues_not_closed = """
+  {
+      "size": 10000,
+      "query": {
+          "bool": {
+              "must_not":[{
+                "terms": {
+                  "reduced_labels": %s
+                }
+              },{
+                  "exists": {
+                      "field": "closed_at"
+                  }
+              }],
+              "filter": [{
+                  "term": {
+                      "origin":"%s"
+                  }},{
+                  "range" : {
+                     "created_at": {"lt" : "%s"}
+                  }
+              }
+              ]
+          }
+      }
+  }
+  """ % (str(exclude_labels).replace("'","\""),repository_url, to_date)
+
+  return issues_not_closed
+
+def get_issues_open_at_other_label(repository_url, to_date, exclude_labels):
+  issues_open_at = """
+  {
+      "size": 10000,
+      "query": {
+          "bool": {
+              "must_not":{
+                "terms": {
+                  "reduced_labels": %s
+                }
+              },
+              "filter": [{
+                  "term": {
+                      "origin": "%s"
+                  }},{
+                  "range" : {
+                     "closed_at": {"gt" : "%s"}
+                  }},{
+                  "range" : {
+                     "created_at": {"lt" : "%s"}
+                  }
+              }
+              ]
+          }
+      }
+  }
+  """ % (str(exclude_labels).replace("'","\""),repository_url, to_date, to_date)
+  
+  return issues_open_at
+  
+  
+
+
+def get_issues_dates(interval,repository_url):
+
+    query_issues_dates = """
+{
+    "size": 0,
+    "aggs" : {
+        "created_per_interval" : {
+            "date_histogram" : {
+                "field" : "metadata__updated_on",
+                "interval" : "%dd"
+            },
+            "aggs": {
+                "created": {
+                  "value_count": {
+                        "field": "created_at"
+                    }
+                },
+                "closed": {
+                  "value_count": {
+                        "field": "closed_at"
+                    }
+                }
+            }
+        }
+    },
+        "query": {
+            "bool": {
+                "filter": [{
+                    "term": {
+                        "origin": "%s"
+                    }
+                }]
+            }
+        }
+    }
+    """ % (interval,repository_url)
+    
+    return query_issues_dates

--- a/grimoire_elk/enriched/github_study_evolution.py
+++ b/grimoire_elk/enriched/github_study_evolution.py
@@ -38,7 +38,7 @@ def get_unique_repository_with_project_name():
                   {"project" : {"terms": {
                       "field": "project"
                   }}},
-                  {"author_org_name" : {"terms": {
+                  {"organization" : {"terms": {
                       "field": "author_org_name"
                   }}}
               ]

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -235,6 +235,7 @@ class TestGit(TestBaseBackend):
             self.assertIn('is_github_stats', source)
             self.assertIn('organization', source)
 
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')
     logging.getLogger("urllib3").setLevel(logging.WARNING)

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -25,6 +25,7 @@ import unittest
 
 from base import TestBaseBackend
 from grimoire_elk.enriched.enrich import logger
+from grimoire_elk.enriched.github import logger as logger_github
 from grimoire_elk.enriched.utils import REPO_LABELS
 from grimoire_elk.raw.github import GitHubOcean
 
@@ -201,6 +202,38 @@ class TestGit(TestBaseBackend):
             else:
                 self.assertIsNone(item['user_geolocation'])
 
+    def test_enrich_backlog_analysis(self):
+        """ Test that the backlog analysis works correctly """
+
+        study, ocean_backend, enrich_backend = self._test_study('enrich_backlog_analysis')
+
+        with self.assertLogs(logger_github, level='INFO') as cm:
+
+            if study.__name__ == "enrich_backlog_analysis":
+                study(ocean_backend, enrich_backend)
+
+            self.assertEqual(cm.output[0], 'INFO:grimoire_elk.enriched.github:[github] '
+                                           'Start enrich_backlog_analysis study')
+            self.assertEqual(cm.output[-1], 'INFO:grimoire_elk.enriched.github:[github] '
+                                            'End enrich_backlog_analysis study')
+
+        time.sleep(5)  # HACK: Wait until github enrich index has been written
+        url = self.es_con + "/github_enrich_backlog/_search"
+        response = enrich_backend.requests.get(url, verify=False).json()
+        for hit in response['hits']['hits']:
+            source = hit['_source']
+            self.assertIn('uuid', source)
+            self.assertIn('opened', source)
+            self.assertIn('average_opened_time', source)
+            self.assertIn('origin', source)
+            self.assertIn('labels', source)
+            self.assertIn('project', source)
+            self.assertIn('interval_days', source)
+            self.assertIn('study_creation_date', source)
+            self.assertIn('metadata__enriched_on', source)
+            self.assertIn('grimoire_creation_date', source)
+            self.assertIn('is_github_stats', source)
+            self.assertIn('organization', source)
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')


### PR DESCRIPTION
This PR fix the issue https://github.com/chaoss/grimoirelab-elk/issues/761 ,to add additional index to compute the chronological evolution of opened issues and average opened time issues.

For each repository and label, we start the study on repository
creation date until today with a day interval (default). For each date
we retrieve the number of open issue at this date by difference between
number of opened issues and number of closed issues. In addition, we
compute the average opened time for all issues open at this date.

To differenciate by label, we compute evolution for bugs and all others
labels (like "enhancement","good first issue" ... ), we call this
"reduced labels". We need to use theses reduced labels because the
complixity to compute evolution for each combinaison of labels would be
too big. In addition, we rename "bug" label to "bugs" in reduced labels.

In addition of this new study, we have also add "tags" field in git enriched
index to get the number of releases.