### PR TITLE
[cocom] total per language

### DIFF
--- a/releases/unreleased/code-complexity-per-language.yml
+++ b/releases/unreleased/code-complexity-per-language.yml
@@ -1,0 +1,6 @@
+---
+title: code complexity per language
+category: added
+author: Florent Kaisser <florent.pro@kaisser.name>
+issue: 782
+notes: Add language differentiation to code complexity analysis (Cocom)


### PR DESCRIPTION
This PR fix issues https://github.com/chaoss/grimoirelab-elk/issues/782 and https://github.com/chaoss/grimoirelab-elk/issues/783

The field `language`  is add to cocom study index. A dict to associate the extension to a language is used. If the extension is not found, we considere the extension in upper case as the language name. 

Currently, the study compute the total for several metrics. But we cannot differenciate this total per the source code language. In this PR we propose to compute this metrics for each language. The sum of value for each language is equal to the old total value.