### PR TITLE
[enriched-bugzillarest] Add new field `is_open`

### DIFF
--- a/grimoire_elk/enriched/bugzillarest.py
+++ b/grimoire_elk/enriched/bugzillarest.py
@@ -140,6 +140,9 @@ class BugzillaRESTEnrich(Enrich):
         eitem['time_to_last_update_days'] = None
         eitem['url'] = None
 
+        # Add the field to know if the ticket is open
+        eitem['is_open'] = issue.get('is_open', None)
+
         if 'long_desc' in issue:
             eitem['number_of_comments'] = len(issue['long_desc'])
         if 'comments' in issue:

--- a/schema/bugzilla.csv
+++ b/schema/bugzilla.csv
@@ -25,6 +25,7 @@ creation_date,date
 delta_ts,date
 grimoire_creation_date,date
 is_bugzilla_bug,long
+is_open,boolean
 labels,list
 main_description,keyword
 metadata__enriched_on,date

--- a/tests/test_bugzillarest.py
+++ b/tests/test_bugzillarest.py
@@ -65,6 +65,7 @@ class TestBugzillaRest(TestBaseBackend):
         self.assertIn('main_description_analyzed', eitem)
         self.assertIn('summary', eitem)
         self.assertIn('summary_analyzed', eitem)
+        self.assertIn('is_open', eitem)
 
     def test_enrich_repo_labels(self):
         """Test whether the field REPO_LABELS is present in the enriched items"""


### PR DESCRIPTION
This code add the field `is_open` to know if the tiket is open.

Signed-off-by: Quan Zhou <quan@bitergia.com>