### PR TITLE
[sortinghat] Create enriched fields related to Sortinghat when it is disabled

### DIFF
--- a/grimoire_elk/enriched/git.py
+++ b/grimoire_elk/enriched/git.py
@@ -317,10 +317,9 @@ class GitEnrich(Enrich):
 
         eitem.update(self.get_grimoire_fields(commit["AuthorDate"], "commit"))
 
-        if self.sortinghat:
-            # grimoire_creation_date is needed in the item
-            item.update(self.get_grimoire_fields(commit["AuthorDate"], "commit"))
-            eitem.update(self.get_item_sh(item, self.roles))
+        # grimoire_creation_date is needed in the item
+        item.update(self.get_grimoire_fields(commit["AuthorDate"], "commit"))
+        eitem.update(self.get_item_sh(item, self.roles))
 
         if self.prjs_map:
             eitem.update(self.get_item_project(eitem))

--- a/grimoire_elk/enriched/github.py
+++ b/grimoire_elk/enriched/github.py
@@ -522,9 +522,8 @@ class GitHubEnrich(Enrich):
 
         rich_pr.update(self.get_grimoire_fields(pull_request['created_at'], "pull_request"))
 
-        if self.sortinghat:
-            item[self.get_field_date()] = rich_pr[self.get_field_date()]
-            rich_pr.update(self.get_item_sh(item, self.pr_roles))
+        item[self.get_field_date()] = rich_pr[self.get_field_date()]
+        rich_pr.update(self.get_item_sh(item, self.pr_roles))
 
         return rich_pr
 
@@ -621,9 +620,8 @@ class GitHubEnrich(Enrich):
 
         rich_issue.update(self.get_grimoire_fields(issue['created_at'], "issue"))
 
-        if self.sortinghat:
-            item[self.get_field_date()] = rich_issue[self.get_field_date()]
-            rich_issue.update(self.get_item_sh(item, self.issue_roles))
+        item[self.get_field_date()] = rich_issue[self.get_field_date()]
+        rich_issue.update(self.get_item_sh(item, self.issue_roles))
 
         return rich_issue
 

--- a/grimoire_elk/enriched/gitlab.py
+++ b/grimoire_elk/enriched/gitlab.py
@@ -242,9 +242,8 @@ class GitLabEnrich(Enrich):
 
         rich_issue.update(self.get_grimoire_fields(issue['created_at'], "issue"))
 
-        if self.sortinghat:
-            item[self.get_field_date()] = rich_issue[self.get_field_date()]
-            rich_issue.update(self.get_item_sh(item, self.issue_roles))
+        item[self.get_field_date()] = rich_issue[self.get_field_date()]
+        rich_issue.update(self.get_item_sh(item, self.issue_roles))
 
         return rich_issue
 
@@ -353,9 +352,8 @@ class GitLabEnrich(Enrich):
 
         rich_mr.update(self.get_grimoire_fields(merge_request['created_at'], "merge_request"))
 
-        if self.sortinghat:
-            item[self.get_field_date()] = rich_mr[self.get_field_date()]
-            rich_mr.update(self.get_item_sh(item, self.merge_roles))
+        item[self.get_field_date()] = rich_mr[self.get_field_date()]
+        rich_mr.update(self.get_item_sh(item, self.merge_roles))
 
         return rich_mr
 

--- a/grimoire_elk/enriched/meetup.py
+++ b/grimoire_elk/enriched/meetup.py
@@ -255,8 +255,7 @@ class MeetupEnrich(Enrich):
         # created is when the meetup entry was created and it is not the interesting date
         eitem.update(self.get_grimoire_fields(eitem['time_date'], eitem['type']))
 
-        if self.sortinghat:
-            eitem.update(self.get_item_sh(event))
+        eitem.update(self.get_item_sh(event))
 
         if self.prjs_map:
             eitem.update(self.get_item_project(eitem))
@@ -270,9 +269,6 @@ class MeetupEnrich(Enrich):
 
         sh_fields = {}
 
-        if not self.sortinghat:
-            return sh_fields
-
         # Not shared common get_item_sh because it is pretty specific
         if 'member' in item:
             # comment and rsvp
@@ -284,7 +280,10 @@ class MeetupEnrich(Enrich):
             return sh_fields
 
         created = unixtime_to_datetime(item['created'] / 1000)
-        sh_fields = self.get_item_sh_fields(identity, created)
+        if self.sortinghat:
+            sh_fields = self.get_item_sh_fields(identity, created)
+        else:
+            sh_fields = self.get_item_no_sh_fields(identity, 'author')
 
         return sh_fields
 
@@ -311,8 +310,7 @@ class MeetupEnrich(Enrich):
             ecomment['member_name'] = member['name']
             ecomment['member_url'] = "https://www.meetup.com/members/" + str(member['id'])
 
-            if self.sortinghat:
-                ecomment.update(self.get_item_sh(comment))
+            ecomment.update(self.get_item_sh(comment))
 
             yield ecomment
 
@@ -341,8 +339,7 @@ class MeetupEnrich(Enrich):
             ersvp['rsvps_updated'] = rsvp['updated']
             ersvp['rsvps_response'] = rsvp['response']
 
-            if self.sortinghat:
-                ersvp.update(self.get_item_sh(rsvp))
+            ersvp.update(self.get_item_sh(rsvp))
 
             yield ersvp
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -86,6 +86,10 @@ class TestGit(TestBaseBackend):
         self.assertEqual(eitem['utc_author_date_weekday'], 2)
         self.assertEqual(eitem['utc_author_date_hour'], 17)
 
+        self.assertEqual(eitem['author_uuid'], 'f3aee5067d4691544f10d915932c9f1d08cb3b36')
+        self.assertEqual(eitem['author_domain'], 'gmail.com')
+        self.assertEqual(eitem['author_name'], 'Eduardo Morais')
+
         self.assertEqual(eitem['commit_date'], '2012-08-14T14:32:15')
         self.assertEqual(eitem['commit_date_weekday'], 2)
         self.assertEqual(eitem['commit_date_hour'], 14)
@@ -99,6 +103,10 @@ class TestGit(TestBaseBackend):
         self.assertEqual(eitem['author_date_hour'], 22)
         self.assertEqual(eitem['utc_author_date_weekday'], 3)
         self.assertEqual(eitem['utc_author_date_hour'], 6)
+
+        self.assertEqual(eitem['author_uuid'], '8abda7ad626330d5065d4c3a93fb45029a32bdcb')
+        self.assertEqual(eitem['author_domain'], 'gmail.com')
+        self.assertEqual(eitem['author_name'], 'Zhongpeng Lin (林中鹏)')
 
         self.assertEqual(eitem['commit_date'], '2014-02-11T22:10:39')
         self.assertEqual(eitem['commit_date_weekday'], 2)

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -67,12 +67,24 @@ class TestGit(TestBaseBackend):
         eitem = enrich_backend.get_rich_item(item)
         self.assertEqual(eitem['labels'], [])
         self.assertEqual(item['category'], 'issue')
+        self.assertEqual(eitem['author_uuid'], '5f9d42ce000e46e9eee60a3c64a353b560051a2e')
+        self.assertEqual(eitem['author_domain'], 'zhquan_example.com')
+        self.assertEqual(eitem['user_data_uuid'], '5f9d42ce000e46e9eee60a3c64a353b560051a2e')
+        self.assertEqual(eitem['user_data_domain'], 'zhquan_example.com')
+        self.assertEqual(eitem['assignee_data_uuid'], '5f9d42ce000e46e9eee60a3c64a353b560051a2e')
+        self.assertEqual(eitem['assignee_data_domain'], 'zhquan_example.com')
 
         item = self.items[1]
         eitem = enrich_backend.get_rich_item(item)
         self.assertEqual(eitem['labels'], ['bug', 'feature'])
         self.assertEqual(item['category'], 'pull_request')
         self.assertEqual(eitem['time_to_merge_request_response'], 335.81)
+        self.assertEqual(eitem['author_uuid'], '5f9d42ce000e46e9eee60a3c64a353b560051a2e')
+        self.assertEqual(eitem['author_domain'], 'zhquan_example.com')
+        self.assertEqual(eitem['user_data_uuid'], '5f9d42ce000e46e9eee60a3c64a353b560051a2e')
+        self.assertEqual(eitem['user_data_domain'], 'zhquan_example.com')
+        self.assertEqual(eitem['merged_by_data_uuid'], '5f9d42ce000e46e9eee60a3c64a353b560051a2e')
+        self.assertEqual(eitem['merged_by_data_domain'], 'zhquan_example.com')
 
         item = self.items[2]
         eitem = enrich_backend.get_rich_item(item)
@@ -105,9 +117,13 @@ class TestGit(TestBaseBackend):
         self.assertIsNone(eitem['user_domain'])
         self.assertIsNone(eitem['user_org'])
         self.assertEqual(eitem['author_name'], 'acs')
+        self.assertEqual(eitem['author_uuid'], 'e8cc482634f2095c935b6a586ddb9ed8215d5cb8')
         self.assertIsNone(eitem['assignee_name'])
         self.assertIsNone(eitem['assignee_domain'])
         self.assertIsNone(eitem['assignee_org'])
+        self.assertEqual(eitem['user_data_name'], 'acs')
+        self.assertEqual(eitem['user_data_uuid'], 'e8cc482634f2095c935b6a586ddb9ed8215d5cb8')
+        self.assertIsNone(eitem['user_data_domain'])
 
         item = self.items[6]
         eitem = enrich_backend.get_rich_item(item)
@@ -116,9 +132,13 @@ class TestGit(TestBaseBackend):
         self.assertIsNone(eitem['user_domain'])
         self.assertIsNone(eitem['user_org'])
         self.assertEqual(eitem['author_name'], 'acs')
+        self.assertEqual(eitem['author_uuid'], 'e8cc482634f2095c935b6a586ddb9ed8215d5cb8')
         self.assertIsNone(eitem['merge_author_name'])
         self.assertIsNone(eitem['merge_author_domain'])
         self.assertIsNone(eitem['merge_author_org'])
+        self.assertEqual(eitem['user_data_name'], 'acs')
+        self.assertEqual(eitem['user_data_uuid'], 'e8cc482634f2095c935b6a586ddb9ed8215d5cb8')
+        self.assertIsNone(eitem['user_data_domain'])
 
     def test_enrich_repo_labels(self):
         """Test whether the field REPO_LABELS is present in the enriched items"""

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -70,6 +70,9 @@ class TestGitLab(TestBaseBackend):
         self.assertEqual(eitem['milestone_iid'], 34)
         self.assertEqual(eitem['labels'], [])
         self.assertEqual(eitem['author_username'], "redfish64")
+        self.assertEqual(eitem['author_uuid'], '3a9ab60b1586bf0a292ccb447746f7bcd1ab14e4')
+        self.assertEqual(eitem['assignee_username'], 'redfish64')
+        self.assertEqual(eitem['assignee_uuid'], '3a9ab60b1586bf0a292ccb447746f7bcd1ab14e4')
         self.assertEqual(eitem['repository'], "https://gitlab.com/fdroid/fdroiddata")
 
         item = self.items[1]
@@ -82,6 +85,7 @@ class TestGitLab(TestBaseBackend):
         self.assertEqual(eitem['milestone_iid'], None)
         self.assertEqual(eitem['labels'], [])
         self.assertEqual(eitem['author_username'], "redfish64")
+        self.assertEqual(eitem['author_uuid'], '3a9ab60b1586bf0a292ccb447746f7bcd1ab14e4')
         self.assertEqual(eitem['repository'], "https://gitlab.com/fdroid/fdroiddata")
 
         item = self.items[2]
@@ -94,6 +98,7 @@ class TestGitLab(TestBaseBackend):
         self.assertEqual(eitem['milestone_iid'], None)
         self.assertEqual(eitem['labels'], ['CI/CD', 'Deliverable'])
         self.assertEqual(eitem['author_username'], "YoeriNijs")
+        self.assertEqual(eitem['author_uuid'], '02a45079282ec8c5ee5e3d04cc5ef46441d45af8')
         self.assertEqual(eitem['repository'], "https://gitlab.com/fdroid/fdroiddata")
 
         item = self.items[4]
@@ -118,6 +123,7 @@ class TestGitLab(TestBaseBackend):
         self.assertEqual(eitem['milestone_iid'], 34)
         self.assertEqual(eitem['labels'], [])
         self.assertEqual(eitem['author_username'], "grote")
+        self.assertEqual(eitem['author_uuid'], 'c6f116d5e92c5ec1393542f63790c3c904ddba28')
         self.assertEqual(eitem['repository'], "https://gitlab.com/fdroid/fdroiddata")
 
         item = self.items[6]
@@ -130,6 +136,7 @@ class TestGitLab(TestBaseBackend):
         self.assertEqual(eitem['milestone_iid'], None)
         self.assertEqual(eitem['labels'], [])
         self.assertEqual(eitem['author_username'], "Rudloff")
+        self.assertEqual(eitem['author_uuid'], '56958a849936fca7a0e4361a6a08d99795770b2f')
         self.assertEqual(eitem['repository'], "https://gitlab.com/fdroid/fdroiddata")
 
         item = self.items[7]
@@ -142,6 +149,7 @@ class TestGitLab(TestBaseBackend):
         self.assertEqual(eitem['milestone_iid'], None)
         self.assertEqual(eitem['labels'], ['CI/CD', 'Deliverable'])
         self.assertEqual(eitem['author_username'], "marc.nause")
+        self.assertEqual(eitem['author_uuid'], 'b7bddb53fc3b7fbba0188015aa74bfc501a7f230')
         self.assertEqual(eitem['repository'], "https://gitlab.com/fdroid/fdroiddata")
 
     def test_enrich_repo_labels(self):

--- a/tests/test_meetup.py
+++ b/tests/test_meetup.py
@@ -63,6 +63,7 @@ class TestMeetup(TestBaseBackend):
         self.assertEqual(eitem['meetup_updated'], '2016-04-07T21:39:24+00:00')
         self.assertEqual(eitem['group_created'], '2016-03-20T15:13:47+00:00')
         self.assertEqual(eitem['group_urlname'], 'sqlpass-es')
+        self.assertEqual(eitem['author_uuid'], '029aa3befc96d386e1c7270586f1ec1d673b0b1b')
 
     def test_enrich_repo_labels(self):
         """Test whether the field REPO_LABELS is present in the enriched items"""


### PR DESCRIPTION
This pull request includes the fields related to Sortinghat with reasonable data when it is disabled:
- id, gender, gender_acc, org_name and bot are empty.
- name, username and domain are obtained from the identity.
- uuid is calculated with a hash of the backend, name, email and username using the function provided by sortinghat