### PR TITLE
[github2] Fix loading identities

### DIFF
--- a/grimoire_elk/enriched/github2.py
+++ b/grimoire_elk/enriched/github2.py
@@ -144,11 +144,11 @@ class GitHubEnrich2(Enrich):
                 if user:
                     yield user
 
-                comments = item.get(comments_attr, [])
-                for comment in comments:
-                    user = self.get_sh_identity(comment['user_data'])
-                    if user:
-                        yield user
+        comments = item.get(comments_attr, [])
+        for comment in comments:
+            user = self.get_sh_identity(comment['user_data'])
+            if user:
+                yield user
 
     def get_sh_identity(self, item, identity_field=None):
         identity = {}


### PR DESCRIPTION
This code fixes the way the identities are loaded in the method `get_identities` to make the process
more efficient. The problem is that the loop that loads the identities found in comments is executed
for each identity type, however this loop should be executed just once.

The fix allows to execute the aforementioned just once.

Signed-off-by: Valerio Cosentino <valcos@bitergia.com>