### PR TITLE
[Enrich] Add `copy_raw_fields()` method and refactor enrichers

### DIFF
--- a/grimoire_elk/enriched/askbot.py
+++ b/grimoire_elk/enriched/askbot.py
@@ -121,11 +121,7 @@ class AskbotEnrich(Enrich):
     def get_rich_item(self, item):
         eitem = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                eitem[f] = item[f]
-            else:
-                eitem[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
 
         question = item['data']
 

--- a/grimoire_elk/enriched/bugzilla.py
+++ b/grimoire_elk/enriched/bugzilla.py
@@ -123,11 +123,7 @@ class BugzillaEnrich(Enrich):
 
         eitem = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                eitem[f] = item[f]
-            else:
-                eitem[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
 
         # The real data
         issue = item['data']

--- a/grimoire_elk/enriched/bugzillarest.py
+++ b/grimoire_elk/enriched/bugzillarest.py
@@ -98,11 +98,7 @@ class BugzillaRESTEnrich(Enrich):
 
         eitem = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                eitem[f] = item[f]
-            else:
-                eitem[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
 
         # The real data
         issue = item['data']

--- a/grimoire_elk/enriched/cocom.py
+++ b/grimoire_elk/enriched/cocom.py
@@ -211,11 +211,7 @@ class CocomEnrich(Enrich):
         for file_analysis in entry["analysis"]:
             eitem = self.get_rich_item(file_analysis)
 
-            for f in self.RAW_FIELDS_COPY:
-                if f in item:
-                    eitem[f] = item[f]
-                else:
-                    eitem[f] = None
+            self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
 
             # common attributes
             eitem['commit_sha'] = entry['commit']

--- a/grimoire_elk/enriched/colic.py
+++ b/grimoire_elk/enriched/colic.py
@@ -302,11 +302,7 @@ class ColicEnrich(Enrich):
         for file_analysis in entry["analysis"]:
             eitem = get_rich_item(file_analysis)
 
-            for f in self.RAW_FIELDS_COPY:
-                if f in item:
-                    eitem[f] = item[f]
-                else:
-                    eitem[f] = None
+            self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
 
             # common attributes
             eitem['author'] = entry['Author']

--- a/grimoire_elk/enriched/confluence.py
+++ b/grimoire_elk/enriched/confluence.py
@@ -102,11 +102,7 @@ class ConfluenceEnrich(Enrich):
     def get_rich_item(self, item):
         eitem = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                eitem[f] = item[f]
-            else:
-                eitem[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
         # The real data
         page = item['data']
 

--- a/grimoire_elk/enriched/crates.py
+++ b/grimoire_elk/enriched/crates.py
@@ -128,11 +128,7 @@ class CratesEnrich(Enrich):
     def get_rich_item(self, item):
         eitem = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                eitem[f] = item[f]
-            else:
-                eitem[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
         # The real data
         crate = item['data']
 

--- a/grimoire_elk/enriched/discourse.py
+++ b/grimoire_elk/enriched/discourse.py
@@ -195,11 +195,7 @@ class DiscourseEnrich(Enrich):
 
         eitem = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                eitem[f] = item[f]
-            else:
-                eitem[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
 
         topic = item['data']
 

--- a/grimoire_elk/enriched/dockerhub.py
+++ b/grimoire_elk/enriched/dockerhub.py
@@ -85,11 +85,7 @@ class DockerHubEnrich(Enrich):
     def get_rich_item(self, item):
         eitem = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                eitem[f] = item[f]
-            else:
-                eitem[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
         # The real data
         image = item['data']
 

--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -985,6 +985,15 @@ class Enrich(ElasticItems):
 
         return sh_ids
 
+    def copy_raw_fields(self, copy_fields, source, target):
+        """Copy fields from item to enriched item."""
+
+        for f in copy_fields:
+            if f in source:
+                target[f] = source[f]
+            else:
+                target[f] = None
+
     def enrich_onion(self, enrich_backend, in_index, out_index, data_source,
                      contribs_field, timeframe_field, sort_on_field,
                      seconds=ONION_INTERVAL, no_incremental=False):

--- a/grimoire_elk/enriched/finosmeetings.py
+++ b/grimoire_elk/enriched/finosmeetings.py
@@ -107,11 +107,7 @@ class FinosMeetingsEnrich(Enrich):
     def get_rich_item(self, item):
         eitem = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                eitem[f] = item[f]
-            else:
-                eitem[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
 
         entry = item['data']
 

--- a/grimoire_elk/enriched/functest.py
+++ b/grimoire_elk/enriched/functest.py
@@ -84,11 +84,7 @@ class FunctestEnrich(Enrich):
     def get_rich_item(self, item):
         eitem = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                eitem[f] = item[f]
-            else:
-                eitem[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
 
         # The real data
         func_test = item['data']

--- a/grimoire_elk/enriched/gerrit.py
+++ b/grimoire_elk/enriched/gerrit.py
@@ -194,11 +194,7 @@ class GerritEnrich(Enrich):
     def get_rich_item(self, item):
         eitem = {}  # Item enriched
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                eitem[f] = item[f]
-            else:
-                eitem[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
         eitem['closed'] = item['metadata__updated_on']
         # The real data
         review = item['data']

--- a/grimoire_elk/enriched/git.py
+++ b/grimoire_elk/enriched/git.py
@@ -194,11 +194,7 @@ class GitEnrich(Enrich):
     def get_rich_item(self, item):
 
         eitem = {}
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                eitem[f] = item[f]
-            else:
-                eitem[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
         # For pair programming uuid is not a unique field. Use git_uuid in general as unique field.
         eitem['git_uuid'] = eitem['uuid']
         # The real data

--- a/grimoire_elk/enriched/github.py
+++ b/grimoire_elk/enriched/github.py
@@ -428,11 +428,7 @@ class GitHubEnrich(Enrich):
     def __get_rich_pull(self, item):
         rich_pr = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                rich_pr[f] = item[f]
-            else:
-                rich_pr[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, rich_pr)
         # The real data
         pull_request = item['data']
 
@@ -530,11 +526,7 @@ class GitHubEnrich(Enrich):
     def __get_rich_issue(self, item):
         rich_issue = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                rich_issue[f] = item[f]
-            else:
-                rich_issue[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, rich_issue)
         # The real data
         issue = item['data']
 
@@ -628,11 +620,7 @@ class GitHubEnrich(Enrich):
     def __get_rich_repo(self, item):
         rich_repo = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                rich_repo[f] = item[f]
-            else:
-                rich_repo[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, rich_repo)
 
         repo = item['data']
 

--- a/grimoire_elk/enriched/github2.py
+++ b/grimoire_elk/enriched/github2.py
@@ -249,8 +249,7 @@ class GitHubEnrich2(Enrich):
         for comment in comments:
             ecomment = {}
 
-            for f in self.RAW_FIELDS_COPY:
-                ecomment[f] = eitem[f]
+            self.copy_raw_fields(self.RAW_FIELDS_COPY, eitem, ecomment)
 
             # Copy data from the enriched issue
             ecomment['issue_labels'] = eitem['issue_labels']
@@ -319,8 +318,7 @@ class GitHubEnrich2(Enrich):
         for comment in comments:
             ecomment = {}
 
-            for f in self.RAW_FIELDS_COPY:
-                ecomment[f] = eitem[f]
+            self.copy_raw_fields(self.RAW_FIELDS_COPY, eitem, ecomment)
 
             # Copy data from the enriched pull
             ecomment['pull_labels'] = eitem['pull_labels']
@@ -434,11 +432,7 @@ class GitHubEnrich2(Enrich):
     def __get_rich_pull(self, item):
         rich_pr = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                rich_pr[f] = item[f]
-            else:
-                rich_pr[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, rich_pr)
         # The real data
         pull_request = item['data']
 
@@ -546,11 +540,7 @@ class GitHubEnrich2(Enrich):
     def __get_rich_issue(self, item):
         rich_issue = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                rich_issue[f] = item[f]
-            else:
-                rich_issue[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, rich_issue)
         # The real data
         issue = item['data']
 
@@ -652,11 +642,7 @@ class GitHubEnrich2(Enrich):
     def __get_rich_repo(self, item):
         rich_repo = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                rich_repo[f] = item[f]
-            else:
-                rich_repo[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, rich_repo)
 
         repo = item['data']
 

--- a/grimoire_elk/enriched/githubql.py
+++ b/grimoire_elk/enriched/githubql.py
@@ -129,11 +129,7 @@ class GitHubQLEnrich(Enrich):
     def __get_rich_event(self, item):
         rich_event = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                rich_event[f] = item[f]
-            else:
-                rich_event[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, rich_event)
 
         event = item['data']
         issue = item['data']['issue']

--- a/grimoire_elk/enriched/gitlab.py
+++ b/grimoire_elk/enriched/gitlab.py
@@ -158,11 +158,7 @@ class GitLabEnrich(Enrich):
 
         rich_issue = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                rich_issue[f] = item[f]
-            else:
-                rich_issue[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, rich_issue)
         # The real data
         issue = item['data']
 
@@ -250,11 +246,7 @@ class GitLabEnrich(Enrich):
     def __get_rich_merge(self, item):
         rich_mr = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                rich_mr[f] = item[f]
-            else:
-                rich_mr[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, rich_mr)
         # The real data
         merge_request = item['data']
 

--- a/grimoire_elk/enriched/gitter.py
+++ b/grimoire_elk/enriched/gitter.py
@@ -103,11 +103,7 @@ class GitterEnrich(Enrich):
 
         eitem = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                eitem[f] = item[f]
-            else:
-                eitem[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
 
         message = item['data']
 

--- a/grimoire_elk/enriched/google_hits.py
+++ b/grimoire_elk/enriched/google_hits.py
@@ -44,11 +44,7 @@ class GoogleHitsEnrich(Enrich):
     def get_rich_item(self, item):
         eitem = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                eitem[f] = item[f]
-            else:
-                eitem[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
         # The real data
         entry = item['data']
 

--- a/grimoire_elk/enriched/jenkins.py
+++ b/grimoire_elk/enriched/jenkins.py
@@ -190,11 +190,7 @@ class JenkinsEnrich(Enrich):
     def get_rich_item(self, item):
         eitem = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                eitem[f] = item[f]
-            else:
-                eitem[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
         # The real data
         build = item['data']
 

--- a/grimoire_elk/enriched/jira.py
+++ b/grimoire_elk/enriched/jira.py
@@ -224,11 +224,7 @@ class JiraEnrich(Enrich):
 
         eitem = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                eitem[f] = item[f]
-            else:
-                eitem[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
         # The real data
         issue = item['data']
 
@@ -371,8 +367,7 @@ class JiraEnrich(Enrich):
         for comment in comments:
             ecomment = {}
 
-            for f in self.RAW_FIELDS_COPY:
-                ecomment[f] = eitem[f]
+            self.copy_raw_fields(self.RAW_FIELDS_COPY, eitem, ecomment)
 
             # Copy data from the enriched issue
             ecomment['project_id'] = eitem['project_id']

--- a/grimoire_elk/enriched/mattermost.py
+++ b/grimoire_elk/enriched/mattermost.py
@@ -115,11 +115,7 @@ class MattermostEnrich(Enrich):
     def get_rich_item(self, item):
         eitem = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                eitem[f] = item[f]
-            else:
-                eitem[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
 
         # The real data
         message = item['data']

--- a/grimoire_elk/enriched/mbox.py
+++ b/grimoire_elk/enriched/mbox.py
@@ -123,11 +123,7 @@ class MBoxEnrich(Enrich):
     def get_rich_item(self, item):
         eitem = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                eitem[f] = item[f]
-            else:
-                eitem[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
         # The real data
         message = CaseInsensitiveDict(item['data'])
 

--- a/grimoire_elk/enriched/mediawiki.py
+++ b/grimoire_elk/enriched/mediawiki.py
@@ -132,11 +132,7 @@ class MediaWikiEnrich(Enrich):
 
         for rev in item["data"]["revisions"]:
             erevision = {}
-            for f in self.RAW_FIELDS_COPY:
-                if f in eitem:
-                    erevision[f] = eitem[f]
-                else:
-                    erevision[f] = None
+            self.copy_raw_fields(self.RAW_FIELDS_COPY, eitem, erevision)
             # Metadata related to the page according to the enrichment specification
             copy_fields_item = ["origin", "metadata__updated_on", "metadata__timestamp", "pageid", "title"]
             for f in copy_fields_item:
@@ -201,11 +197,7 @@ class MediaWikiEnrich(Enrich):
     def get_rich_item(self, item):
         eitem = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                eitem[f] = item[f]
-            else:
-                eitem[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
         # The real data
         page = item['data']
 

--- a/grimoire_elk/enriched/meetup.py
+++ b/grimoire_elk/enriched/meetup.py
@@ -124,11 +124,7 @@ class MeetupEnrich(Enrich):
             logger.warning("[meetup] Not processing {}: no time field".format(item['uuid']))
             return eitem
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                eitem[f] = item[f]
-            else:
-                eitem[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
 
         event = item['data']
 

--- a/grimoire_elk/enriched/pagure.py
+++ b/grimoire_elk/enriched/pagure.py
@@ -160,8 +160,7 @@ class PagureEnrich(Enrich):
         for comment in comments:
             ecomment = {}
 
-            for f in self.RAW_FIELDS_COPY:
-                ecomment[f] = eitem[f]
+            self.copy_raw_fields(self.RAW_FIELDS_COPY, eitem, ecomment)
 
             # Copy data from the enriched issue
             ecomment['issue_id'] = eitem['id']
@@ -278,11 +277,7 @@ class PagureEnrich(Enrich):
 
         rich_issue = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                rich_issue[f] = item[f]
-            else:
-                rich_issue[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, rich_issue)
 
         # The real data
         issue = item['data']

--- a/grimoire_elk/enriched/phabricator.py
+++ b/grimoire_elk/enriched/phabricator.py
@@ -255,11 +255,7 @@ class PhabricatorEnrich(Enrich):
 
         self.__fill_phab_ids(item['data'])
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                eitem[f] = item[f]
-            else:
-                eitem[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
         # The real data
         phab_item = item['data']
 

--- a/grimoire_elk/enriched/puppetforge.py
+++ b/grimoire_elk/enriched/puppetforge.py
@@ -76,11 +76,7 @@ class PuppetForgeEnrich(Enrich):
     def get_rich_item(self, item):
         eitem = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                eitem[f] = item[f]
-            else:
-                eitem[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
         # The real data
         entry = item['data']
 

--- a/grimoire_elk/enriched/redmine.py
+++ b/grimoire_elk/enriched/redmine.py
@@ -103,11 +103,7 @@ class RedmineEnrich(Enrich):
     def get_rich_item(self, item):
         eitem = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                eitem[f] = item[f]
-            else:
-                eitem[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
         # The real data
         ticket = item['data']
 

--- a/grimoire_elk/enriched/rss.py
+++ b/grimoire_elk/enriched/rss.py
@@ -91,11 +91,7 @@ class RSSEnrich(Enrich):
     def get_rich_item(self, item):
         eitem = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                eitem[f] = item[f]
-            else:
-                eitem[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
         # The real data
         entry = item['data']
 

--- a/grimoire_elk/enriched/slack.py
+++ b/grimoire_elk/enriched/slack.py
@@ -101,11 +101,7 @@ class SlackEnrich(Enrich):
     def get_rich_item(self, item):
         eitem = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                eitem[f] = item[f]
-            else:
-                eitem[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
 
         # The real data
         message = item['data']

--- a/grimoire_elk/enriched/stackexchange.py
+++ b/grimoire_elk/enriched/stackexchange.py
@@ -107,11 +107,7 @@ class StackExchangeEnrich(Enrich):
                          "last_activity_date", "link", "score", "tags"]
 
         if kind == 'question':
-            for f in self.RAW_FIELDS_COPY:
-                if f in item:
-                    eitem[f] = item[f]
-                else:
-                    eitem[f] = None
+            self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
             # The real data
             question = item['data']
 

--- a/grimoire_elk/enriched/supybot.py
+++ b/grimoire_elk/enriched/supybot.py
@@ -89,11 +89,7 @@ class SupybotEnrich(Enrich):
     def get_rich_item(self, item):
         eitem = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                eitem[f] = item[f]
-            else:
-                eitem[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
         # The real data
         message = item['data']
 

--- a/grimoire_elk/enriched/telegram.py
+++ b/grimoire_elk/enriched/telegram.py
@@ -84,12 +84,7 @@ class TelegramEnrich(Enrich):
     def get_rich_item(self, item):
         eitem = {}
 
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                eitem[f] = item[f]
-            else:
-                eitem[f] = None
-
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
         eitem['update_id'] = item['data']['update_id']
 
         # The real data

--- a/grimoire_elk/enriched/twitter.py
+++ b/grimoire_elk/enriched/twitter.py
@@ -123,11 +123,7 @@ class TwitterEnrich(Enrich):
     @metadata
     def get_rich_item(self, item):
         eitem = {}
-        for f in self.RAW_FIELDS_COPY:
-            if f in item:
-                eitem[f] = item[f]
-            else:
-                eitem[f] = None
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
 
         # The real data
         tweet = item['data']

--- a/tests/test_askbot.py
+++ b/tests/test_askbot.py
@@ -92,6 +92,20 @@ class TestAskbot(TestBaseBackend):
         self.assertEqual(result['raw'], 2)
         self.assertEqual(result['enrich'], 155)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
     def test_refresh_identities(self):
         """Test refresh identities"""
 

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -99,6 +99,20 @@ class TestBugzilla(TestBaseBackend):
         self.assertEqual(result['raw'], 7)
         self.assertEqual(result['enrich'], 7)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
     def test_refresh_identities(self):
         """Test refresh identities"""
 

--- a/tests/test_bugzillarest.py
+++ b/tests/test_bugzillarest.py
@@ -105,6 +105,20 @@ class TestBugzillaRest(TestBaseBackend):
         self.assertEqual(result['raw'], 7)
         self.assertEqual(result['enrich'], 7)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
     def test_refresh_identities(self):
         """Test refresh identities"""
 

--- a/tests/test_cocom.py
+++ b/tests/test_cocom.py
@@ -151,6 +151,20 @@ class TestCoCom(TestBaseBackend):
         ]
         self.assertListEqual(GraalOcean.get_perceval_params_from_url(url), expected_params)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_items(item)[0]
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')

--- a/tests/test_colic.py
+++ b/tests/test_colic.py
@@ -141,6 +141,20 @@ class TestCoLic(TestBaseBackend):
         ]
         self.assertListEqual(GraalOcean.get_perceval_params_from_url(url), expected_params)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_items(item)[0]
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')

--- a/tests/test_confluence.py
+++ b/tests/test_confluence.py
@@ -120,6 +120,20 @@ class TestConfluence(TestBaseBackend):
         self.assertEqual(result['raw'], 4)
         self.assertEqual(result['enrich'], 4)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
     def test_refresh_identities(self):
         """Test refresh identities"""
 

--- a/tests/test_crates.py
+++ b/tests/test_crates.py
@@ -94,6 +94,20 @@ class TestCrates(TestBaseBackend):
         self.assertEqual(result['raw'], 4)
         self.assertEqual(result['enrich'], 4)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
     def test_refresh_identities(self):
         """Test refresh identities"""
 

--- a/tests/test_discourse.py
+++ b/tests/test_discourse.py
@@ -98,6 +98,20 @@ class TestDiscourse(TestBaseBackend):
         self.assertEqual(result['raw'], 3)
         self.assertEqual(result['enrich'], 35)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
     def test_refresh_identities(self):
         """Test refresh identities"""
 

--- a/tests/test_dockerhub.py
+++ b/tests/test_dockerhub.py
@@ -84,6 +84,20 @@ class TestDockerhub(TestBaseBackend):
         self.assertEqual(result['raw'], 1)
         self.assertEqual(result['enrich'], 3)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
     def test_refresh_identities(self):
         """Test refresh identities"""
 

--- a/tests/test_enrich.py
+++ b/tests/test_enrich.py
@@ -656,6 +656,41 @@ class TestEnrich(unittest.TestCase):
 
         requests.delete(tmp_index_url, verify=False)
 
+    def test_copy_raw_fields(self):
+        """Test whether raw fields are copied properly"""
+
+        raw_fields = ["metadata__updated_on", "metadata__timestamp",
+                      "offset", "origin", "tag", "uuid", "extra"]
+        source = {
+            "metadata__updated_on": "2020-03-19T18:08:45.480000+00:00",
+            "metadata__timestamp": "2020-04-11T12:45:37.229535+00:00",
+            "offset": None,
+            "origin": "https://gitter.im/jenkinsci/jenkins",
+            "tag": "https://gitter.im/jenkinsci/jenkins",
+            "uuid": "a9f92bf99785ad838df6736b7825c6f7ae16ac58",
+        }
+
+        expected = {
+            "metadata__updated_on": "2020-03-19T18:08:45.480000+00:00",
+            "metadata__timestamp": "2020-04-11T12:45:37.229535+00:00",
+            "offset": None,
+            "origin": "https://gitter.im/jenkinsci/jenkins",
+            "tag": "https://gitter.im/jenkinsci/jenkins",
+            "uuid": "a9f92bf99785ad838df6736b7825c6f7ae16ac58",
+            "extra": None
+        }
+
+        eitem = {}
+        self._enrich.copy_raw_fields(raw_fields, source, eitem)
+
+        self.assertEqual(eitem['metadata__updated_on'], expected['metadata__updated_on'])
+        self.assertEqual(eitem['metadata__timestamp'], expected['metadata__timestamp'])
+        self.assertEqual(eitem['offset'], expected['offset'])
+        self.assertEqual(eitem['origin'], expected['origin'])
+        self.assertEqual(eitem['tag'], expected['tag'])
+        self.assertEqual(eitem['uuid'], expected['uuid'])
+        self.assertEqual(eitem['extra'], expected['extra'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_finosmeetings.py
+++ b/tests/test_finosmeetings.py
@@ -154,6 +154,20 @@ class TestFinosMeetings(TestBaseBackend):
         self.assertEqual(eitem['project'], eitem['cm_title'])
         self.assertEqual(eitem['project_1'], eitem['cm_title'])
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
     def test_refresh_identities(self):
         """Test refresh identities"""
 

--- a/tests/test_functest.py
+++ b/tests/test_functest.py
@@ -104,6 +104,20 @@ class TestFunctest(TestBaseBackend):
         self.assertEqual(result['raw'], 27)
         self.assertEqual(result['enrich'], 27)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
     def test_refresh_identities(self):
         """Test refresh identities"""
 

--- a/tests/test_gerrit.py
+++ b/tests/test_gerrit.py
@@ -290,6 +290,20 @@ class TestGerrit(TestBaseBackend):
         self.assertEqual(result['raw'], 6)
         self.assertEqual(result['enrich'], 240)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
     def test_refresh_identities(self):
         """Test refresh identities"""
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -482,6 +482,20 @@ class TestGit(TestBaseBackend):
         self.assertEqual(eitem['committer_domain'], 'gmail.com')
         self.assertEqual(eitem['committer_name'], 'abe1a5515d468ed258124c4c946ceb34ef7ffbda')
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -318,6 +318,20 @@ class TestGitHub(TestBaseBackend):
         self.assertEqual(eitem['merged_by_data_uuid'], 'e4992881f28cf3318a566f0bd45dcf435216a82f')
         self.assertEqual(eitem['merged_by_data_name'], '176eee2bd2c010d02dd419c453aca854195de172')
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')

--- a/tests/test_github2.py
+++ b/tests/test_github2.py
@@ -275,6 +275,20 @@ class TestGitHub2(TestBaseBackend):
             self.assertEqual(item['feeling_emotion'], '__label__unknown')
             self.assertEqual(item['feeling_sentiment'], '__label__unknown')
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')

--- a/tests/test_githubql.py
+++ b/tests/test_githubql.py
@@ -257,6 +257,20 @@ class TestGitHubQL(TestBaseBackend):
         ]
         self.assertListEqual(GitHubQLOcean.get_perceval_params_from_url(url), expected_params)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -286,6 +286,20 @@ class TestGitLab(TestBaseBackend):
         ]
         self.assertListEqual(GitLabOcean.get_perceval_params_from_url(url), expected_params)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')

--- a/tests/test_gitter.py
+++ b/tests/test_gitter.py
@@ -218,6 +218,20 @@ class TestGitter(TestBaseBackend):
         ]
         self.assertListEqual(GitterOcean.get_perceval_params_from_url(url), expected_params)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')

--- a/tests/test_google_hits.py
+++ b/tests/test_google_hits.py
@@ -72,6 +72,20 @@ class TestGoogleHits(TestBaseBackend):
         enrich_backend = self.connectors[self.connector][2]()
         self.assertFalse(enrich_backend.has_identities())
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
     def test_raw_to_enrich_projects(self):
         """Test enrich with Projects"""
 

--- a/tests/test_groupsio.py
+++ b/tests/test_groupsio.py
@@ -97,6 +97,20 @@ class TestGrousio(TestBaseBackend):
         self.assertEqual(result['raw'], 50)
         self.assertEqual(result['enrich'], 50)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
     def test_refresh_identities(self):
         """Test refresh identities"""
 

--- a/tests/test_hyperkitty.py
+++ b/tests/test_hyperkitty.py
@@ -106,6 +106,20 @@ class TestHyperkitty(TestBaseBackend):
         self.assertEqual(result['raw'], 3)
         self.assertEqual(result['enrich'], 3)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
     def test_refresh_identities(self):
         """Test refresh identities"""
 

--- a/tests/test_jenkins.py
+++ b/tests/test_jenkins.py
@@ -143,6 +143,20 @@ class TestJenkins(TestBaseBackend):
         }
         self.assertDictEqual(JenkinsOcean.get_p2o_params_from_url(url), expected_params)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -188,6 +188,23 @@ class TestJira(TestBaseBackend):
             p2o_params = {'url': 'https://jira.opnfv.org', 'filter-raw': 'data.fields.project.key:PROJECT-KEY'}
             self.assertDictEqual(p2o_params, JiraOcean.get_p2o_params_from_url(url))
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        eitems = [enrich_backend.get_rich_item(self.items[0]),
+                  enrich_backend.get_rich_item(self.items[0], author_type='assignee'),
+                  enrich_backend.get_rich_item(self.items[0], author_type='reporter')]
+
+        for eitem in eitems:
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in self.items[0]:
+                    self.assertEqual(self.items[0][attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')

--- a/tests/test_kitsune.py
+++ b/tests/test_kitsune.py
@@ -91,6 +91,20 @@ class TestKitsune(TestBaseBackend):
         self.assertEqual(result['raw'], 4)
         self.assertEqual(result['enrich'], 9)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
     def test_refresh_identities(self):
         """Test refresh identities"""
 

--- a/tests/test_mattermost.py
+++ b/tests/test_mattermost.py
@@ -103,6 +103,20 @@ class TestMattermost(TestBaseBackend):
         for eitem in res.json()['hits']['hits']:
             self.assertEqual(eitem['_source']['project'], "grimoire")
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
     def test_refresh_identities(self):
         """Test refresh identities"""
 

--- a/tests/test_mbox.py
+++ b/tests/test_mbox.py
@@ -205,6 +205,20 @@ class TestMbox(TestBaseBackend):
         ]
         self.assertListEqual(MBoxOcean.get_perceval_params_from_url(url), expected_params)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')

--- a/tests/test_mediawiki.py
+++ b/tests/test_mediawiki.py
@@ -239,6 +239,20 @@ class TestMediawiki(TestBaseBackend):
         ]
         self.assertListEqual(MediaWikiOcean.get_perceval_params_from_url(url), expected_params)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')

--- a/tests/test_meetup.py
+++ b/tests/test_meetup.py
@@ -171,6 +171,20 @@ class TestMeetup(TestBaseBackend):
         self.assertEqual(result['raw'], 3)
         self.assertEqual(result['enrich'], 19)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')

--- a/tests/test_nntp.py
+++ b/tests/test_nntp.py
@@ -140,6 +140,20 @@ class TestNNTP(TestBaseBackend):
         ]
         self.assertListEqual(NNTPOcean.get_perceval_params_from_url(url), expected_params)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')

--- a/tests/test_pagure.py
+++ b/tests/test_pagure.py
@@ -239,6 +239,21 @@ class TestPagure(TestBaseBackend):
         self.assertEqual(result['raw'], 7)
         self.assertEqual(result['enrich'], 26)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            if 'author_name' in eitem:
+                for attribute in enrich_backend.RAW_FIELDS_COPY:
+                    if attribute in item:
+                        self.assertEqual(item[attribute], eitem[attribute])
+                    else:
+                        self.assertIsNone(eitem[attribute])
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')

--- a/tests/test_phabricator.py
+++ b/tests/test_phabricator.py
@@ -103,6 +103,20 @@ class TestPhabricator(TestBaseBackend):
         result = self._test_refresh_project()
         # ... ?
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')

--- a/tests/test_pipermail.py
+++ b/tests/test_pipermail.py
@@ -113,6 +113,20 @@ class TestPipermail(TestBaseBackend):
         result = self._test_refresh_project()
         # ... ?
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')

--- a/tests/test_puppetforge.py
+++ b/tests/test_puppetforge.py
@@ -91,6 +91,20 @@ class TestPuppetForge(TestBaseBackend):
         self.assertEqual(result['raw'], 3)
         self.assertEqual(result['enrich'], 3)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
     def test_refresh_identities(self):
         """Test refresh identities"""
 

--- a/tests/test_redmine.py
+++ b/tests/test_redmine.py
@@ -113,6 +113,20 @@ class TestRedmine(TestBaseBackend):
             self.assertIn('project', ei)
             self.assertIn('project_1', ei)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
     def test_refresh_identities(self):
         """Test refresh identities"""
 

--- a/tests/test_remo.py
+++ b/tests/test_remo.py
@@ -91,6 +91,20 @@ class TestRemo(TestBaseBackend):
         self.assertEqual(result['raw'], 1)
         self.assertEqual(result['enrich'], 1)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
     def test_refresh_identities(self):
         """Test refresh identities"""
 

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -91,6 +91,20 @@ class TestRSS(TestBaseBackend):
         self.assertEqual(result['raw'], 30)
         self.assertEqual(result['enrich'], 30)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
     def test_refresh_identities(self):
         """Test refresh identities"""
 

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -123,6 +123,20 @@ class TestSlack(TestBaseBackend):
         for eitem in res.json()['hits']['hits']:
             self.assertEqual(eitem['_source']['project'], "grimoire")
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
     def test_refresh_identities(self):
         """Test refresh identities"""
 

--- a/tests/test_stackexchange.py
+++ b/tests/test_stackexchange.py
@@ -115,6 +115,20 @@ class TestStackexchange(TestBaseBackend):
         ]
         self.assertListEqual(StackExchangeOcean.get_perceval_params_from_url(url), expected_params)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')

--- a/tests/test_supybot.py
+++ b/tests/test_supybot.py
@@ -114,6 +114,20 @@ class TestSupybot(TestBaseBackend):
         ]
         self.assertListEqual(SupybotOcean.get_perceval_params_from_url(url), expected_params)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -117,6 +117,20 @@ class TestTelegram(TestBaseBackend):
         self.assertEqual(result['raw'], 8)
         self.assertEqual(result['enrich'], 8)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
     def test_refresh_identities(self):
         """Test refresh identities"""
 

--- a/tests/test_twitter.py
+++ b/tests/test_twitter.py
@@ -92,6 +92,20 @@ class TestTwitter(TestBaseBackend):
         self.assertEqual(result['raw'], 5)
         self.assertEqual(result['enrich'], 5)
 
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
     def test_refresh_identities(self):
         """Test refresh identities"""
 


### PR DESCRIPTION
This PR removes the following redundant code snippet from enrichers
```python
for f in self.RAW_FIELDS_COPY:
    if f in item:
        eitem[f] = item[f]
    else:
        eitem[f] = None
```
and replaces with new method `copy_raw_fields()`
Based on the discussion here https://github.com/chaoss/grimoirelab-elk/pull/851#discussion_r415019209


Signed-off-by: Nitish Gupta <imnitish.ng@gmail.com>