### PR TITLE
[enriched-gitlab] Fix repository value in issue

### DIFF
--- a/grimoire_elk/enriched/gitlab.py
+++ b/grimoire_elk/enriched/gitlab.py
@@ -213,7 +213,7 @@ class GitLabEnrich(Enrich):
 
         rich_issue['id'] = issue['id']
         rich_issue['id_in_repo'] = issue['iid']
-        rich_issue['repository'] = issue['web_url'].rsplit("/", 2)[0]
+        rich_issue['repository'] = issue['web_url'].rsplit("/", 2)[0].split("/-")[0]
         rich_issue['title'] = issue['title']
         rich_issue['title_analyzed'] = issue['title']
         rich_issue['state'] = issue['state']

--- a/tests/data/gitlab.json
+++ b/tests/data/gitlab.json
@@ -245,7 +245,7 @@
             "updated_at": "2017-03-18T18:36:39.764Z",
             "upvotes": 0,
             "user_notes_count": 2,
-            "web_url": "https://gitlab.com/fdroid/fdroiddata/issues/641",
+            "web_url": "https://gitlab.com/fdroid/fdroiddata/-/issues/641",
             "weight": null
         },
         "origin": "https://gitlab.com/fdroid/fdroiddata",


### PR DESCRIPTION
This code fixes the 'repository' value of the issues URL.
The api add the character '-' before '/issues/'.

Tests data and the corresponding tests have been modified
accordingly.

Signed-off-by: Quan Zhou <quan@bitergia.com>