### PR TITLE
added warning for trailing slashes in URL

### DIFF
--- a/grimoire_elk/raw/github.py
+++ b/grimoire_elk/raw/github.py
@@ -21,7 +21,9 @@
 
 from .elastic import ElasticOcean
 from ..elastic_mapping import Mapping as BaseMapping
+import logging
 
+logger = logging.getLogger(__name__)
 
 class Mapping(BaseMapping):
 
@@ -92,6 +94,10 @@ class GitHubOcean(ElasticOcean):
     def get_perceval_params_from_url(cls, url):
         """ Get the perceval params given a URL for the data source """
         params = []
+
+        if url[-1] == '/':
+            logger.error('Please remove trailing forward slash (/) from the URL.')
+            return None
 
         owner = url.split('/')[-2]
         repository = url.split('/')[-1]


### PR DESCRIPTION
Encountered an error where the github backend would consider owner of the repository as its name and repository argument was left empty because of an extra forward slash (/) in the URL of repositories in `projects.json` (which is pretty common while copying and pasting a URL). Thought of adding this warning if this situation occurs.
Signed-off-by: Nitish Gupta <imnitish.ng@gmail.com>