### PR TITLE
[enriched-jira] Handle missing creator/ assignee displayName and name

### DIFF
--- a/grimoire_elk/enriched/jira.py
+++ b/grimoire_elk/enriched/jira.py
@@ -243,19 +243,19 @@ class JiraEnrich(Enrich):
         eitem['changes'] = issue['changelog']['total']
 
         if "creator" in issue["fields"] and issue["fields"]["creator"]:
-            eitem['creator_name'] = issue["fields"]["creator"]["displayName"]
-            eitem['creator_login'] = issue["fields"]["creator"]["name"]
+            eitem['creator_name'] = issue["fields"]["creator"].get("displayName", None)
+            eitem['creator_login'] = issue["fields"]["creator"].get("name", None)
             if "timeZone" in issue["fields"]["creator"]:
                 eitem['creator_tz'] = issue["fields"]["creator"]["timeZone"]
 
         if "assignee" in issue["fields"] and issue["fields"]["assignee"]:
-            eitem['assignee'] = issue["fields"]["assignee"]["displayName"]
+            eitem['assignee'] = issue["fields"]["assignee"].get("displayName", None)
             if "timeZone" in issue["fields"]["assignee"]:
                 eitem['assignee_tz'] = issue["fields"]["assignee"]["timeZone"]
 
         if 'reporter' in issue['fields'] and issue['fields']['reporter']:
-            eitem['reporter_name'] = issue['fields']['reporter']['displayName']
-            eitem['reporter_login'] = issue['fields']['reporter']['name']
+            eitem['reporter_name'] = issue['fields']['reporter'].get('displayName', None)
+            eitem['reporter_login'] = issue['fields']['reporter'].get('name', None)
             if "timeZone" in issue["fields"]["reporter"]:
                 eitem['reporter_tz'] = issue["fields"]["reporter"]["timeZone"]
 

--- a/tests/data/jira.json
+++ b/tests/data/jira.json
@@ -111,7 +111,6 @@
                 },
                 "displayName": "Maurizio Pillitu",
                 "key": "maoo",
-                "name": "maoo",
                 "self": "https://finosfoundation.atlassian.net/rest/api/2/user?accountId=557058%3Afbbe73fc-f16a-419c-8624-c5413dbb7288",
                 "timeZone": "Europe/Madrid"
             },
@@ -1051,7 +1050,6 @@
                     "32x32": "https://avatar-cdn.atlassian.com/da024d15cb00e0e56ea9c904d051fb30?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fda024d15cb00e0e56ea9c904d051fb30%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue",
                     "48x48": "https://avatar-cdn.atlassian.com/da024d15cb00e0e56ea9c904d051fb30?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fda024d15cb00e0e56ea9c904d051fb30%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue"
                 },
-                "displayName": "Maurizio Pillitu",
                 "key": "maoo",
                 "name": "maoo",
                 "self": "https://finosfoundation.atlassian.net/rest/api/2/user?accountId=557058%3Afbbe73fc-f16a-419c-8624-c5413dbb7288",

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -141,7 +141,7 @@ class TestJira(TestBaseBackend):
         eitem = enrich_backend.get_rich_item(item)
         self.assertEqual(eitem['author_name'], 'Maurizio Pillitu')
         self.assertEqual(eitem['author_org_name'], 'Unknown')
-        self.assertEqual(eitem['author_user_name'], 'maoo')
+        self.assertEqual(eitem['author_user_name'], 'Unknown')
         self.assertEqual(eitem['author_type'], 'creator')
 
         item = self.items[0]


### PR DESCRIPTION
This code allows to handle creators and assignees without displayName or name.

Tests data have been modified accordingly.