### PR TITLE
[enriched-gerrit] Propagate changeset status to patchsets

### DIFF
--- a/grimoire_elk/enriched/gerrit.py
+++ b/grimoire_elk/enriched/gerrit.py
@@ -235,6 +235,8 @@ class GerritEnrich(Enrich):
             created_on = patchsets[0]['createdOn']
 
         eitem['status_value'] = self.last_changeset_approval_value(patchsets)
+        eitem['changeset_status_value'] = eitem['status_value']
+        eitem['changeset_status'] = eitem['status']
 
         created_on_date = str_to_datetime(created_on)
         eitem["created_on"] = created_on
@@ -358,6 +360,8 @@ class GerritEnrich(Enrich):
             epatchset['repository'] = eitem['repository']
             epatchset['branch'] = eitem['branch']
             epatchset['changeset_number'] = eitem['changeset_number']
+            epatchset['changeset_status'] = eitem['changeset_status']
+            epatchset['changeset_status_value'] = eitem['changeset_status_value']
 
             # Add author info
             epatchset["patchset_author_name"] = None
@@ -439,6 +443,8 @@ class GerritEnrich(Enrich):
             eapproval['repository'] = epatchset['repository']
             eapproval['branch'] = epatchset['branch']
             eapproval['changeset_number'] = epatchset['changeset_number']
+            eapproval['changeset_status'] = epatchset['changeset_status']
+            eapproval['changeset_status_value'] = epatchset['changeset_status_value']
             eapproval['patchset_number'] = epatchset['patchset_number']
             eapproval['patchset_revision'] = epatchset['patchset_revision']
             eapproval['patchset_ref'] = epatchset['patchset_ref']

--- a/schema/gerrit.csv
+++ b/schema/gerrit.csv
@@ -34,6 +34,8 @@ changeset_author_org_name,keyword,true,"Organization the changeset author belong
 changeset_author_user_name,keyword,true,"Changeset author user name, equal to owner_user_name."
 changeset_author_uuid,keyword,true,"Changeset author unique identifier from SortingHat, equal to owner_uuid."
 changeset_number,long,true,"Gerrit changeset unique identifier."
+changeset_status,keyword,true,"Changeset status such as Abandoned, Merged or Open. The actual value depends on the instance of Gerrit."
+changeset_status_value,keyword,true,"Value of the last code-review approval made by someone else than the author for a given changeset, it can be -2 -1 1 or 2."
 closed,date,true,"Closing date of the changeset."
 comment_created_on,date,true,"Creation date of the changeset comment."
 comment_message,keyword,true,"Message of the patchset comment"

--- a/tests/test_gerrit.py
+++ b/tests/test_gerrit.py
@@ -67,6 +67,8 @@ class TestGerrit(TestBaseBackend):
         self.assertIn('metadata__enriched_on', eitem)
         self.assertIn('metadata__gelk_backend_name', eitem)
         self.assertIn('metadata__gelk_version', eitem)
+        self.assertIn('changeset_status', eitem)
+        self.assertIn('changeset_status_value', eitem)
         self.assertIn(REPO_LABELS, eitem)
 
         self.assertEqual(eitem['time_to_first_review'], 0.06)
@@ -92,6 +94,8 @@ class TestGerrit(TestBaseBackend):
             self.assertIn('metadata__enriched_on', epatchset)
             self.assertIn('metadata__gelk_backend_name', epatchset)
             self.assertIn('metadata__gelk_version', epatchset)
+            self.assertIn('changeset_status', epatchset)
+            self.assertIn('changeset_status_value', epatchset)
             self.assertIn(REPO_LABELS, epatchset)
 
         eapprovals = [ei for ei in epatchsets if 'is_gerrit_approval' in ei]
@@ -104,6 +108,8 @@ class TestGerrit(TestBaseBackend):
             self.assertIn('metadata__enriched_on', epatchset)
             self.assertIn('metadata__gelk_backend_name', epatchset)
             self.assertIn('metadata__gelk_version', epatchset)
+            self.assertIn('changeset_status', epatchset)
+            self.assertIn('changeset_status_value', epatchset)
             self.assertIn(REPO_LABELS, epatchset)
             self.assertEqual(epatchset['patchset_time_to_first_review'], expected_patchset_time_to_first_review[i])
 
@@ -111,6 +117,8 @@ class TestGerrit(TestBaseBackend):
         for eapproval in eapprovals:
             self.assertIn('approval_description', eapproval)
             self.assertIn('approval_description_analyzed', eapproval)
+            self.assertIn('changeset_status', eapproval)
+            self.assertIn('changeset_status_value', eapproval)
             self.assertIn('metadata__enriched_on', eapproval)
             self.assertIn('metadata__gelk_backend_name', eapproval)
             self.assertIn('metadata__gelk_version', eapproval)


### PR DESCRIPTION
This code copies the attributes `status` and `status_value` of the changeset to the corresponding patchsets. With these new attributes, it is possible to compare the time to first review for patchsets belonging to a given type of changesets (e.g.,
merged, abandoned or new).

These new attributes are also included in the changeset enriched items for consistency purpose.

Tests have been updated accordingly.
Schema has been updated accordingly.