### PR TITLE
[github] GitHub evolution backlog

### DIFF
--- a/grimoire_elk/enriched/github_study_evolution.py
+++ b/grimoire_elk/enriched/github_study_evolution.py
@@ -1,0 +1,215 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2000 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+#
+# Authors:
+#   Florent Kaisser <florent.pro@kaisser.name>
+#
+# In this file, we have the ES requests used by backlog evolution github study
+#
+
+
+def get_unique_repository_with_project_name():
+    """ Retrieve all the repository names from the index. """
+
+    query_unique_repository = """
+    {
+        "size": 0,
+        "aggs": {
+            "unique_repos": {
+              "composite" : {
+                "size": 5000,
+                "sources" : [
+                  {"origin" : {"terms": {
+                      "field": "origin"
+                  }}},
+                  {"project" : {"terms": {
+                      "field": "project"
+                  }}},
+                  {"organization" : {"terms": {
+                      "field": "author_org_name"
+                  }}}
+              ]
+            }
+          }
+        }
+    }
+    """
+
+    return query_unique_repository
+
+
+def get_issues_not_closed_by_label(repository_url, to_date, label):
+    issues_not_closed = """
+    {
+      "size": 10000,
+      "query": {
+          "bool": {
+              "must_not": {
+                  "exists": {
+                      "field": "closed_at"
+                  }
+              },
+      "filter": [{
+                  "term": {
+                      "origin": "%s"
+                  }},{
+                  "term": {
+                      "labels": "%s"
+                  }},{
+                  "range" : {
+                     "created_at": {"lt" : "%s"}
+                  }
+              }
+              ]
+          }
+      }
+    }
+    """ % (repository_url, label, to_date)
+
+    return issues_not_closed
+
+
+def get_issues_open_at_by_label(repository_url, to_date, label):
+    issues_open_at = """
+    {
+      "size": 10000,
+      "query": {
+          "bool": {
+              "filter": [{
+                  "term": {
+                      "origin": "%s"
+                  }},{
+                  "term": {
+                      "labels": "%s"
+                  }},{
+                  "range" : {
+                     "closed_at": {"gt" : "%s"}
+                  }},{
+                  "range" : {
+                     "created_at": {"lt" : "%s"}
+                  }
+              }
+              ]
+          }
+      }
+    }
+    """ % (repository_url, label, to_date, to_date)
+
+    return issues_open_at
+
+
+def get_issues_not_closed_other_label(repository_url, to_date, exclude_labels):
+    issues_not_closed = """
+    {
+      "size": 10000,
+      "query": {
+          "bool": {
+              "must_not":[{
+                "terms": {
+                  "labels": %s
+                }
+              },{
+                  "exists": {
+                      "field": "closed_at"
+                  }
+              }],
+              "filter": [{
+                  "term": {
+                      "origin":"%s"
+                  }},{
+                  "range" : {
+                     "created_at": {"lt" : "%s"}
+                  }
+              }
+              ]
+          }
+      }
+    }
+    """ % (str(exclude_labels).replace("'", "\""), repository_url, to_date)
+
+    return issues_not_closed
+
+
+def get_issues_open_at_other_label(repository_url, to_date, exclude_labels):
+    issues_open_at = """
+    {
+      "size": 10000,
+      "query": {
+          "bool": {
+              "must_not":{
+                "terms": {
+                  "labels": %s
+                }
+              },
+              "filter": [{
+                  "term": {
+                      "origin": "%s"
+                  }},{
+                  "range" : {
+                     "closed_at": {"gt" : "%s"}
+                  }},{
+                  "range" : {
+                     "created_at": {"lt" : "%s"}
+                  }
+              }
+              ]
+          }
+      }
+    }
+    """ % (str(exclude_labels).replace("'", "\""),
+           repository_url, to_date, to_date)
+
+    return issues_open_at
+
+
+def get_issues_dates(interval, repository_url):
+
+    query_issues_dates = """
+{
+    "size": 0,
+    "aggs" : {
+        "created_per_interval" : {
+            "date_histogram" : {
+                "field" : "metadata__updated_on",
+                "interval" : "%dd"
+            },
+            "aggs": {
+                "created": {
+                  "value_count": {
+                        "field": "created_at"
+                    }
+                },
+                "closed": {
+                  "value_count": {
+                        "field": "closed_at"
+                    }
+                }
+            }
+        }
+    },
+        "query": {
+            "bool": {
+                "filter": [{
+                    "term": {
+                        "origin": "%s"
+                    }
+                }]
+            }
+        }
+    }
+    """ % (interval, repository_url)
+
+    return query_issues_dates

--- a/schema/github_backlog.csv
+++ b/schema/github_backlog.csv
@@ -1,0 +1,13 @@
+name,type,aggregatable,description
+average_opened_time,long,true,"Average of issue opened time."
+grimoire_creation_date,date,true,"Issue creation date."
+interval_days,long,true,"Number of days between each analysis."
+is_github_stats,boolean,true,"True if is Github Stats."
+labels,keyword,true,"The labels assigned to an issue."
+metadata__enriched_on,date,true,"Date when the data were enriched."
+opened,long,true,"Number of issues opens."
+organization,keyword,true,"Organization name of the repository uthor"
+origin,keyword,true,"The original URL from which the repository was retrieved from."
+project,keyword,true,"Project name."
+study_creation_date,true,"Date when the study is created."
+uuid,keyword,true,"Perceval UUID."


### PR DESCRIPTION
This PR fix the issue https://github.com/chaoss/grimoirelab-elk/issues/761 to add additional index to compute
the chronological evolution of opened issues and average opened time 
issues.

For each repository and label, we start the study on repository
creation date until today with a day interval (default). For each date
we retrieve the number of open issue at this date by difference between
number of opened issues and number of closed issues. In addition, we
compute the average opened time for all issues open at this date.

To differenciate by label, we compute evolution for bugs and all others
labels (like "enhancement","good first issue" ... ), we call this
"reduced labels". We need to use theses reduced labels because the
complixity to compute evolution for each combinaison of labels would be
too big. In addition, we rename "bug" label to "bugs" in reduced labels.