### PR TITLE
[grimoire_elk] Add support for multiple affiliations

### DIFF
--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -41,6 +41,7 @@ from ..elastic import ElasticSearch
 from ..elastic_items import (ElasticItems,
                              HEADER_JSON)
 from .study_ceres_onion import ESOnionConnector, onion_study
+from .sortinghat_gelk import MULTI_ORG_NAME, MULTI_ORG_NAMES
 from .graal_study_evolution import (get_to_date,
                                     get_unique_repository)
 from statsmodels.duration.survfunc import SurvfuncRight
@@ -674,6 +675,28 @@ class Enrich(ElasticItems):
                     break
         return enroll
 
+    def get_multi_enrollment(self, uuid, item_date):
+        """ Get the enrollments for the uuid when the item was done """
+
+        enrolls = []
+
+        # item_date must be offset-naive (utc)
+        if item_date and item_date.tzinfo:
+            item_date = (item_date - item_date.utcoffset()).replace(tzinfo=None)
+
+        enrollments = self.get_enrollments(uuid)
+
+        if enrollments:
+            for enrollment in enrollments:
+                if not item_date:
+                    enrolls.append(enrollment.organization.name)
+                elif enrollment.start <= item_date <= enrollment.end:
+                    enrolls.append(enrollment.organization.name)
+        else:
+            enrolls.append(self.unaffiliated_group)
+
+        return enrolls
+
     def __get_item_sh_fields_empty(self, rol, undefined=False):
         """ Return a SH identity with all fields to empty_field """
         # If empty_field is None, the fields do not appear in index patterns
@@ -687,7 +710,9 @@ class Enrich(ElasticItems):
             rol + "_gender": empty_field,
             rol + "_gender_acc": None,
             rol + "_org_name": empty_field,
-            rol + "_bot": False
+            rol + "_bot": False,
+            rol + MULTI_ORG_NAMES: [empty_field],
+            rol + MULTI_ORG_NAME + "0": empty_field
         }
 
     def get_item_no_sh_fields(self, identity, rol):
@@ -764,6 +789,13 @@ class Enrich(ElasticItems):
 
         eitem_sh[rol + "_org_name"] = self.get_enrollment(eitem_sh[rol + "_uuid"], item_date)
         eitem_sh[rol + "_bot"] = self.is_bot(eitem_sh[rol + '_uuid'])
+
+        eitem_sh[rol + MULTI_ORG_NAMES] = self.get_multi_enrollment(eitem_sh[rol + "_uuid"], item_date)
+
+        if eitem_sh[rol + MULTI_ORG_NAMES]:
+            for pos in range(len(eitem_sh[rol + MULTI_ORG_NAMES])):
+                eitem_sh[rol + MULTI_ORG_NAME + str(pos)] = eitem_sh[rol + MULTI_ORG_NAMES][pos]
+
         return eitem_sh
 
     def get_profile_sh(self, uuid):

--- a/grimoire_elk/enriched/gerrit.py
+++ b/grimoire_elk/enriched/gerrit.py
@@ -326,6 +326,11 @@ class GerritEnrich(Enrich):
                     ecomment['author_org_name'] = ecomment['reviewer_org_name']
                     ecomment['author_bot'] = ecomment['reviewer_bot']
 
+                    ecomment['author_multi_org_names'] = ecomment.get('reviewer_multi_org_names', [])
+                    if ecomment['author_multi_org_names']:
+                        for pos in range(len(ecomment['author_multi_org_names'])):
+                            ecomment['author_multi_org_name_' + str(pos)] = ecomment['author_multi_org_names'][pos]
+
                 # add changeset author
                 self.add_changeset_author(eitem, ecomment)
 
@@ -482,6 +487,11 @@ class GerritEnrich(Enrich):
                 eapproval['author_org_name'] = eapproval.get('by_org_name', None)
                 eapproval['author_bot'] = eapproval.get('by_bot', None)
 
+                eapproval['author_multi_org_names'] = eapproval.get('by_multi_org_names', [])
+                if eapproval['author_multi_org_names']:
+                    for pos in range(len(eapproval['author_multi_org_names'])):
+                        eapproval['author_multi_org_name_' + str(pos)] = eapproval['author_multi_org_names'][pos]
+
                 # add changeset author
                 self.add_changeset_author(epatchset, eapproval)
 
@@ -513,6 +523,12 @@ class GerritEnrich(Enrich):
         target_eitem['changeset_author_gender_acc'] = source_eitem.get(rol + '_gender_acc', None)
         target_eitem['changeset_author_org_name'] = source_eitem.get(rol + '_org_name', None)
         target_eitem['changeset_author_bot'] = source_eitem.get(rol + '_bot', None)
+
+        target_eitem['changeset_author_multi_org_names'] = source_eitem.get(rol + '_multi_org_names', [])
+        if target_eitem['changeset_author_multi_org_names']:
+            for pos in range(len(target_eitem['changeset_author_multi_org_names'])):
+                target_eitem['changeset_author_multi_org_name_' + str(pos)] = \
+                    target_eitem['changeset_author_multi_org_names'][pos]
 
     def get_field_unique_id(self):
         return "id"

--- a/grimoire_elk/enriched/jira.py
+++ b/grimoire_elk/enriched/jira.py
@@ -353,6 +353,11 @@ class JiraEnrich(Enrich):
             eitem['author_org_name'] = eitem[author_type + '_org_name']
             eitem['author_bot'] = eitem[author_type + '_bot']
 
+            eitem['author_multi_org_names'] = eitem.get(author_type + '_multi_org_names', [])
+            if eitem['author_multi_org_names']:
+                for pos in range(len(eitem['author_multi_org_names'])):
+                    eitem['author_multi_org_name_' + str(pos)] = eitem['author_multi_org_names'][pos]
+
         if self.prjs_map:
             eitem.update(self.get_item_project(eitem))
 

--- a/grimoire_elk/enriched/sortinghat_gelk.py
+++ b/grimoire_elk/enriched/sortinghat_gelk.py
@@ -30,6 +30,10 @@ from sortinghat.exceptions import AlreadyExistsError, InvalidValueError
 logger = logging.getLogger(__name__)
 
 
+MULTI_ORG_NAME = '_multi_org_name_'
+MULTI_ORG_NAMES = '_multi_org_names'
+
+
 class SortingHat(object):
 
     @classmethod

--- a/grimoire_elk/enriched/study_ceres_onion.py
+++ b/grimoire_elk/enriched/study_ceres_onion.py
@@ -51,6 +51,7 @@ class ESOnionConnector(ESConnector):
 
     AUTHOR_NAME = 'author_name'
     AUTHOR_ORG = 'author_org_name'
+    AUTHOR_MULTI_ORG_NAMES = 'author_multi_org_names'
     AUTHOR_UUID = 'author_uuid'
     CONTRIBUTIONS = 'contributions'
     LATEST_TS = 'latest_ts'
@@ -86,7 +87,13 @@ class ESOnionConnector(ESConnector):
 
             date_range = {self._timeframe_field: {'gte': quarter.start_time, 'lte': quarter.end_time}}
 
-            orgs = self.__list_uniques(date_range, self.AUTHOR_ORG)
+            orgs = self.__list_uniques(date_range, self.AUTHOR_MULTI_ORG_NAMES)
+            if not orgs:
+                logger.warning("{} Attribute {} not found, using {}".format(
+                    self.__log_prefix, self.AUTHOR_MULTI_ORG_NAMES, self.AUTHOR_ORG)
+                )
+                orgs = self.__list_uniques(date_range, self.AUTHOR_ORG)
+
             projects = self.__list_uniques(date_range, self.PROJECT)
 
             # Get global data

--- a/tests/test_askbot.py
+++ b/tests/test_askbot.py
@@ -71,6 +71,21 @@ class TestAskbot(TestBaseBackend):
         self.assertEqual(result['raw'], 2)
         self.assertEqual(result['enrich'], 155)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        url = self.es_con + "/" + self.enrich_index + "/_search"
+        response = enrich_backend.requests.get(url, verify=False).json()
+        for hit in response['hits']['hits']:
+            source = hit['_source']
+            if 'author_uuid' in source:
+                self.assertIn('author_domain', source)
+                self.assertIn('author_gender', source)
+                self.assertIn('author_gender_acc', source)
+                self.assertIn('author_org_name', source)
+                self.assertIn('author_bot', source)
+                self.assertIn('author_multi_org_names', source)
+                self.assertIn('author_multi_org_name_0', source)
+
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -78,6 +78,21 @@ class TestBugzilla(TestBaseBackend):
         self.assertEqual(result['raw'], 7)
         self.assertEqual(result['enrich'], 7)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        url = self.es_con + "/" + self.enrich_index + "/_search"
+        response = enrich_backend.requests.get(url, verify=False).json()
+        for hit in response['hits']['hits']:
+            source = hit['_source']
+            if 'author_uuid' in source:
+                self.assertIn('author_domain', source)
+                self.assertIn('author_gender', source)
+                self.assertIn('author_gender_acc', source)
+                self.assertIn('author_org_name', source)
+                self.assertIn('author_bot', source)
+                self.assertIn('author_multi_org_names', source)
+                self.assertIn('author_multi_org_name_0', source)
+
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 

--- a/tests/test_bugzillarest.py
+++ b/tests/test_bugzillarest.py
@@ -84,15 +84,19 @@ class TestBugzillaRest(TestBaseBackend):
         self.assertEqual(result['enrich'], 7)
 
         enrich_backend = self.connectors[self.connector][2]()
-        enrich_backend.sortinghat = True
 
-        item = self.items[0]
-        eitem = enrich_backend.get_rich_item(item)
-        self.assertIsNone(eitem['author_domain'])
-
-        item = self.items[1]
-        eitem = enrich_backend.get_rich_item(item)
-        self.assertEqual(eitem['author_domain'], 'example.org')
+        url = self.es_con + "/" + self.enrich_index + "/_search"
+        response = enrich_backend.requests.get(url, verify=False).json()
+        for hit in response['hits']['hits']:
+            source = hit['_source']
+            if 'author_uuid' in source:
+                self.assertIn('author_domain', source)
+                self.assertIn('author_gender', source)
+                self.assertIn('author_gender_acc', source)
+                self.assertIn('author_org_name', source)
+                self.assertIn('author_bot', source)
+                self.assertIn('author_multi_org_names', source)
+                self.assertIn('author_multi_org_name_0', source)
 
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""

--- a/tests/test_confluence.py
+++ b/tests/test_confluence.py
@@ -99,6 +99,21 @@ class TestConfluence(TestBaseBackend):
         self.assertEqual(result['raw'], 4)
         self.assertEqual(result['enrich'], 4)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        url = self.es_con + "/" + self.enrich_index + "/_search"
+        response = enrich_backend.requests.get(url, verify=False).json()
+        for hit in response['hits']['hits']:
+            source = hit['_source']
+            if 'author_uuid' in source:
+                self.assertIn('author_domain', source)
+                self.assertIn('author_gender', source)
+                self.assertIn('author_gender_acc', source)
+                self.assertIn('author_org_name', source)
+                self.assertIn('author_bot', source)
+                self.assertIn('author_multi_org_names', source)
+                self.assertIn('author_multi_org_name_0', source)
+
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 

--- a/tests/test_crates.py
+++ b/tests/test_crates.py
@@ -73,6 +73,21 @@ class TestCrates(TestBaseBackend):
         self.assertEqual(result['raw'], 4)
         self.assertEqual(result['enrich'], 4)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        url = self.es_con + "/" + self.enrich_index + "/_search"
+        response = enrich_backend.requests.get(url, verify=False).json()
+        for hit in response['hits']['hits']:
+            source = hit['_source']
+            if 'author_uuid' in source:
+                self.assertIn('author_domain', source)
+                self.assertIn('author_gender', source)
+                self.assertIn('author_gender_acc', source)
+                self.assertIn('author_org_name', source)
+                self.assertIn('author_bot', source)
+                self.assertIn('author_multi_org_names', source)
+                self.assertIn('author_multi_org_name_0', source)
+
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 

--- a/tests/test_discourse.py
+++ b/tests/test_discourse.py
@@ -77,6 +77,21 @@ class TestDiscourse(TestBaseBackend):
         self.assertEqual(result['raw'], 3)
         self.assertEqual(result['enrich'], 35)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        url = self.es_con + "/" + self.enrich_index + "/_search"
+        response = enrich_backend.requests.get(url, verify=False).json()
+        for hit in response['hits']['hits']:
+            source = hit['_source']
+            if 'author_uuid' in source:
+                self.assertIn('author_domain', source)
+                self.assertIn('author_gender', source)
+                self.assertIn('author_gender_acc', source)
+                self.assertIn('author_org_name', source)
+                self.assertIn('author_bot', source)
+                self.assertIn('author_multi_org_names', source)
+                self.assertIn('author_multi_org_name_0', source)
+
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 

--- a/tests/test_enrich.py
+++ b/tests/test_enrich.py
@@ -52,7 +52,9 @@ class TestEnrich(unittest.TestCase):
             "author_gender": "",
             "author_gender_acc": None,
             "author_org_name": "",
-            "author_bot": False
+            "author_bot": False,
+            "author_multi_org_names": [""],
+            "author_multi_org_name_0": ""
         }
 
     def test_get_profile_sh(self):
@@ -97,6 +99,8 @@ class TestEnrich(unittest.TestCase):
             'author_gender_acc': 100,
             'author_org_name': "Bitergia",
             'author_bot': False,
+            'author_multi_org_names': ['Bitergia'],
+            'author_multi_org_name_0': 'Bitergia'
         }
 
         empty_item_by_rol = {'author': self.empty_item}
@@ -139,6 +143,12 @@ class TestEnrich(unittest.TestCase):
             return enrollments[(uuid, item_date)]
         self._enrich.get_enrollment = MagicMock(side_effect=enrollments_side_effect)
 
+        multi_enrollments = {(expected['author_uuid'], None): expected['author_multi_org_names']}
+
+        def multi_enrollments_side_effect(uuid, item_date):
+            return multi_enrollments[(uuid, item_date)]
+        self._enrich.get_multi_enrollment = MagicMock(side_effect=multi_enrollments_side_effect)
+
         bots = {'aaaaa': False}
 
         def bots_side_effect(uuid):
@@ -158,6 +168,8 @@ class TestEnrich(unittest.TestCase):
         self.assertEqual(eitem_sh['author_gender_acc'], expected['author_gender_acc'])
         self.assertEqual(eitem_sh['author_org_name'], expected['author_org_name'])
         self.assertEqual(eitem_sh['author_bot'], expected['author_bot'])
+        self.assertEqual(eitem_sh['author_multi_org_names'], expected['author_multi_org_names'])
+        self.assertEqual(eitem_sh['author_multi_org_name_0'], expected['author_multi_org_name_0'])
 
         # 2. Change role
 
@@ -172,6 +184,8 @@ class TestEnrich(unittest.TestCase):
         self.assertEqual(eitem_sh['assignee_gender_acc'], expected['author_gender_acc'])
         self.assertEqual(eitem_sh['assignee_org_name'], expected['author_org_name'])
         self.assertEqual(eitem_sh['assignee_bot'], expected['author_bot'])
+        self.assertEqual(eitem_sh['assignee_multi_org_names'], expected['author_multi_org_names'])
+        self.assertEqual(eitem_sh['assignee_multi_org_name_0'], expected['author_multi_org_name_0'])
 
     def test_get_item_sh_fields_identity_no_uuid(self):
         """uuid is None (not found in sortinghat) or does not exist"""
@@ -212,7 +226,8 @@ class TestEnrich(unittest.TestCase):
         self.assertEqual(eitem_sh['author_gender'], '-- UNDEFINED --')
         self.assertEqual(eitem_sh['author_gender_acc'], None)
         self.assertEqual(eitem_sh['author_org_name'], '-- UNDEFINED --')
-        self.assertEqual(eitem_sh['author_bot'], False)
+        self.assertEqual(eitem_sh['author_multi_org_names'], ['-- UNDEFINED --'])
+        self.assertEqual(eitem_sh['author_multi_org_name_0'], '-- UNDEFINED --')
 
         # 2. No uuid field
         sh_ids = {
@@ -231,6 +246,8 @@ class TestEnrich(unittest.TestCase):
         self.assertEqual(eitem_sh['author_gender_acc'], None)
         self.assertEqual(eitem_sh['author_org_name'], '-- UNDEFINED --')
         self.assertEqual(eitem_sh['author_bot'], False)
+        self.assertEqual(eitem_sh['author_multi_org_names'], ['-- UNDEFINED --'])
+        self.assertEqual(eitem_sh['author_multi_org_name_0'], '-- UNDEFINED --')
 
     def test_get_item_sh_fields_identity_no_profile(self):
         """Test retrieval when no profile data is found or data is not what we expected"""
@@ -255,6 +272,8 @@ class TestEnrich(unittest.TestCase):
             'author_gender_acc': 0,
             'author_org_name': "Bitergia",
             'author_bot': False,
+            'author_multi_org_names': ['Bitergia'],
+            'author_multi_org_name_0': 'Bitergia'
         }
 
         # 1. Profile is None
@@ -289,6 +308,13 @@ class TestEnrich(unittest.TestCase):
             return enrollments[(uuid, item_date)]
         self._enrich.get_enrollment = MagicMock(side_effect=enrollments_side_effect)
 
+        multi_enrollments = {(expected['author_uuid'], None): expected['author_multi_org_names']}
+
+        def multi_enrollments_side_effect(uuid, item_date):
+            return multi_enrollments[(uuid, item_date)]
+
+        self._enrich.get_multi_enrollment = MagicMock(side_effect=multi_enrollments_side_effect)
+
         bots = {'aaaaa': False}
 
         def bots_side_effect(uuid):
@@ -306,6 +332,8 @@ class TestEnrich(unittest.TestCase):
         self.assertEqual(eitem_sh['author_gender_acc'], expected['author_gender_acc'])
         self.assertEqual(eitem_sh['author_org_name'], expected['author_org_name'])
         self.assertEqual(eitem_sh['author_bot'], expected['author_bot'])
+        self.assertEqual(eitem_sh['author_multi_org_names'], expected['author_multi_org_names'])
+        self.assertEqual(eitem_sh['author_multi_org_name_0'], expected['author_multi_org_name_0'])
 
         # 2. Profile as empty dict
 
@@ -323,6 +351,8 @@ class TestEnrich(unittest.TestCase):
         self.assertEqual(eitem_sh['author_gender_acc'], expected['author_gender_acc'])
         self.assertEqual(eitem_sh['author_org_name'], expected['author_org_name'])
         self.assertEqual(eitem_sh['author_bot'], expected['author_bot'])
+        self.assertEqual(eitem_sh['author_multi_org_names'], expected['author_multi_org_names'])
+        self.assertEqual(eitem_sh['author_multi_org_name_0'], expected['author_multi_org_name_0'])
 
         # 3 Profile with other fields
 
@@ -346,6 +376,8 @@ class TestEnrich(unittest.TestCase):
         self.assertEqual(eitem_sh['author_gender_acc'], expected['author_gender_acc'])
         self.assertEqual(eitem_sh['author_org_name'], expected['author_org_name'])
         self.assertEqual(eitem_sh['author_bot'], expected['author_bot'])
+        self.assertEqual(eitem_sh['author_multi_org_names'], expected['author_multi_org_names'])
+        self.assertEqual(eitem_sh['author_multi_org_name_0'], expected['author_multi_org_name_0'])
 
     def test_get_item_sh_fields_identity_no_gender(self):
         """Profile with no gender values"""
@@ -366,6 +398,8 @@ class TestEnrich(unittest.TestCase):
             'author_gender_acc': 0,
             'author_org_name': "Bitergia",
             'author_bot': False,
+            'author_multi_org_names': ['Bitergia'],
+            'author_multi_org_name_0': 'Bitergia'
         }
 
         empty_item_by_rol = {'author': self.empty_item}
@@ -408,6 +442,13 @@ class TestEnrich(unittest.TestCase):
             return enrollments[(uuid, item_date)]
         self._enrich.get_enrollment = MagicMock(side_effect=enrollments_side_effect)
 
+        multi_enrollments = {(expected['author_uuid'], None): expected['author_multi_org_names']}
+
+        def multi_enrollments_side_effect(uuid, item_date):
+            return multi_enrollments[(uuid, item_date)]
+
+        self._enrich.get_multi_enrollment = MagicMock(side_effect=multi_enrollments_side_effect)
+
         bots = {'aaaaa': False}
 
         def bots_side_effect(uuid):
@@ -435,6 +476,8 @@ class TestEnrich(unittest.TestCase):
         self.assertEqual(eitem_sh['author_gender_acc'], expected['author_gender_acc'])
         self.assertEqual(eitem_sh['author_org_name'], expected['author_org_name'])
         self.assertEqual(eitem_sh['author_bot'], expected['author_bot'])
+        self.assertEqual(eitem_sh['author_multi_org_names'], expected['author_multi_org_names'])
+        self.assertEqual(eitem_sh['author_multi_org_name_0'], expected['author_multi_org_name_0'])
 
     def test_get_item_sh_fields_sh_id(self):
         """Test retrieval from sortinghat id"""
@@ -451,6 +494,8 @@ class TestEnrich(unittest.TestCase):
             'author_gender_acc': 100,
             'author_org_name': "Bitergia",
             'author_bot': False,
+            'author_multi_org_names': ['Bitergia'],
+            'author_multi_org_name_0': 'Bitergia'
         }
 
         empty_item_by_rol = {'author': self.empty_item}
@@ -489,6 +534,13 @@ class TestEnrich(unittest.TestCase):
             return enrollments[(uuid, item_date)]
         self._enrich.get_enrollment = MagicMock(side_effect=enrollments_side_effect)
 
+        multi_enrollments = {(expected['author_uuid'], None): expected['author_multi_org_names']}
+
+        def multi_enrollments_side_effect(uuid, item_date):
+            return multi_enrollments[(uuid, item_date)]
+
+        self._enrich.get_multi_enrollment = MagicMock(side_effect=multi_enrollments_side_effect)
+
         bots = {'aaaaa': False}
 
         def bots_side_effect(uuid):
@@ -506,6 +558,10 @@ class TestEnrich(unittest.TestCase):
         self.assertEqual(eitem_sh['author_gender_acc'], expected['author_gender_acc'])
         self.assertEqual(eitem_sh['author_org_name'], expected['author_org_name'])
         self.assertEqual(eitem_sh['author_bot'], expected['author_bot'])
+        self.assertEqual(eitem_sh['author_org_name'], expected['author_org_name'])
+        self.assertEqual(eitem_sh['author_bot'], expected['author_bot'])
+        self.assertEqual(eitem_sh['author_multi_org_names'], expected['author_multi_org_names'])
+        self.assertEqual(eitem_sh['author_multi_org_name_0'], expected['author_multi_org_name_0'])
 
     def test_get_item_sh_fields_sh_id_no_uuid(self):
         """Test retrieval from sortinghat id when there is no uuid"""
@@ -533,6 +589,8 @@ class TestEnrich(unittest.TestCase):
         self.assertEqual(eitem_sh['author_gender_acc'], None)
         self.assertEqual(eitem_sh['author_org_name'], '-- UNDEFINED --')
         self.assertEqual(eitem_sh['author_bot'], False)
+        self.assertEqual(eitem_sh['author_multi_org_names'], ['-- UNDEFINED --'])
+        self.assertEqual(eitem_sh['author_multi_org_name_0'], '-- UNDEFINED --')
 
         # 2. uuid is an empty string
 
@@ -549,6 +607,8 @@ class TestEnrich(unittest.TestCase):
         self.assertEqual(eitem_sh['author_gender_acc'], None)
         self.assertEqual(eitem_sh['author_org_name'], '-- UNDEFINED --')
         self.assertEqual(eitem_sh['author_bot'], False)
+        self.assertEqual(eitem_sh['author_multi_org_names'], ['-- UNDEFINED --'])
+        self.assertEqual(eitem_sh['author_multi_org_name_0'], '-- UNDEFINED --')
 
     def test_no_params(self):
         """Neither identity nor sh_id are passed as arguments"""
@@ -570,6 +630,8 @@ class TestEnrich(unittest.TestCase):
         self.assertEqual(eitem_sh['author_gender_acc'], self.empty_item['author_gender_acc'])
         self.assertEqual(eitem_sh['author_org_name'], self.empty_item['author_org_name'])
         self.assertEqual(eitem_sh['author_bot'], self.empty_item['author_bot'])
+        self.assertEqual(eitem_sh['author_multi_org_names'], self.empty_item['author_multi_org_names'])
+        self.assertEqual(eitem_sh['author_multi_org_name_0'], self.empty_item['author_multi_org_name_0'])
 
     def test_has_identities(self):
         """Test whether has_identities works"""

--- a/tests/test_finosmeetings.py
+++ b/tests/test_finosmeetings.py
@@ -102,6 +102,8 @@ class TestFinosMeetings(TestBaseBackend):
         self.assertIn('email_uuid', eitem)
         self.assertIn('email_name', eitem)
         self.assertIn('email_user_name', eitem)
+        self.assertIn('email_multi_org_names', eitem)
+        self.assertIn('email_multi_org_name_0', eitem)
 
         item = self.items[1]
         eitem = enrich_backend.get_rich_item(item)
@@ -112,6 +114,8 @@ class TestFinosMeetings(TestBaseBackend):
         self.assertIn('email_uuid', eitem)
         self.assertIn('email_name', eitem)
         self.assertIn('email_user_name', eitem)
+        self.assertIn('email_multi_org_names', eitem)
+        self.assertIn('email_multi_org_name_0', eitem)
 
         item = self.items[2]
         eitem = enrich_backend.get_rich_item(item)
@@ -122,6 +126,8 @@ class TestFinosMeetings(TestBaseBackend):
         self.assertIn('email_uuid', eitem)
         self.assertIn('email_name', eitem)
         self.assertIn('email_user_name', eitem)
+        self.assertIn('email_multi_org_names', eitem)
+        self.assertIn('email_multi_org_name_0', eitem)
 
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""

--- a/tests/test_gerrit.py
+++ b/tests/test_gerrit.py
@@ -251,6 +251,9 @@ class TestGerrit(TestBaseBackend):
             self.assertIn('changeset_author_gender_acc', eitem)
             self.assertIn('changeset_author_org_name', eitem)
             self.assertIn('changeset_author_bot', eitem)
+            self.assertIn('changeset_author_multi_org_names', eitem)
+            if eitem['changeset_author_multi_org_names']:
+                self.assertIn('changeset_author_multi_org_name_0', eitem)
 
             comments = item['data']['comments']
             ecomments = enrich_backend.get_rich_item_comments(comments, eitem)
@@ -265,6 +268,9 @@ class TestGerrit(TestBaseBackend):
                 self.assertIn('changeset_author_gender_acc', ecomment)
                 self.assertIn('changeset_author_org_name', ecomment)
                 self.assertIn('changeset_author_bot', ecomment)
+                self.assertIn('changeset_author_multi_org_names', ecomment)
+                if ecomment['changeset_author_multi_org_names']:
+                    self.assertIn('changeset_author_multi_org_name_0', ecomment)
 
             patchsets = item['data']['patchSets']
             epatchsets = enrich_backend.get_rich_item_patchsets(patchsets, eitem)
@@ -279,6 +285,9 @@ class TestGerrit(TestBaseBackend):
                 self.assertIn('changeset_author_gender_acc', epatchset)
                 self.assertIn('changeset_author_org_name', epatchset)
                 self.assertIn('changeset_author_bot', epatchset)
+                self.assertIn('changeset_author_multi_org_names', epatchset)
+                if epatchset['changeset_author_multi_org_names']:
+                    self.assertIn('changeset_author_multi_org_name_0', epatchset)
 
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -143,10 +143,14 @@ class TestGit(TestBaseBackend):
         self.assertEqual(eitem['Commit_name'], '-- UNDEFINED --')
         self.assertEqual(eitem['Commit_user_name'], '-- UNDEFINED --')
         self.assertEqual(eitem['Commit_org_name'], '-- UNDEFINED --')
+        self.assertEqual(eitem['Commit_multi_org_names'], ['-- UNDEFINED --'])
+        self.assertEqual(eitem['Commit_multi_org_name_0'], '-- UNDEFINED --')
 
         self.assertEqual(eitem['author_name'], 'Eduardo Morais')
         self.assertEqual(eitem['Author_name'], 'Eduardo Morais')
         self.assertEqual(eitem['Author_user_name'], 'Unknown')
+        self.assertEqual(eitem['Author_multi_org_names'], ['Unknown'])
+        self.assertEqual(eitem['Author_multi_org_name_0'], 'Unknown')
 
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -154,7 +154,24 @@ class TestGit(TestBaseBackend):
         """Test enrich with SortingHat"""
 
         result = self._test_raw_to_enrich(sortinghat=True)
-        # ... ?
+        self.assertGreater(result['raw'], 0)
+        self.assertGreater(result['enrich'], 0)
+        self.assertEqual(result['raw'], result['enrich'])
+
+        enrich_backend = self.connectors[self.connector][2]()
+
+        url = self.es_con + "/" + self.enrich_index + "/_search"
+        response = enrich_backend.requests.get(url, verify=False).json()
+        for hit in response['hits']['hits']:
+            source = hit['_source']
+            if 'author_uuid' in source:
+                self.assertIn('author_domain', source)
+                self.assertIn('author_gender', source)
+                self.assertIn('author_gender_acc', source)
+                self.assertIn('author_org_name', source)
+                self.assertIn('author_bot', source)
+                self.assertIn('author_multi_org_names', source)
+                self.assertIn('author_multi_org_name_0', source)
 
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""

--- a/tests/test_github2.py
+++ b/tests/test_github2.py
@@ -152,7 +152,24 @@ class TestGitHub2(TestBaseBackend):
         """Test enrich with SortingHat"""
 
         result = self._test_raw_to_enrich(sortinghat=True)
-        # ... ?
+        self.assertGreater(result['raw'], 0)
+        self.assertGreater(result['enrich'], 0)
+        self.assertGreater(result['enrich'], result['raw'])
+
+        enrich_backend = self.connectors[self.connector][2]()
+
+        url = self.es_con + "/" + self.enrich_index + "/_search"
+        response = enrich_backend.requests.get(url, verify=False).json()
+        for hit in response['hits']['hits']:
+            source = hit['_source']
+            if 'author_uuid' in source:
+                self.assertIn('author_domain', source)
+                self.assertIn('author_gender', source)
+                self.assertIn('author_gender_acc', source)
+                self.assertIn('author_org_name', source)
+                self.assertIn('author_bot', source)
+                self.assertIn('author_multi_org_names', source)
+                self.assertIn('author_multi_org_name_0', source)
 
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -165,7 +165,24 @@ class TestGitLab(TestBaseBackend):
         """Test enrich with SortingHat"""
 
         result = self._test_raw_to_enrich(sortinghat=True)
-        # ... ?
+        self.assertGreater(result['raw'], 0)
+        self.assertGreater(result['enrich'], 0)
+        self.assertEqual(result['raw'], result['enrich'])
+
+        enrich_backend = self.connectors[self.connector][2]()
+
+        url = self.es_con + "/" + self.enrich_index + "/_search"
+        response = enrich_backend.requests.get(url, verify=False).json()
+        for hit in response['hits']['hits']:
+            source = hit['_source']
+            if 'author_uuid' in source:
+                self.assertIn('author_domain', source)
+                self.assertIn('author_gender', source)
+                self.assertIn('author_gender_acc', source)
+                self.assertIn('author_org_name', source)
+                self.assertIn('author_bot', source)
+                self.assertIn('author_multi_org_names', source)
+                self.assertIn('author_multi_org_name_0', source)
 
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""

--- a/tests/test_groupsio.py
+++ b/tests/test_groupsio.py
@@ -76,6 +76,21 @@ class TestGrousio(TestBaseBackend):
         self.assertEqual(result['raw'], 50)
         self.assertEqual(result['enrich'], 50)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        url = self.es_con + "/" + self.enrich_index + "/_search"
+        response = enrich_backend.requests.get(url, verify=False).json()
+        for hit in response['hits']['hits']:
+            source = hit['_source']
+            if 'author_uuid' in source:
+                self.assertIn('author_domain', source)
+                self.assertIn('author_gender', source)
+                self.assertIn('author_gender_acc', source)
+                self.assertIn('author_org_name', source)
+                self.assertIn('author_bot', source)
+                self.assertIn('author_multi_org_names', source)
+                self.assertIn('author_multi_org_name_0', source)
+
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 

--- a/tests/test_hyperkitty.py
+++ b/tests/test_hyperkitty.py
@@ -85,6 +85,21 @@ class TestHyperkitty(TestBaseBackend):
         self.assertEqual(result['raw'], 3)
         self.assertEqual(result['enrich'], 3)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        url = self.es_con + "/" + self.enrich_index + "/_search"
+        response = enrich_backend.requests.get(url, verify=False).json()
+        for hit in response['hits']['hits']:
+            source = hit['_source']
+            if 'author_uuid' in source:
+                self.assertIn('author_domain', source)
+                self.assertIn('author_gender', source)
+                self.assertIn('author_gender_acc', source)
+                self.assertIn('author_org_name', source)
+                self.assertIn('author_bot', source)
+                self.assertIn('author_multi_org_names', source)
+                self.assertIn('author_multi_org_name_0', source)
+
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 

--- a/tests/test_jenkins.py
+++ b/tests/test_jenkins.py
@@ -84,25 +84,12 @@ class TestJenkins(TestBaseBackend):
         enrich_backend = self.connectors[self.connector][2]()
         self.assertFalse(enrich_backend.has_identities())
 
-    def test_raw_to_enrich_sorting_hat(self):
-        """Test enrich with SortingHat"""
-
-        result = self._test_raw_to_enrich(sortinghat=True)
-        self.assertEqual(result['raw'], 32)
-        self.assertEqual(result['enrich'], 32)
-
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 
         result = self._test_raw_to_enrich(projects=True)
         self.assertEqual(result['raw'], 32)
         self.assertEqual(result['enrich'], 32)
-
-    def test_refresh_identities(self):
-        """Test refresh identities"""
-
-        result = self._test_refresh_identities()
-        # ... ?
 
     def test_refresh_project(self):
         """Test refresh project field for all sources"""

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -143,6 +143,8 @@ class TestJira(TestBaseBackend):
         self.assertEqual(eitem['author_org_name'], 'Unknown')
         self.assertEqual(eitem['author_user_name'], 'Unknown')
         self.assertEqual(eitem['author_type'], 'creator')
+        self.assertEqual(eitem['author_multi_org_names'], ['Unknown'])
+        self.assertEqual(eitem['author_multi_org_name_0'], 'Unknown')
 
         item = self.items[0]
         eitem = enrich_backend.get_rich_item(item, author_type='assignee')
@@ -150,6 +152,8 @@ class TestJira(TestBaseBackend):
         self.assertEqual(eitem['author_org_name'], 'Unknown')
         self.assertEqual(eitem['author_user_name'], 'peter')
         self.assertEqual(eitem['author_type'], 'assignee')
+        self.assertEqual(eitem['author_multi_org_names'], ['Unknown'])
+        self.assertEqual(eitem['author_multi_org_name_0'], 'Unknown')
 
         item = self.items[0]
         eitem = enrich_backend.get_rich_item(item, author_type='reporter')
@@ -157,6 +161,8 @@ class TestJira(TestBaseBackend):
         self.assertEqual(eitem['author_org_name'], 'Unknown')
         self.assertEqual(eitem['author_user_name'], 'maoo')
         self.assertEqual(eitem['author_type'], 'reporter')
+        self.assertEqual(eitem['author_multi_org_names'], ['Unknown'])
+        self.assertEqual(eitem['author_multi_org_name_0'], 'Unknown')
 
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""

--- a/tests/test_kitsune.py
+++ b/tests/test_kitsune.py
@@ -70,6 +70,21 @@ class TestKitsune(TestBaseBackend):
         self.assertEqual(result['raw'], 4)
         self.assertEqual(result['enrich'], 9)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        url = self.es_con + "/" + self.enrich_index + "/_search"
+        response = enrich_backend.requests.get(url, verify=False).json()
+        for hit in response['hits']['hits']:
+            source = hit['_source']
+            if 'author_uuid' in source:
+                self.assertIn('author_domain', source)
+                self.assertIn('author_gender', source)
+                self.assertIn('author_gender_acc', source)
+                self.assertIn('author_org_name', source)
+                self.assertIn('author_bot', source)
+                self.assertIn('author_multi_org_names', source)
+                self.assertIn('author_multi_org_name_0', source)
+
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 

--- a/tests/test_mattermost.py
+++ b/tests/test_mattermost.py
@@ -78,6 +78,21 @@ class TestMattermost(TestBaseBackend):
         self.assertEqual(result['raw'], 89)
         self.assertEqual(result['enrich'], 89)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        url = self.es_con + "/" + self.enrich_index + "/_search"
+        response = enrich_backend.requests.get(url, verify=False).json()
+        for hit in response['hits']['hits']:
+            source = hit['_source']
+            if 'author_uuid' in source:
+                self.assertIn('author_domain', source)
+                self.assertIn('author_gender', source)
+                self.assertIn('author_gender_acc', source)
+                self.assertIn('author_org_name', source)
+                self.assertIn('author_bot', source)
+                self.assertIn('author_multi_org_names', source)
+                self.assertIn('author_multi_org_name_0', source)
+
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 

--- a/tests/test_mbox.py
+++ b/tests/test_mbox.py
@@ -112,6 +112,21 @@ class TestMbox(TestBaseBackend):
         self.assertEqual(result['raw'], 9)
         self.assertEqual(result['enrich'], 9)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        url = self.es_con + "/" + self.enrich_index + "/_search"
+        response = enrich_backend.requests.get(url, verify=False).json()
+        for hit in response['hits']['hits']:
+            source = hit['_source']
+            if 'author_uuid' in source:
+                self.assertIn('author_domain', source)
+                self.assertIn('author_gender', source)
+                self.assertIn('author_gender_acc', source)
+                self.assertIn('author_org_name', source)
+                self.assertIn('author_bot', source)
+                self.assertIn('author_multi_org_names', source)
+                self.assertIn('author_multi_org_name_0', source)
+
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 

--- a/tests/test_mediawiki.py
+++ b/tests/test_mediawiki.py
@@ -174,6 +174,21 @@ class TestMediawiki(TestBaseBackend):
         self.assertEqual(result['raw'], 3)
         self.assertEqual(result['enrich'], 8)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        url = self.es_con + "/" + self.enrich_index + "/_search"
+        response = enrich_backend.requests.get(url, verify=False).json()
+        for hit in response['hits']['hits']:
+            source = hit['_source']
+            if 'author_uuid' in source:
+                self.assertIn('author_domain', source)
+                self.assertIn('author_gender', source)
+                self.assertIn('author_gender_acc', source)
+                self.assertIn('author_org_name', source)
+                self.assertIn('author_bot', source)
+                self.assertIn('author_multi_org_names', source)
+                self.assertIn('author_multi_org_name_0', source)
+
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 

--- a/tests/test_meetup.py
+++ b/tests/test_meetup.py
@@ -82,6 +82,21 @@ class TestMeetup(TestBaseBackend):
         self.assertEqual(result['raw'], 3)
         self.assertEqual(result['enrich'], 19)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        url = self.es_con + "/" + self.enrich_index + "/_search"
+        response = enrich_backend.requests.get(url, verify=False).json()
+        for hit in response['hits']['hits']:
+            source = hit['_source']
+            if 'author_uuid' in source:
+                self.assertIn('author_domain', source)
+                self.assertIn('author_gender', source)
+                self.assertIn('author_gender_acc', source)
+                self.assertIn('author_org_name', source)
+                self.assertIn('author_bot', source)
+                self.assertIn('author_multi_org_names', source)
+                self.assertIn('author_multi_org_name_0', source)
+
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 

--- a/tests/test_mozillaclub.py
+++ b/tests/test_mozillaclub.py
@@ -89,6 +89,21 @@ class TestMozillaClub(TestBaseBackend):
         self.assertEqual(result['raw'], 91)
         self.assertEqual(result['enrich'], 91)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        url = self.es_con + "/" + self.enrich_index + "/_search"
+        response = enrich_backend.requests.get(url, verify=False).json()
+        for hit in response['hits']['hits']:
+            source = hit['_source']
+            if 'author_uuid' in source:
+                self.assertIn('author_domain', source)
+                self.assertIn('author_gender', source)
+                self.assertIn('author_gender_acc', source)
+                self.assertIn('author_org_name', source)
+                self.assertIn('author_bot', source)
+                self.assertIn('author_multi_org_names', source)
+                self.assertIn('author_multi_org_name_0', source)
+
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 

--- a/tests/test_nntp.py
+++ b/tests/test_nntp.py
@@ -97,6 +97,21 @@ class TestNNTP(TestBaseBackend):
         self.assertEqual(result['raw'], 6)
         self.assertEqual(result['enrich'], 6)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        url = self.es_con + "/" + self.enrich_index + "/_search"
+        response = enrich_backend.requests.get(url, verify=False).json()
+        for hit in response['hits']['hits']:
+            source = hit['_source']
+            if 'author_uuid' in source:
+                self.assertIn('author_domain', source)
+                self.assertIn('author_gender', source)
+                self.assertIn('author_gender_acc', source)
+                self.assertIn('author_org_name', source)
+                self.assertIn('author_bot', source)
+                self.assertIn('author_multi_org_names', source)
+                self.assertIn('author_multi_org_name_0', source)
+
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 

--- a/tests/test_phabricator.py
+++ b/tests/test_phabricator.py
@@ -70,6 +70,21 @@ class TestPhabricator(TestBaseBackend):
         self.assertEqual(result['raw'], 4)
         self.assertEqual(result['enrich'], 4)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        url = self.es_con + "/" + self.enrich_index + "/_search"
+        response = enrich_backend.requests.get(url, verify=False).json()
+        for hit in response['hits']['hits']:
+            source = hit['_source']
+            if 'author_uuid' in source:
+                self.assertIn('author_domain', source)
+                self.assertIn('author_gender', source)
+                self.assertIn('author_gender_acc', source)
+                self.assertIn('author_org_name', source)
+                self.assertIn('author_bot', source)
+                self.assertIn('author_multi_org_names', source)
+                self.assertIn('author_multi_org_name_0', source)
+
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 

--- a/tests/test_pipermail.py
+++ b/tests/test_pipermail.py
@@ -80,6 +80,21 @@ class TestPipermail(TestBaseBackend):
         self.assertEqual(result['raw'], 17)
         self.assertEqual(result['enrich'], 17)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        url = self.es_con + "/" + self.enrich_index + "/_search"
+        response = enrich_backend.requests.get(url, verify=False).json()
+        for hit in response['hits']['hits']:
+            source = hit['_source']
+            if 'author_uuid' in source:
+                self.assertIn('author_domain', source)
+                self.assertIn('author_gender', source)
+                self.assertIn('author_gender_acc', source)
+                self.assertIn('author_org_name', source)
+                self.assertIn('author_bot', source)
+                self.assertIn('author_multi_org_names', source)
+                self.assertIn('author_multi_org_name_0', source)
+
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 

--- a/tests/test_puppetforge.py
+++ b/tests/test_puppetforge.py
@@ -70,6 +70,21 @@ class TestPuppetForge(TestBaseBackend):
         self.assertEqual(result['raw'], 3)
         self.assertEqual(result['enrich'], 3)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        url = self.es_con + "/" + self.enrich_index + "/_search"
+        response = enrich_backend.requests.get(url, verify=False).json()
+        for hit in response['hits']['hits']:
+            source = hit['_source']
+            if 'author_uuid' in source:
+                self.assertIn('author_domain', source)
+                self.assertIn('author_gender', source)
+                self.assertIn('author_gender_acc', source)
+                self.assertIn('author_org_name', source)
+                self.assertIn('author_bot', source)
+                self.assertIn('author_multi_org_names', source)
+                self.assertIn('author_multi_org_name_0', source)
+
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 

--- a/tests/test_redmine.py
+++ b/tests/test_redmine.py
@@ -84,6 +84,21 @@ class TestRedmine(TestBaseBackend):
         self.assertEqual(result['raw'], 3)
         self.assertEqual(result['enrich'], 3)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        url = self.es_con + "/" + self.enrich_index + "/_search"
+        response = enrich_backend.requests.get(url, verify=False).json()
+        for hit in response['hits']['hits']:
+            source = hit['_source']
+            if 'author_uuid' in source:
+                self.assertIn('author_domain', source)
+                self.assertIn('author_gender', source)
+                self.assertIn('author_gender_acc', source)
+                self.assertIn('author_org_name', source)
+                self.assertIn('author_bot', source)
+                self.assertIn('author_multi_org_names', source)
+                self.assertIn('author_multi_org_name_0', source)
+
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 

--- a/tests/test_remo.py
+++ b/tests/test_remo.py
@@ -70,6 +70,21 @@ class TestRemo(TestBaseBackend):
         self.assertEqual(result['raw'], 1)
         self.assertEqual(result['enrich'], 1)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        url = self.es_con + "/" + self.enrich_index + "/_search"
+        response = enrich_backend.requests.get(url, verify=False).json()
+        for hit in response['hits']['hits']:
+            source = hit['_source']
+            if 'author_uuid' in source:
+                self.assertIn('author_domain', source)
+                self.assertIn('author_gender', source)
+                self.assertIn('author_gender_acc', source)
+                self.assertIn('author_org_name', source)
+                self.assertIn('author_bot', source)
+                self.assertIn('author_multi_org_names', source)
+                self.assertIn('author_multi_org_name_0', source)
+
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -70,6 +70,21 @@ class TestRSS(TestBaseBackend):
         self.assertEqual(result['raw'], 30)
         self.assertEqual(result['enrich'], 30)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        url = self.es_con + "/" + self.enrich_index + "/_search"
+        response = enrich_backend.requests.get(url, verify=False).json()
+        for hit in response['hits']['hits']:
+            source = hit['_source']
+            if 'author_uuid' in source:
+                self.assertIn('author_domain', source)
+                self.assertIn('author_gender', source)
+                self.assertIn('author_gender_acc', source)
+                self.assertIn('author_org_name', source)
+                self.assertIn('author_bot', source)
+                self.assertIn('author_multi_org_names', source)
+                self.assertIn('author_multi_org_name_0', source)
+
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -95,18 +95,24 @@ class TestSlack(TestBaseBackend):
         self.assertEqual(eitem['author_name'], 'Unknown')
         self.assertEqual(eitem['author_user_name'], 'Unknown')
         self.assertEqual(eitem['author_org_name'], 'Unknown')
+        self.assertEqual(eitem['author_multi_org_names'], ['Unknown'])
+        self.assertEqual(eitem['author_multi_org_name_0'], 'Unknown')
 
         item = self.items[1]
         eitem = enrich_backend.get_rich_item(item)
-        self.assertTrue('author_name' not in eitem)
-        self.assertTrue('author_user_name' not in eitem)
-        self.assertTrue('author_org_name' not in eitem)
+        self.assertNotIn('author_name', eitem)
+        self.assertNotIn('author_user_name', eitem)
+        self.assertNotIn('author_org_name', eitem)
+        self.assertNotIn('author_multi_org_names', eitem)
+        self.assertNotIn('author_multi_org_name_0', eitem)
 
         item = self.items[2]
         eitem = enrich_backend.get_rich_item(item)
         self.assertNotEqual(eitem['author_name'], 'Unknown')
         self.assertNotEqual(eitem['author_user_name'], 'Unknown')
         self.assertEqual(eitem['author_org_name'], 'Unknown')
+        self.assertEqual(eitem['author_multi_org_names'], ['Unknown'])
+        self.assertEqual(eitem['author_multi_org_name_0'], 'Unknown')
 
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""

--- a/tests/test_stackexchange.py
+++ b/tests/test_stackexchange.py
@@ -71,6 +71,21 @@ class TestStackexchange(TestBaseBackend):
         self.assertEqual(result['raw'], 3)
         self.assertEqual(result['enrich'], 6)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        url = self.es_con + "/" + self.enrich_index + "/_search"
+        response = enrich_backend.requests.get(url, verify=False).json()
+        for hit in response['hits']['hits']:
+            source = hit['_source']
+            if 'author_uuid' in source:
+                self.assertIn('author_domain', source)
+                self.assertIn('author_gender', source)
+                self.assertIn('author_gender_acc', source)
+                self.assertIn('author_org_name', source)
+                self.assertIn('author_bot', source)
+                self.assertIn('author_multi_org_names', source)
+                self.assertIn('author_multi_org_name_0', source)
+
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 

--- a/tests/test_supybot.py
+++ b/tests/test_supybot.py
@@ -71,6 +71,21 @@ class TestSupybot(TestBaseBackend):
         self.assertEqual(result['raw'], 16)
         self.assertEqual(result['enrich'], 16)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        url = self.es_con + "/" + self.enrich_index + "/_search"
+        response = enrich_backend.requests.get(url, verify=False).json()
+        for hit in response['hits']['hits']:
+            source = hit['_source']
+            if 'author_uuid' in source:
+                self.assertIn('author_domain', source)
+                self.assertIn('author_gender', source)
+                self.assertIn('author_gender_acc', source)
+                self.assertIn('author_org_name', source)
+                self.assertIn('author_bot', source)
+                self.assertIn('author_multi_org_names', source)
+                self.assertIn('author_multi_org_name_0', source)
+
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -96,6 +96,21 @@ class TestTelegram(TestBaseBackend):
         self.assertEqual(result['raw'], 6)
         self.assertEqual(result['enrich'], 6)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        url = self.es_con + "/" + self.enrich_index + "/_search"
+        response = enrich_backend.requests.get(url, verify=False).json()
+        for hit in response['hits']['hits']:
+            source = hit['_source']
+            if 'author_uuid' in source:
+                self.assertIn('author_domain', source)
+                self.assertIn('author_gender', source)
+                self.assertIn('author_gender_acc', source)
+                self.assertIn('author_org_name', source)
+                self.assertIn('author_bot', source)
+                self.assertIn('author_multi_org_names', source)
+                self.assertIn('author_multi_org_name_0', source)
+
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 

--- a/tests/test_twitter.py
+++ b/tests/test_twitter.py
@@ -71,6 +71,21 @@ class TestTwitter(TestBaseBackend):
         self.assertEqual(result['raw'], 5)
         self.assertEqual(result['enrich'], 5)
 
+        enrich_backend = self.connectors[self.connector][2]()
+
+        url = self.es_con + "/" + self.enrich_index + "/_search"
+        response = enrich_backend.requests.get(url, verify=False).json()
+        for hit in response['hits']['hits']:
+            source = hit['_source']
+            if 'author_uuid' in source:
+                self.assertIn('author_domain', source)
+                self.assertIn('author_gender', source)
+                self.assertIn('author_gender_acc', source)
+                self.assertIn('author_org_name', source)
+                self.assertIn('author_bot', source)
+                self.assertIn('author_multi_org_names', source)
+                self.assertIn('author_multi_org_name_0', source)
+
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 


### PR DESCRIPTION
This code allows to store in the enriched indexes information of multiple affiliations. Such a data is stored:
- as a list in the sortinghat-related attribute `<rol>_multi_org_names`
  Ex.: author_multi_org_names
- as single sortinghat-related attributes `<rol>_multi_org_name_<num>`
  Ex.: author_multi_org_name_0, author_mult_org_name_1

The code that deals with the identities refresh has been modified as well (https://github.com/chaoss/grimoirelab-elk/commit/20ea441550cb200b5f811b25940bbe7cc20f4de6#diff-a94b51d8c8a4c2e33e52cff8968a0b3c) to make sure that the affiliations stored in the list `<rol>_multi_org_names` is aligned with the attributes `<rol>_multi_org_name_<num>`. The change consists of removing the attributes `<rol>_multi_org_name_<num>` and add them again. It was need to cover the cases when the number of affiliations decreases. In this scenario, the attributes `<rol>_multi_org_name_<num>` with `<num`> greater than the new list size `<rol>_multi_org_names` were not modified/updated, thus introducing a misalignment between the list and single attributes.

Tests have been updated accordingly. Special cases are Jira and Gerrit, which have been separated in different commits (to ease the review).

Schemas have not been updated.
Once the PR is accepted, the index patterns in Sigils should be updated.

Related to: https://github.com/chaoss/grimoirelab-cereslib/pull/28