### PR TITLE
[enriched-meetup] Handle event without geolocation

### DIFF
--- a/grimoire_elk/enriched/meetup.py
+++ b/grimoire_elk/enriched/meetup.py
@@ -210,10 +210,12 @@ class MeetupEnrich(Enrich):
                 else:
                     eitem[f] = None
 
-            eitem['venue_geolocation'] = {
-                "lat": event['venue']['lat'],
-                "lon": event['venue']['lon'],
-            }
+            eitem['venue_geolocation'] = None
+            if 'lat' in event['venue'] and 'lon' in event['venue']:
+                eitem['venue_geolocation'] = {
+                    "lat": event['venue']['lat'],
+                    "lon": event['venue']['lon']
+                }
 
         if 'series' in event:
             eitem['series_id'] = event['series']['id']

--- a/releases/unreleased/fix-missing-geolocation-in-meetup-event.yml
+++ b/releases/unreleased/fix-missing-geolocation-in-meetup-event.yml
@@ -1,0 +1,10 @@
+---
+title: Fix missing geolocation in Meetup event
+category: fixed
+author: Valerio Cosentino <valcos@bitergia.com>
+issue: 826
+notes: >
+  This fix allows to process Meetup events for which
+  geolocation information isn't provided. For these
+  events, the corresponding attribute in the enriched
+  index (`venue_geolocation`) is set to None.

--- a/tests/data/meetup.json
+++ b/tests/data/meetup.json
@@ -330,9 +330,6 @@
             "city": "Madrid",
             "country": "es",
             "id": 24442542,
-            "lat": 40.46653747558594,
-            "localized_country_name": "Spain",
-            "lon": -3.654146909713745,
             "name": "Gran V\u00eda Open Future (Espacio Wayra)",
             "repinned": false
         },

--- a/tests/test_meetup.py
+++ b/tests/test_meetup.py
@@ -66,6 +66,17 @@ class TestMeetup(TestBaseBackend):
         self.assertEqual(eitem['group_created'], '2016-03-20T15:13:47+00:00')
         self.assertEqual(eitem['group_urlname'], 'sqlpass-es')
         self.assertEqual(eitem['author_uuid'], '029aa3befc96d386e1c7270586f1ec1d673b0b1b')
+        self.assertIsNone(eitem['venue_geolocation'])
+
+        item = self.items[1]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['meetup_created'], '2016-05-31T17:30:48+00:00')
+        self.assertEqual(eitem['meetup_time'], '2016-06-09T16:45:00+00:00')
+        self.assertEqual(eitem['meetup_updated'], '2016-06-09T20:18:18+00:00')
+        self.assertEqual(eitem['group_created'], '2016-03-20T15:13:47+00:00')
+        self.assertEqual(eitem['group_urlname'], 'sqlpass-es')
+        self.assertEqual(eitem['author_uuid'], '810d53ef4a9ae2ebd8064ac690b2e13cfc2df924')
+        self.assertIsNotNone(eitem['venue_geolocation'])
 
     def test_enrich_repo_labels(self):
         """Test whether the field REPO_LABELS is present in the enriched items"""


### PR DESCRIPTION
This code handles the meetup events for which the geolocation isn't provided. Thus, for these events the venue_geolocation is set to None.

Tests have been added accordingly.

Fixes #826 