### PR TITLE
[travis] Upgrade setuptools and pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ jobs:
 
       before_install:
         - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.1.0.deb && sudo dpkg -i --force-confnew elasticsearch-6.1.0.deb && sudo service elasticsearch restart
+        - pip install --upgrade setuptools
+        - pip install --upgrade pip
         - pip install flake8
         - pip install coveralls
         - pip install -r "requirements.txt"
@@ -98,6 +100,8 @@ jobs:
         - echo -e '-XX:+DisableExplicitGC\n-Djdk.io.permissionsUseCanonicalPath=true\n-Dlog4j.skipJansi=true\n-server\n' | sudo tee -a /etc/elasticsearch/jvm.options
         - sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
         - sudo systemctl start elasticsearch
+        - pip install --upgrade setuptools
+        - pip install --upgrade pip
         - pip install flake8
         - pip install coveralls
         - pip install -r "requirements.txt"


### PR DESCRIPTION
This code upgrades the setuptools and pip. This change
is needed to fix the CI tests that were failing due
to the following error:
```
Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/setuptools/sandbox.py", line 154, in save_modules
        yield saved
      File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/setuptools/sandbox.py", line 195, in setup_context
        yield
      File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/setuptools/sandbox.py", line 250, in run_setup
        _execfile(setup_script, ns)
      File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/setuptools/sandbox.py", line 44, in _execfile
        code = compile(script, filename, 'exec')
      File "/tmp/easy_install-wu9lgsxc/pandoc-2.0a4/setup.py", line 11
        error = f"pip is not installed, refer to <{url}> for instructions."
                                                                          ^
    SyntaxError: invalid syntax
```

Signed-off-by: Valerio Cosentino <valcos@bitergia.com>