### PR TITLE
[grimoire_elk] Replace datetime/dateutil calls with toolkit

### DIFF
--- a/grimoire_elk/elk.py
+++ b/grimoire_elk/elk.py
@@ -24,12 +24,9 @@ import logging
 
 from elasticsearch import Elasticsearch
 
-from datetime import datetime
-from dateutil import parser
-
 from perceval.backend import find_signature_parameters, Archive
 from perceval.errors import RateLimitError
-from grimoirelab_toolkit.datetime import datetime_utcnow
+from grimoirelab_toolkit.datetime import (datetime_utcnow, str_to_datetime)
 
 from .elastic_mapping import Mapping as BaseMapping
 from .elastic_items import ElasticItems
@@ -70,7 +67,7 @@ def feed_backend(url, clean, fetch_archive, backend_name, backend_params,
         if not es_index:
             logger.error("Raw index not defined for {}".format(backend_name))
 
-        repo['repo_update_start'] = datetime.now().isoformat()
+        repo['repo_update_start'] = datetime_utcnow().isoformat()
 
         # perceval backends fetch params
         offset = None
@@ -158,7 +155,7 @@ def feed_backend(url, clean, fetch_archive, backend_name, backend_params,
             params['branches'] = branches
         if filter_classified:
             params['filter_classified'] = filter_classified
-        if from_date and (from_date.replace(tzinfo=None) != parser.parse("1970-01-01")):
+        if from_date and (from_date.replace(tzinfo=None) != str_to_datetime("1970-01-01")):
             params['from_date'] = from_date
         if offset:
             params['from_offset'] = offset
@@ -360,7 +357,7 @@ def get_ocean_backend(backend_cmd, enrich_backend, no_incremental, filter_raw=No
         if params:
             try:
                 date_pos = params.index('--from-date')
-                last_enrich = parser.parse(params[date_pos + 1])
+                last_enrich = str_to_datetime(params[date_pos + 1])
             except ValueError:
                 pass
         if last_enrich:

--- a/grimoire_elk/enriched/crates.py
+++ b/grimoire_elk/enriched/crates.py
@@ -23,11 +23,9 @@ import logging
 
 from copy import deepcopy
 
-from dateutil import parser
-
 from .enrich import Enrich, metadata
 from ..elastic_mapping import Mapping as BaseMapping
-
+from grimoirelab_toolkit.datetime import str_to_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -117,7 +115,7 @@ class CratesEnrich(Enrich):
             event = deepcopy(eitem)
             event['download_sample_id'] = sample['id']
             event['sample_date'] = sample['date']
-            sample_date = parser.parse(event['sample_date'])
+            sample_date = str_to_datetime(event['sample_date'])
             event['sample_version'] = sample['version']
             event['sample_downloads'] = sample['downloads']
             event.update(self.get_grimoire_fields(sample_date.isoformat(), "downloads_event"))

--- a/grimoire_elk/enriched/jenkins.py
+++ b/grimoire_elk/enriched/jenkins.py
@@ -23,11 +23,9 @@ import csv
 import logging
 import re
 
-from dateutil import parser
-
 from .enrich import Enrich, metadata
 from ..elastic_mapping import Mapping as BaseMapping
-
+from grimoirelab_toolkit.datetime import str_to_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -230,7 +228,7 @@ class JenkinsEnrich(Enrich):
         eitem['job_build'] = eitem['job_name'] + '/' + str(eitem['build'])
 
         # Enrich dates
-        eitem["build_date"] = parser.parse(item["metadata__updated_on"]).isoformat()
+        eitem["build_date"] = str_to_datetime(item["metadata__updated_on"]).isoformat()
 
         # Add duration in days
         if "duration" in eitem:

--- a/grimoire_elk/enriched/kitsune.py
+++ b/grimoire_elk/enriched/kitsune.py
@@ -22,11 +22,10 @@
 import json
 import logging
 
-from dateutil import parser
-
 from .enrich import Enrich, metadata
 from .utils import get_time_diff_days
 from ..elastic_mapping import Mapping as BaseMapping
+from grimoirelab_toolkit.datetime import str_to_datetime
 
 
 logger = logging.getLogger(__name__)
@@ -141,8 +140,8 @@ class KitsuneEnrich(Enrich):
             eitem["tags_analyzed"] = tags
 
             # Enrich dates
-            eitem["creation_date"] = parser.parse(question["created"]).isoformat()
-            eitem["last_activity_date"] = parser.parse(question["updated"]).isoformat()
+            eitem["creation_date"] = str_to_datetime(question["created"]).isoformat()
+            eitem["last_activity_date"] = str_to_datetime(question["updated"]).isoformat()
 
             eitem['lifetime_days'] = \
                 get_time_diff_days(question['created'], question['updated'])
@@ -189,8 +188,8 @@ class KitsuneEnrich(Enrich):
             eitem["helpful_answer"] = answer['num_helpful_votes']
 
             # Enrich dates
-            eitem["creation_date"] = parser.parse(answer["created"]).isoformat()
-            eitem["last_activity_date"] = parser.parse(answer["updated"]).isoformat()
+            eitem["creation_date"] = str_to_datetime(answer["created"]).isoformat()
+            eitem["last_activity_date"] = str_to_datetime(answer["updated"]).isoformat()
 
             eitem['lifetime_days'] = \
                 get_time_diff_days(answer['created'], answer['updated'])

--- a/grimoire_elk/enriched/mbox.py
+++ b/grimoire_elk/enriched/mbox.py
@@ -23,13 +23,12 @@ import json
 import logging
 
 from requests.structures import CaseInsensitiveDict
-from dateutil import parser
 import email.utils
 
 from .enrich import Enrich, metadata
 from ..elastic_mapping import Mapping as BaseMapping
 from .mbox_study_kip import kafka_kip, MAX_LINES_FOR_VOTE
-
+from grimoirelab_toolkit.datetime import str_to_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -149,7 +148,7 @@ class MBoxEnrich(Enrich):
                 eitem[map_fields[fn]] = None
 
         # Enrich dates
-        eitem["email_date"] = parser.parse(item["metadata__updated_on"]).isoformat()
+        eitem["email_date"] = str_to_datetime(item["metadata__updated_on"]).isoformat()
         eitem["list"] = item["origin"]
 
         if 'Subject' in message and message['Subject']:
@@ -171,7 +170,7 @@ class MBoxEnrich(Enrich):
 
         # Time zone
         try:
-            message_date = parser.parse(message['Date'])
+            message_date = str_to_datetime(message['Date'])
             eitem["tz"] = int(message_date.strftime("%z")[0:3])
         except Exception:
             eitem["tz"] = None

--- a/grimoire_elk/enriched/mbox_study_kip.py
+++ b/grimoire_elk/enriched/mbox_study_kip.py
@@ -21,11 +21,8 @@
 
 import logging
 
-from datetime import datetime
-
-from dateutil import parser
-
 from .utils import get_time_diff_days
+from grimoirelab_toolkit.datetime import (datetime_utcnow, str_to_datetime)
 
 logger = logging.getLogger(__name__)
 
@@ -269,7 +266,7 @@ def kafka_kip(enrich):
                 # It is not a KIP message
                 continue
             kip = eitem["kip"]
-            kip_date = parser.parse(eitem["email_date"])
+            kip_date = str_to_datetime(eitem["email_date"])
 
             if eitem['kip_is_discuss']:
                 kip_fields["kip_discuss_time_days"] = \
@@ -290,7 +287,7 @@ def kafka_kip(enrich):
                 max_discuss_date = enrich.kips_dates[kip]['kip_max_discuss']
                 kip_fields['kip_discuss_inactive_days'] = \
                     get_time_diff_days(max_discuss_date.replace(tzinfo=None),
-                                       datetime.utcnow())
+                                       datetime_utcnow())
 
             if eitem['kip_is_vote']:
                 kip_fields["kip_voting_time_days"] = \
@@ -310,7 +307,7 @@ def kafka_kip(enrich):
                 max_vote_date = enrich.kips_dates[kip]['kip_max_vote']
                 kip_fields['kip_voting_inactive_days'] = \
                     get_time_diff_days(max_vote_date.replace(tzinfo=None),
-                                       datetime.utcnow())
+                                       datetime_utcnow())
 
                 # Now check if there is a result from enrich.kips_scores
                 kip_fields['kip_result'] = lazy_result(enrich.kips_scores[kip])
@@ -382,7 +379,7 @@ def kafka_kip(enrich):
             if kip not in enrich.kips_scores:
                 enrich.kips_scores[kip] = []
 
-            kip_date = parser.parse(eitem["email_date"])
+            kip_date = str_to_datetime(eitem["email_date"])
 
             # Analyze the subject to fill the kip fields
             if '[discuss]' in eitem['Subject'].lower() or \

--- a/grimoire_elk/enriched/puppetforge.py
+++ b/grimoire_elk/enriched/puppetforge.py
@@ -19,9 +19,8 @@
 #   Alvaro del Castillo San Felix <acs@bitergia.com>
 #
 
-from dateutil import parser
-
 from .enrich import Enrich, metadata
+from grimoirelab_toolkit.datetime import str_to_datetime
 
 
 class PuppetForgeEnrich(Enrich):
@@ -162,7 +161,7 @@ class PuppetForgeEnrich(Enrich):
             event["source_url"] = release['metadata']['source']
             event["summary"] = release['metadata']['summary']
 
-            event["metadata__updated_on"] = parser.parse(release['updated_at']).isoformat()
+            event["metadata__updated_on"] = str_to_datetime(release['updated_at']).isoformat()
 
             if self.sortinghat:
                 release["metadata__updated_on"] = event["metadata__updated_on"]  # Needed in get_item_sh logic

--- a/grimoire_elk/enriched/rss.py
+++ b/grimoire_elk/enriched/rss.py
@@ -21,10 +21,9 @@
 
 import logging
 
-from dateutil import parser
-
 from .enrich import Enrich, metadata
 from ..elastic_mapping import Mapping as BaseMapping
+from grimoirelab_toolkit.datetime import str_to_datetime
 
 
 logger = logging.getLogger(__name__)
@@ -114,7 +113,7 @@ class RSSEnrich(Enrich):
                 eitem[map_fields[f]] = entry[f]
 
         # Enrich dates
-        eitem["publish_date"] = parser.parse(eitem["published"]).isoformat()
+        eitem["publish_date"] = str_to_datetime(eitem["published"]).isoformat()
 
         if self.sortinghat:
             eitem.update(self.get_item_sh(item))

--- a/grimoire_elk/enriched/supybot.py
+++ b/grimoire_elk/enriched/supybot.py
@@ -21,11 +21,9 @@
 
 import logging
 
-from dateutil import parser
-
 from .enrich import Enrich, metadata
 from ..elastic_mapping import Mapping as BaseMapping
-
+from grimoirelab_toolkit.datetime import str_to_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -110,7 +108,7 @@ class SupybotEnrich(Enrich):
             eitem[map_fields[fn]] = message[fn]
 
         # Enrich dates
-        eitem["update_date"] = parser.parse(item["metadata__updated_on"]).isoformat()
+        eitem["update_date"] = str_to_datetime(item["metadata__updated_on"]).isoformat()
         eitem["channel"] = eitem["origin"]
 
         eitem.update(self.get_grimoire_fields(eitem["update_date"], "message"))

--- a/grimoire_elk/enriched/twitter.py
+++ b/grimoire_elk/enriched/twitter.py
@@ -21,12 +21,11 @@
 
 import logging
 
-from dateutil import parser
 from requests.structures import CaseInsensitiveDict
 
 from .enrich import Enrich, metadata, DEFAULT_PROJECT
 from ..elastic_mapping import Mapping as BaseMapping
-
+from grimoirelab_toolkit.datetime import str_to_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -143,7 +142,7 @@ class TwitterEnrich(Enrich):
                 eitem[f] = None
 
         # Date fields
-        eitem["created_at"] = parser.parse(tweet["created_at"]).isoformat()
+        eitem["created_at"] = str_to_datetime(tweet["created_at"]).isoformat()
 
         # data fields to copy from user
         copy_fields = ["created_at", "description", "followers_count",

--- a/grimoire_elk/enriched/utils.py
+++ b/grimoire_elk/enriched/utils.py
@@ -20,7 +20,6 @@
 #
 
 import datetime
-from dateutil import parser
 import inspect
 import json
 import logging
@@ -96,9 +95,9 @@ def get_time_diff_days(start, end):
         return None
 
     if type(start) is not datetime.datetime:
-        start = parser.parse(start).replace(tzinfo=None)
+        start = str_to_datetime(start).replace(tzinfo=None)
     if type(end) is not datetime.datetime:
-        end = parser.parse(end).replace(tzinfo=None)
+        end = str_to_datetime(end).replace(tzinfo=None)
 
     seconds_day = float(60 * 60 * 24)
     diff_days = (end - start).total_seconds() / seconds_day
@@ -168,7 +167,7 @@ def get_last_enrich(backend_cmd, enrich_backend, filter_raw=None):
                 offset = backend_cmd.parsed_args.offset
 
         if from_date:
-            if from_date.replace(tzinfo=None) != parser.parse("1970-01-01"):
+            if from_date.replace(tzinfo=None) != str_to_datetime("1970-01-01"):
                 last_enrich = from_date
             # if the index is empty, set the last enrich to None
             elif not enrich_backend.from_date:

--- a/grimoire_elk/utils.py
+++ b/grimoire_elk/utils.py
@@ -24,8 +24,8 @@ import logging
 import sys
 
 import requests
-from dateutil import parser
 
+from grimoirelab_toolkit.datetime import str_to_datetime
 from grimoire_elk.errors import ElasticError
 from grimoire_elk.elastic import ElasticSearch
 # Connectors for Graal
@@ -420,8 +420,8 @@ def get_time_diff_days(start_txt, end_txt):
     if start_txt is None or end_txt is None:
         return None
 
-    start = parser.parse(start_txt)
-    end = parser.parse(end_txt)
+    start = str_to_datetime(start_txt)
+    end = str_to_datetime(end_txt)
 
     seconds_day = float(60 * 60 * 24)
     diff_days = \


### PR DESCRIPTION
This code replaces the calls to the datetime and dateutil calls to the equivalent ones provided by toolkit. This is needed to centralize the possible point of failures to a single library.