### PR TITLE
Make anonymization optional for each backend

### DIFF
--- a/grimoire_elk/elk.py
+++ b/grimoire_elk/elk.py
@@ -48,7 +48,8 @@ requests_ses = grimoire_con()
 
 def feed_backend(url, clean, fetch_archive, backend_name, backend_params,
                  es_index=None, es_index_enrich=None, project=None,
-                 es_aliases=None, projects_json_repo=None, repo_labels=None):
+                 es_aliases=None, projects_json_repo=None, repo_labels=None,
+                 anonymize=False):
     """ Feed Ocean with backend data """
 
     error_msg = None
@@ -94,7 +95,7 @@ def feed_backend(url, clean, fetch_archive, backend_name, backend_params,
         backend_cmd.backend = backend_cmd.BACKEND(**init_args)
         backend = backend_cmd.backend
 
-        ocean_backend = connector[1](backend, fetch_archive=fetch_archive, project=project)
+        ocean_backend = connector[1](backend, fetch_archive=fetch_archive, project=project, anonymize=anonymize)
         elastic_ocean = get_elastic(url, es_index, clean, ocean_backend, es_aliases)
         ocean_backend.set_elastic(elastic_ocean)
         ocean_backend.set_repo_labels(repo_labels)

--- a/grimoire_elk/raw/elastic.py
+++ b/grimoire_elk/raw/elastic.py
@@ -57,12 +57,13 @@ class ElasticOcean(ElasticItems):
                             help="Host with elastic search and enriched indexes")
 
     def __init__(self, perceval_backend, from_date=None, fetch_archive=False,
-                 project=None, insecure=True, offset=None):
+                 project=None, insecure=True, offset=None, anonymize=False):
 
         super().__init__(perceval_backend, from_date, insecure, offset)
 
         self.fetch_archive = fetch_archive  # fetch from archive
         self.project = project  # project to be used for this data source
+        self.anonymize = anonymize
 
     def set_elastic_url(self, url):
         """ Elastic URL """
@@ -139,6 +140,11 @@ class ElasticOcean(ElasticItems):
 
     def _fix_item(self, item):
         """ Some buggy data sources need fixing (like mbox and message-id) """
+        pass
+
+    def _anonymize_item(self, item):
+        """ Remove or hash the fields that contain personal information """
+        # TODO: Question: raise exception if not implemented? or just pass?
         pass
 
     def add_update_date(self, item):
@@ -245,6 +251,8 @@ class ElasticOcean(ElasticItems):
             self._fix_item(item)
             if self.project:
                 item['project'] = self.project
+            if self.anonymize:
+                self._anonymize_item(item)
             if len(items_pack) >= self.elastic.max_items_bulk:
                 self._items_to_es(items_pack)
                 items_pack = []

--- a/tests/base.py
+++ b/tests/base.py
@@ -67,6 +67,9 @@ def data2es(items, ocean):
         except KeyError:
             pass
 
+        if ocean.anonymize:
+            ocean._anonymize_item(item)
+
         return item
 
     items_pack = []  # to feed item in packs
@@ -284,3 +287,37 @@ class TestBaseBackend(unittest.TestCase):
                 break
 
         return found
+
+    def _test_items_to_raw_anonymized(self):
+        clean = True
+        perceval_backend = None
+        self.ocean_backend = self.connectors[self.connector][1](perceval_backend, anonymize=True)
+        elastic_ocean = get_elastic(self.es_con, self.ocean_index_anonymized, clean, self.ocean_backend,
+                                    self.ocean_aliases)
+        self.ocean_backend.set_elastic(elastic_ocean)
+
+        raw_items = data2es(self.items, self.ocean_backend)
+
+        return {'items': len(self.items), 'raw': raw_items}
+
+    def _test_raw_to_enrich_anonymized(self, sortinghat=False, projects=False):
+        """Test whether raw indexes are properly enriched"""
+
+        # populate raw index
+        perceval_backend = None
+        clean = True
+        self.ocean_backend = self.connectors[self.connector][1](perceval_backend, anonymize=True)
+        elastic_ocean = get_elastic(self.es_con, self.ocean_index_anonymized, clean, self.ocean_backend)
+        self.ocean_backend.set_elastic(elastic_ocean)
+        data2es(self.items, self.ocean_backend)
+
+        # populate enriched index
+        self.enrich_backend = self.connectors[self.connector][2]()
+
+        elastic_enrich = get_elastic(self.es_con, self.enrich_index_anonymized, clean, self.enrich_backend, self.enrich_aliases)
+        self.enrich_backend.set_elastic(elastic_enrich)
+
+        raw_count = len([item for item in self.ocean_backend.fetch()])
+        enrich_count = self.enrich_backend.enrich_items(self.ocean_backend)
+
+        return {'raw': raw_count, 'enrich': enrich_count}

--- a/tests/test_meetup.py
+++ b/tests/test_meetup.py
@@ -33,6 +33,8 @@ class TestMeetup(TestBaseBackend):
     connector = "meetup"
     ocean_index = "test_" + connector
     enrich_index = "test_" + connector + "_enrich"
+    ocean_index_anonymized = "test_" + connector + "_anonymized"
+    enrich_index_anonymized = "test_" + connector + "_enrich_anonymized"
 
     def test_has_identites(self):
         """Test value of has_identities method"""
@@ -125,6 +127,38 @@ class TestMeetup(TestBaseBackend):
             "South-East-Puppet-User-Group"
         ]
         self.assertListEqual(MeetupOcean.get_perceval_params_from_url(url), expected_params)
+
+    def test_items_to_raw_anonymized(self):
+        """Test whether JSON items are properly inserted into ES anonymized"""
+
+        result = self._test_items_to_raw_anonymized()
+
+        self.assertGreater(result['items'], 0)
+        self.assertGreater(result['raw'], 0)
+        self.assertEqual(result['items'], result['raw'])
+
+        item = self.items[0]['data']
+        self.assertEqual(item['event_hosts'][0]['name'], '3b3e55fdc7886baea165a854d080caf9808cac97')
+        self.assertEqual(item['rsvps'][0]['member']['name'], '3b3e55fdc7886baea165a854d080caf9808cac97')
+        self.assertEqual(item['rsvps'][1]['member']['name'], '9b0740c20617be08bd6b81a02017e63235cc0204')
+        self.assertEqual(item['rsvps'][2]['member']['name'], 'cbd5438b1e1084c1d85bec65a96ca566d9b2ef2e')
+
+        item = self.items[1]['data']
+        self.assertEqual(item['event_hosts'][0]['name'], 'aff2cc6caa4228a709ac3bba6b303c7e5dcce550')
+        self.assertEqual(item['event_hosts'][1]['name'], '3b3e55fdc7886baea165a854d080caf9808cac97')
+        self.assertEqual(item['rsvps'][0]['member']['name'], '3b3e55fdc7886baea165a854d080caf9808cac97')
+        self.assertEqual(item['rsvps'][1]['member']['name'], '9b0740c20617be08bd6b81a02017e63235cc0204')
+        self.assertEqual(item['rsvps'][2]['member']['name'], 'cbd5438b1e1084c1d85bec65a96ca566d9b2ef2e')
+        self.assertEqual(item['comments'][0]['member']['name'], '58668e7669fd564d99db5d581fcdb6a5618440b5')
+        self.assertEqual(item['comments'][1]['member']['name'], 'c96634ae1100ab91de991e40bb2fe656bd765de1')
+
+    def test_raw_to_enrich_anonymized(self):
+        """Test whether the raw index is properly enriched"""
+
+        result = self._test_raw_to_enrich_anonymized()
+
+        self.assertEqual(result['raw'], 3)
+        self.assertEqual(result['enrich'], 19)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We need a way to anonymize the personal information that comes from Perceval: names, emails and information that may be related to the users of each backend must be hidden.

The information stored in the Elasticsearch indexes should only be identifiers that cannot be related directly with the user.

In this merge request, information related with the users is hashed or removed.

You can set the parameter `anonymize` to true in the sirmordred configuration:
```
[git]
...
anonymize = true

[github]
...
filter-classified = true
anonymize = true

[gitlab]
...
anonymize = true

[meetup]
...
anonymize = true
```

Related with https://github.com/chaoss/grimoirelab-elk/issues/822

Depends on https://github.com/chaoss/grimoirelab-elk/pull/823