### PR TITLE
Handle Git private repos in ELK

### DIFF
--- a/grimoire_elk/elastic_items.py
+++ b/grimoire_elk/elastic_items.py
@@ -27,7 +27,7 @@ import logging
 import re
 import time
 
-from .enriched.utils import get_repository_filter, grimoire_con
+from .enriched.utils import get_repository_filter, grimoire_con, anonymize_url
 from .elastic_mapping import Mapping
 
 HEADER_JSON = {"Content-Type": "application/json"}
@@ -189,7 +189,7 @@ class ElasticItems:
             res = self.requests.delete(url, data=query_data, headers=headers)
             res.raise_for_status()
         except Exception:
-            logger.debug("Error releasing scroll: {}/{}".format(self.elastic.anonymize_url(url), scroll_id))
+            logger.debug("Error releasing scroll: {}/{}".format(anonymize_url(url), scroll_id))
             logger.debug("Error releasing scroll: {}".format(res.json()))
 
     # Items generator
@@ -228,14 +228,14 @@ class ElasticItems:
 
         if scroll_size == 0:
             logger.debug("No results found from {} and filter {}".format(
-                         self.elastic.anonymize_url(self.elastic.index_url), _filter))
+                         anonymize_url(self.elastic.index_url), _filter))
             self.free_scroll(scroll_id)
             return
 
         while scroll_size > 0:
 
             logger.debug("Fetching from {}: {} received".format(
-                         self.elastic.anonymize_url(self.elastic.index_url), len(page['hits']['hits'])))
+                         anonymize_url(self.elastic.index_url), len(page['hits']['hits'])))
             for item in page['hits']['hits']:
                 eitem = item['_source']
                 yield eitem
@@ -248,7 +248,7 @@ class ElasticItems:
             scroll_size = len(page['hits']['hits'])
 
         self.free_scroll(scroll_id)
-        logger.debug("Fetching from {}: done receiving".format(self.elastic.anonymize_url(self.elastic.index_url)))
+        logger.debug("Fetching from {}: done receiving".format(anonymize_url(self.elastic.index_url)))
 
     def get_elastic_items(self, elastic_scroll_id=None, _filter=None, ignore_incremental=False):
         """Get the items from the index related to the backend applying and
@@ -349,7 +349,7 @@ class ElasticItems:
             }
             """ % (filters, order_query)
 
-            logger.debug("Raw query to {}\n{}".format(self.elastic.anonymize_url(url),
+            logger.debug("Raw query to {}\n{}".format(anonymize_url(url),
                          json.dumps(json.loads(query), indent=4)))
             query_data = query
 
@@ -362,7 +362,7 @@ class ElasticItems:
             rjson = res.json()
         except Exception:
             # The index could not exists yet or it could be empty
-            logger.debug("No results found from {}".format(self.elastic.anonymize_url(url)))
+            logger.debug("No results found from {}".format(anonymize_url(url)))
 
         return rjson
 

--- a/grimoire_elk/elastic_items.py
+++ b/grimoire_elk/elastic_items.py
@@ -118,7 +118,7 @@ class ElasticItems:
         if matchObj:
             labels_info = matchObj.group(1)
             labels = matchObj.group(2)
-            labels_lst = [l.strip() for l in labels.split(',')]
+            labels_lst = [label.strip() for label in labels.split(',')]
             processed_repo = processed_repo.replace(labels_info, '').strip()
 
         return processed_repo, labels_lst

--- a/grimoire_elk/enriched/cocom.py
+++ b/grimoire_elk/enriched/cocom.py
@@ -31,7 +31,7 @@ from .enrich import (Enrich,
 from .graal_study_evolution import (get_to_date,
                                     get_unique_repository,
                                     get_files_at_time)
-from .utils import fix_field_date
+from .utils import fix_field_date, anonymize_url
 from ..elastic_mapping import Mapping as BaseMapping
 
 from grimoirelab_toolkit.datetime import datetime_utcnow
@@ -224,7 +224,7 @@ class CocomEnrich(Enrich):
             # Other enrichment
             eitem["repo_url"] = item["origin"]
             if eitem["repo_url"].startswith('http'):
-                eitem["repo_url"] = ElasticSearch.anonymize_url(eitem["repo_url"])
+                eitem["repo_url"] = anonymize_url(eitem["repo_url"])
 
             if self.prjs_map:
                 eitem.update(self.get_item_project(eitem))
@@ -315,7 +315,7 @@ class CocomEnrich(Enrich):
         for repository_url in repositories:
             repository_url_anonymized = repository_url
             if repository_url_anonymized.startswith('http'):
-                repository_url_anonymized = ElasticSearch.anonymize_url(repository_url_anonymized)
+                repository_url_anonymized = anonymize_url(repository_url_anonymized)
 
             logger.info("[cocom] study enrich-cocom-analysis start analysis for {}".format(
                         repository_url_anonymized))

--- a/grimoire_elk/enriched/colic.py
+++ b/grimoire_elk/enriched/colic.py
@@ -27,7 +27,7 @@ from .enrich import (Enrich,
                      metadata)
 from .graal_study_evolution import (get_to_date,
                                     get_unique_repository)
-from .utils import fix_field_date
+from .utils import fix_field_date, anonymize_url
 from ..elastic_mapping import Mapping as BaseMapping
 
 from grimoirelab_toolkit.datetime import datetime_utcnow
@@ -317,7 +317,7 @@ class ColicEnrich(Enrich):
             # Other enrichment
             eitem["repo_url"] = item["origin"]
             if eitem["repo_url"].startswith('http'):
-                eitem["repo_url"] = ElasticSearch.anonymize_url(eitem["repo_url"])
+                eitem["repo_url"] = anonymize_url(eitem["repo_url"])
 
             if self.prjs_map:
                 eitem.update(self.get_item_project(eitem))
@@ -391,7 +391,7 @@ class ColicEnrich(Enrich):
         for repository_url in repositories:
             repository_url_anonymized = repository_url
             if repository_url_anonymized.startswith('http'):
-                repository_url_anonymized = ElasticSearch.anonymize_url(repository_url_anonymized)
+                repository_url_anonymized = anonymize_url(repository_url_anonymized)
 
             logger.info("[colic] study enrich-colic-analysis start analysis for {}".format(
                         repository_url_anonymized))

--- a/grimoire_elk/enriched/dockerhub.py
+++ b/grimoire_elk/enriched/dockerhub.py
@@ -23,7 +23,7 @@ import json
 import logging
 import sys
 
-from .enrich import Enrich, metadata
+from .enrich import Enrich, metadata, anonymize_url
 from ..elastic_mapping import Mapping as BaseMapping
 
 
@@ -133,15 +133,14 @@ class DockerHubEnrich(Enrich):
 
         url = self.elastic.get_bulk_url()
 
-        logger.debug("[dockerhub] Adding items to {} (in {} packs)".format(
-                     self.elastic.anonymize_url(url), max_items))
+        logger.debug("[dockerhub] Adding items to {} (in {} packs)".format(anonymize_url(url), max_items))
 
         for item in items:
             if current >= max_items:
                 total += self.elastic.safe_put_bulk(url, bulk_json)
                 json_size = sys.getsizeof(bulk_json) / (1024 * 1024)
                 logger.debug("[dockerhub] Added {} items to {} ({:.2f} MB)".format(
-                             total, self.elastic.anonymize_url(url), json_size))
+                             total, anonymize_url(url), json_size))
                 bulk_json = ""
                 current = 0
 

--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -546,7 +546,7 @@ class Enrich(ElasticItems):
             # elk.enrich_backend)
             if self.projects_json_repo:
                 project = self.prjs_map[ds_name][self.projects_json_repo]
-            # if `projects_json_repo`, which shouldn't never happen, use the
+            # if `projects_json_repo` (e.g., AOC study), use the
             # method `get_project_repository` (defined in each enricher)
             else:
                 repository = self.get_project_repository(eitem)
@@ -561,6 +561,16 @@ class Enrich(ElasticItems):
                 fltr = eitem['origin'] + ' --filter-raw=' + self.filter_raw
                 if ds_name in self.prjs_map and fltr in self.prjs_map[ds_name]:
                     project = self.prjs_map[ds_name][fltr]
+            elif ds_name in self.prjs_map:
+                # this code is executed to retrieve the project of private repositories (in particular Git ones)
+                # the URLs in the prjs_map are retrieved, anonymized and compared with the value
+                # returned by `get_project_repository`
+                repository = self.get_project_repository(eitem)
+                for r in self.prjs_map[ds_name]:
+                    anonymized_repo = anonymize_url(r)
+                    if repository == anonymized_repo:
+                        project = self.prjs_map[ds_name][r]
+                        break
 
             if project == UNKNOWN_PROJECT:
                 return None

--- a/grimoire_elk/enriched/git.py
+++ b/grimoire_elk/enriched/git.py
@@ -568,9 +568,10 @@ class GitEnrich(Enrich):
                 repos.extend(items)
 
         for repo in repos:
-            logger.info("{} Processing repo: {}".format(log_prefix, repo))
-            in_conn.update_repo(repo)
-            out_conn.update_repo(repo)
+            anonymize_repo = anonymize_url(repo)
+            logger.info("{} Processing repo: {}".format(log_prefix, anonymize_repo))
+            in_conn.update_repo(anonymize_repo)
+            out_conn.update_repo(anonymize_repo)
             areas_of_code(git_enrich=enrich_backend, in_conn=in_conn, out_conn=out_conn)
 
         # Create alias if output index exists and alias does not
@@ -776,7 +777,7 @@ class GitEnrich(Enrich):
                     }
                 }
             ]
-        """ % git_repo.uri
+        """ % anonymize_url(git_repo.uri)
 
         # reset references in enrich index
         es_query = """
@@ -856,7 +857,7 @@ class GitEnrich(Enrich):
             logger.warning("[git] Change branch name from {} to {}".format(branch_name, digested_branch_name))
 
         # update enrich index
-        fltr = self.__prepare_filter("hash", commits_str, repo_origin)
+        fltr = self.__prepare_filter("hash", commits_str, anonymize_url(repo_origin))
 
         es_query = """
             {

--- a/grimoire_elk/enriched/github.py
+++ b/grimoire_elk/enriched/github.py
@@ -37,7 +37,7 @@ from elasticsearch import Elasticsearch as ES, RequestsHttpConnection
 
 from .utils import get_time_diff_days
 
-from .enrich import Enrich, metadata
+from .enrich import Enrich, metadata, anonymize_url
 from ..elastic_mapping import Mapping as BaseMapping
 
 from .github_study_evolution import (get_unique_repository_with_project_name,
@@ -297,7 +297,7 @@ class GitHubEnrich(Enrich):
         enrich_index_search_url = self.elastic.index_url + "/_search"
 
         logger.info("[github] Doing enrich_pull_request study for index {}".format(
-                    self.elastic.anonymize_url(self.elastic.index_url)))
+                    anonymize_url(self.elastic.index_url)))
         time.sleep(1)  # HACK: Wait until git enrich index has been written
 
         def make_request(url, error_msg, data=None, req_type="GET"):

--- a/grimoire_elk/enriched/github.py
+++ b/grimoire_elk/enriched/github.py
@@ -768,7 +768,7 @@ class GitHubEnrich(Enrich):
             )['aggregations']['created_per_interval'].get("buckets", [])
 
             # for each selected label + others labels
-            for label, other in [("", True)] + [(l, False) for l in reduced_labels]:
+            for label, other in [("", True)] + [(label, False) for label in reduced_labels]:
                 # compute metrics for each day (ES request for each day)
                 evolution_items = []
                 for date in map(lambda i: i['key_as_string'], dates):

--- a/grimoire_elk/enriched/graal_study_evolution.py
+++ b/grimoire_elk/enriched/graal_study_evolution.py
@@ -20,7 +20,7 @@
 #   Nishchith Shetty <inishchith@gmail.com>
 #
 
-from grimoirelab_toolkit.datetime import str_to_datetime
+from grimoirelab_toolkit.datetime import str_to_datetime, unixtime_to_datetime
 
 
 def get_unique_repository():
@@ -178,9 +178,15 @@ def get_to_date(es_in, in_index, out_index, repository_url, interval):
             index=out_index,
             body=get_last_study_date(repository_url, interval))["aggregations"]["1"]
 
-        if last_study_date["value"] is not None:
+        if "value_as_string" in last_study_date and last_study_date["value_as_string"]:
             study_data_available = True
             to_date = str_to_datetime(last_study_date["value_as_string"])
+        elif "value" in last_study_date and last_study_date["value"]:
+            study_data_available = True
+            try:
+                to_date = unixtime_to_datetime(last_study_date["value"])
+            except Exception:
+                to_date = unixtime_to_datetime(last_study_date["value"] / 1000)
 
     if not study_data_available:
         first_item_date = es_in.search(

--- a/grimoire_elk/enriched/jira.py
+++ b/grimoire_elk/enriched/jira.py
@@ -277,7 +277,7 @@ class JiraEnrich(Enrich):
             eitem['priority'] = issue['fields']['priority']['name']
 
         # data.fields.progress.percent not exists in Puppet JIRA
-        if 'progress'in issue['fields']:
+        if 'progress' in issue['fields']:
             eitem['progress_total'] = issue['fields']['progress']['total']
         eitem['project_id'] = issue['fields']['project']['id']
         eitem['project_key'] = issue['fields']['project']['key']

--- a/grimoire_elk/enriched/kitsune.py
+++ b/grimoire_elk/enriched/kitsune.py
@@ -23,7 +23,7 @@ import json
 import logging
 
 from .enrich import Enrich, metadata
-from .utils import get_time_diff_days
+from .utils import get_time_diff_days, anonymize_url
 from ..elastic_mapping import Mapping as BaseMapping
 from grimoirelab_toolkit.datetime import str_to_datetime
 
@@ -219,7 +219,7 @@ class KitsuneEnrich(Enrich):
 
         url = self.elastic.get_bulk_url()
 
-        logger.debug("[kitsune] Adding items to {} (in {} packs)".format(self.elastic.anonymize_url(url), max_items))
+        logger.debug("[kitsune] Adding items to {} (in {} packs)".format(anonymize_url(url), max_items))
 
         items = ocean_backend.fetch()
         for item in items:

--- a/grimoire_elk/enriched/mbox.py
+++ b/grimoire_elk/enriched/mbox.py
@@ -25,7 +25,7 @@ import logging
 from requests.structures import CaseInsensitiveDict
 import email.utils
 
-from .enrich import Enrich, metadata
+from .enrich import Enrich, metadata, anonymize_url
 from ..elastic_mapping import Mapping as BaseMapping
 from .mbox_study_kip import kafka_kip, MAX_LINES_FOR_VOTE
 from grimoirelab_toolkit.datetime import str_to_datetime
@@ -208,7 +208,7 @@ class MBoxEnrich(Enrich):
 
         url = self.elastic.get_bulk_url()
 
-        logger.debug("[mbox] Adding items to {} (in {} packs)".format(self.elastic.anonymize_url(url), max_items))
+        logger.debug("[mbox] Adding items to {} (in {} packs)".format(anonymize_url(url), max_items))
 
         for item in items:
             if current >= max_items:

--- a/grimoire_elk/enriched/mbox_study_kip.py
+++ b/grimoire_elk/enriched/mbox_study_kip.py
@@ -21,7 +21,7 @@
 
 import logging
 
-from .utils import get_time_diff_days
+from .utils import get_time_diff_days, anonymize_url
 from grimoirelab_toolkit.datetime import (datetime_utcnow, str_to_datetime)
 
 logger = logging.getLogger(__name__)
@@ -425,7 +425,7 @@ def kafka_kip(enrich):
 
         logger.info("[mbox] study Kafka KIP total eitems with kafka kip fields {}".format(total))
 
-    logger.debug("[mbox] study Kafka KIP doing from {}".format(enrich.elastic.anonymize_url(enrich.elastic.index_url)))
+    logger.debug("[mbox] study Kafka KIP doing from {}".format(anonymize_url(enrich.elastic.index_url)))
 
     # First iteration with the basic fields
     eitems = add_kip_fields(enrich)

--- a/grimoire_elk/enriched/mbox_study_kip.py
+++ b/grimoire_elk/enriched/mbox_study_kip.py
@@ -379,8 +379,8 @@ def kafka_kip(enrich):
 
             # Analyze the subject to fill the kip fields
             if '[discuss]' in eitem['Subject'].lower() or \
-               '[kip-discussion]'in eitem['Subject'].lower() or \
-               '[discussion]'in eitem['Subject'].lower():
+               '[kip-discussion]' in eitem['Subject'].lower() or \
+               '[discussion]' in eitem['Subject'].lower():
                 kip_fields['kip_is_discuss'] = 1
                 kip_fields['kip_type'] = "discuss"
                 kip_fields['kip'] = kip

--- a/grimoire_elk/enriched/mediawiki.py
+++ b/grimoire_elk/enriched/mediawiki.py
@@ -24,7 +24,7 @@ import logging
 
 from grimoirelab_toolkit.datetime import str_to_datetime
 
-from .enrich import Enrich, metadata
+from .enrich import Enrich, metadata, anonymize_url
 from ..elastic_mapping import Mapping as BaseMapping
 
 logger = logging.getLogger(__name__)
@@ -240,7 +240,7 @@ class MediaWikiEnrich(Enrich):
 
         url = self.elastic.get_bulk_url()
 
-        logger.debug("[mediawiki] Adding items to {} (in {} packs)".format(self.elastic.anonymize_url(url), max_items))
+        logger.debug("[mediawiki] Adding items to {} (in {} packs)".format(anonymize_url(url), max_items))
 
         items = ocean_backend.fetch()
         for item in items:

--- a/grimoire_elk/enriched/mozillaclub.py
+++ b/grimoire_elk/enriched/mozillaclub.py
@@ -22,7 +22,7 @@
 import json
 import logging
 
-from grimoire_elk.enriched.enrich import Enrich, metadata
+from grimoire_elk.enriched.enrich import Enrich, metadata, anonymize_url
 from ..elastic_mapping import Mapping as BaseMapping
 
 
@@ -173,8 +173,7 @@ class MozillaClubEnrich(Enrich):
 
         url = self.elastic.get_bulk_url()
 
-        logger.debug("[mozillaclub] Adding items to {} (in {} packs)".format(
-                     self.elastic.anonymize_url(url), max_items))
+        logger.debug("[mozillaclub] Adding items to {} (in {} packs)".format(anonymize_url(url), max_items))
 
         items = ocean_backend.fetch()
         for item in items:

--- a/grimoire_elk/enriched/utils.py
+++ b/grimoire_elk/enriched/utils.py
@@ -23,10 +23,10 @@ import datetime
 import inspect
 import json
 import logging
+import re
 
 import requests
 import urllib3
-
 
 from grimoirelab_toolkit.datetime import (datetime_utcnow,
                                           str_to_datetime)
@@ -44,8 +44,7 @@ REPO_LABELS = 'repository_labels'
 logger = logging.getLogger(__name__)
 
 
-def get_repository_filter(perceval_backend, perceval_backend_name,
-                          term=False):
+def get_repository_filter(perceval_backend, perceval_backend_name, term=False):
     """ Get the filter needed for get the items in a repository """
     from .github import GITHUB
 
@@ -86,6 +85,16 @@ def get_repository_filter(perceval_backend, perceval_backend_name,
         filter_ = {}
 
     return filter_
+
+
+def anonymize_url(url):
+    """Remove credentials from the url
+
+    :param url: target url
+    """
+    anonymized = re.sub('://.*@', '://', url)
+
+    return anonymized
 
 
 def get_time_diff_days(start, end):

--- a/grimoire_elk/enriched/utils.py
+++ b/grimoire_elk/enriched/utils.py
@@ -54,7 +54,7 @@ def get_repository_filter(perceval_backend, perceval_backend_name, term=False):
         return filter_
 
     field = 'origin'
-    value = perceval_backend.origin
+    value = anonymize_url(perceval_backend.origin)
 
     if perceval_backend_name in ["meetup", "nntp", "stackexchange", "jira"]:
         # Until tag is supported in all raw and enriched indexes

--- a/grimoire_elk/raw/elastic.py
+++ b/grimoire_elk/raw/elastic.py
@@ -29,7 +29,7 @@ import logging
 from grimoirelab_toolkit.datetime import unixtime_to_datetime
 
 from datetime import datetime
-from ..enriched.utils import get_repository_filter
+from ..enriched.utils import get_repository_filter, anonymize_url
 from ..elastic_items import ElasticItems
 from ..elastic_mapping import Mapping
 from ..errors import ELKError
@@ -166,8 +166,8 @@ class ElasticOcean(ElasticItems):
 
         # We need to filter by repository to support several repositories
         # in the same raw index
-        filters_ = [get_repository_filter(self.perceval_backend,
-                    self.get_connector_name())]
+
+        filters_ = [get_repository_filter(self.perceval_backend, self.get_connector_name())]
 
         # Check if backend supports from_date
         signature = inspect.signature(self.perceval_backend.fetch)
@@ -182,7 +182,7 @@ class ElasticOcean(ElasticItems):
 
             logger.info("[{}] Incremental from: {} for {}".format(
                         self.perceval_backend.__class__.__name__.lower(),
-                        last_update, self.perceval_backend.origin))
+                        last_update, anonymize_url(self.perceval_backend.origin)))
 
         offset = None
         if 'offset' in signature.parameters:
@@ -194,7 +194,7 @@ class ElasticOcean(ElasticItems):
             if offset is not None:
                 logger.info("[{}] Incremental from: {} offset, for {}".format(
                             self.perceval_backend.__class__.__name__.lower(),
-                            offset, self.perceval_backend.origin))
+                            offset, anonymize_url(self.perceval_backend.origin)))
             else:
                 logger.info("[{}] Not incremental".format(
                             self.perceval_backend.__class__.__name__.lower()))

--- a/grimoire_elk/raw/git.py
+++ b/grimoire_elk/raw/git.py
@@ -22,6 +22,7 @@
 from .elastic import ElasticOcean
 from ..elastic_mapping import Mapping as BaseMapping
 from ..identities.git import GitIdentities
+from ..enriched.utils import anonymize_url
 
 
 class Mapping(BaseMapping):
@@ -60,6 +61,9 @@ class GitOcean(ElasticOcean):
 
     mapping = Mapping
     identities = GitIdentities
+
+    def _fix_item(self, item):
+        item['origin'] = anonymize_url(item['origin'])
 
     @classmethod
     def get_perceval_params_from_url(cls, url):

--- a/grimoire_elk/raw/git.py
+++ b/grimoire_elk/raw/git.py
@@ -64,6 +64,7 @@ class GitOcean(ElasticOcean):
 
     def _fix_item(self, item):
         item['origin'] = anonymize_url(item['origin'])
+        item['tag'] = anonymize_url(item['tag'])
 
     @classmethod
     def get_perceval_params_from_url(cls, url):

--- a/releases/unreleased/support-for-git-private-repos.yml
+++ b/releases/unreleased/support-for-git-private-repos.yml
@@ -1,0 +1,12 @@
+---
+title: Support for Git private repos
+category: added
+author: Valerio Cosentino <valcos@bitergia.com>
+issue: 873
+notes: > Git private repos can now be handled by 
+ELK, which allows to deal with the credentials that
+appear in the repo URLs passed via the projects.json.
+These URLs are processed when storing/retrieving the 
+data in the raw, enriched and studies indexes to make 
+sure that the credentials are not included in the
+indexes nor visible on the dashboards.

--- a/tests/base.py
+++ b/tests/base.py
@@ -261,7 +261,7 @@ class TestBaseBackend(unittest.TestCase):
         total = refresh_projects(self.enrich_backend)
         return total
 
-    def _test_study(self, test_study):
+    def _test_study(self, test_study, projects_json_repo=None, projects_json=None, prjs_map=None):
         """Test the execution of a study"""
 
         # populate raw index
@@ -280,6 +280,16 @@ class TestBaseBackend(unittest.TestCase):
 
         elastic_enrich = get_elastic(self.es_con, self.enrich_index, clean, self.enrich_backend)
         self.enrich_backend.set_elastic(elastic_enrich)
+
+        if projects_json:
+            self.enrich_backend.json_projects = projects_json
+
+        if projects_json_repo:
+            self.enrich_backend.projects_json_repo = projects_json_repo
+
+        if prjs_map:
+            self.enrich_backend.prjs_map = prjs_map
+
         self.enrich_backend.enrich_items(self.ocean_backend)
 
         for study in self.enrich_backend.studies:

--- a/tests/data/git.json
+++ b/tests/data/git.json
@@ -394,4 +394,93 @@
     "timestamp": 1518165202.700072,
     "updated_on": 1392185439.0,
     "uuid": "875a172baaf9af3980c2ffc7d6b95892d6e17b6a"
-}]
+},{
+    "backend_name": "Git",
+    "backend_version": "0.12.0",
+    "perceval_version": "0.14.0",
+    "timestamp": 1589042739.252209,
+    "origin": "https://username:password@github.com/acme/errors",
+    "uuid": "e03a0d94104f7591313946c1d6d9a7468c2e8fa9",
+    "updated_on": 1569952131,
+    "classified_fields_filtered": null,
+    "category": "commit",
+    "search_fields": {
+      "item_id": "d10842e50ab4eb93c5bea0fea76afb8601571aa8"
+    },
+    "tag": "https://username:password@github.com/acme/errors",
+    "data": {
+      "commit": "d10842e50ab4eb93c5bea0fea76afb8601571aa8",
+      "parents": [
+        "915a61fe8e83265ab3859fbb55aaf16d8a0bacd7"
+      ],
+      "refs": [
+        "HEAD -> refs/heads/master"
+      ],
+      "Author": "Owl Capone <owlcapone@boss.io>",
+      "AuthorDate": "Tue Oct 10 12:48:51 2019 -0700",
+      "Commit": "GitHub <noreply@github.com>",
+      "CommitDate": "Tue Oct 10 12:48:51 2019 -0700",
+      "message": "Update README.md",
+      "files": [
+        {
+          "modes": [
+            "100644",
+            "100644"
+          ],
+          "indexes": [
+            "b0192b7",
+            "868b4a7"
+          ],
+          "action": "M",
+          "file": "README.md",
+          "added": "1",
+          "removed": "0"
+        }
+      ]
+    }
+  },{
+    "backend_name": "Git",
+    "backend_version": "0.12.0",
+    "perceval_version": "0.14.0",
+    "timestamp": 1589045739.252209,
+    "origin": "https://username:password@github.com/acme/errors",
+    "uuid": "a03a0d94104f7591313946c1d6d9a7468c2e8fa7",
+    "updated_on": 1569953131,
+    "classified_fields_filtered": null,
+    "category": "commit",
+    "search_fields": {
+      "item_id": "e10842e50ab4eb93c5bea0fea76afb8601571aa1"
+    },
+    "tag": "https://username:password@github.com/acme/errors",
+    "data": {
+      "commit": "e10842e50ab4eb93c5bea0fea76afb8601571aa1",
+      "parents": [
+        "715a61fe8e83265ab3859fbb55aaf16d8a0bacd6"
+      ],
+      "refs": [
+        "HEAD -> refs/heads/master"
+      ],
+      "Author": "Owl Capone <owlcapone@boss.io>",
+      "AuthorDate": "Tue Oct 11 14:48:51 2019 -0700",
+      "Commit": "GitHub <noreply@github.com>",
+      "CommitDate": "Tue Oct 11 14:48:51 2019 -0700",
+      "message": "Update README.md",
+      "files": [
+        {
+          "modes": [
+            "100644",
+            "100644"
+          ],
+          "indexes": [
+            "b0192b7",
+            "868b4a7"
+          ],
+          "action": "M",
+          "file": "README.md",
+          "added": "1",
+          "removed": "0"
+        }
+      ]
+    }
+  }
+]

--- a/tests/data/git.json
+++ b/tests/data/git.json
@@ -438,7 +438,7 @@
         }
       ]
     }
-  },{
+},{
     "backend_name": "Git",
     "backend_version": "0.12.0",
     "perceval_version": "0.14.0",

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -471,7 +471,7 @@ class TestElastic(unittest.TestCase):
         elastic = ElasticSearch(self.es_con, self.target_index, GitOcean.mapping)
 
         new_items = elastic.bulk_upload(items, field_id="uuid")
-        self.assertEqual(new_items, 9)
+        self.assertEqual(new_items, 11)
 
     def test_bulk_upload_max_bulk(self):
         """Test whether items are correctly uploaded to an index"""
@@ -481,7 +481,7 @@ class TestElastic(unittest.TestCase):
         elastic.max_items_bulk = 2
 
         new_items = elastic.bulk_upload(items, field_id="uuid")
-        self.assertEqual(new_items, 9)
+        self.assertEqual(new_items, 11)
 
     def test_bulk_upload_no_items(self):
         """Test whether items are correctly uploaded to an index"""
@@ -600,11 +600,11 @@ class TestElastic(unittest.TestCase):
         items = json.loads(read_file('data/git.json'))
         elastic = ElasticSearch(self.es_con, self.target_index, GitOcean.mapping)
         new_items = elastic.bulk_upload(items, field_id="uuid")
-        self.assertEqual(new_items, 9)
+        self.assertEqual(new_items, 11)
 
         # no filter
         last_date = elastic.get_last_date('updated_on')
-        self.assertEqual(last_date.isoformat(), '2014-02-12T06:11:12+00:00')
+        self.assertEqual(last_date.isoformat(), '2019-10-01T18:05:52+00:00')
 
         # filter including all items
         fltr = {
@@ -656,15 +656,15 @@ class TestElastic(unittest.TestCase):
         items = json.loads(read_file('data/git.json'))
         elastic = ElasticSearch(self.es_con, self.target_index, GitOcean.mapping)
         new_items = elastic.bulk_upload(items, field_id="uuid")
-        self.assertEqual(new_items, 9)
+        self.assertEqual(new_items, 11)
 
         # no filter
         last_date = elastic.get_last_item_field('updated_on')
-        self.assertEqual(last_date.isoformat(), '2014-02-12T06:11:12+00:00')
+        self.assertEqual(last_date.isoformat(), '2019-10-01T18:05:52+00:00')
 
         # None filter
         last_date = elastic.get_last_item_field('updated_on', filters_=None)
-        self.assertEqual(last_date.isoformat(), '2014-02-12T06:11:12+00:00')
+        self.assertEqual(last_date.isoformat(), '2019-10-01T18:05:52+00:00')
 
         # Multiple filters
         fltrs = [
@@ -702,10 +702,10 @@ class TestElastic(unittest.TestCase):
         items[-1]['updated_on'] = items[-1]['updated_on'] * 1000
         elastic = ElasticSearch(self.es_con, self.target_index, GitOcean.mapping)
         new_items = elastic.bulk_upload(items, field_id="uuid")
-        self.assertEqual(new_items, 9)
+        self.assertEqual(new_items, 11)
 
         last_date = elastic.get_last_item_field('updated_on')
-        self.assertEqual(last_date.isoformat(), '2014-02-12T06:10:42.304000+00:00')
+        self.assertEqual(last_date.isoformat(), '2019-10-01T18:05:53.024000+00:00')
 
     def test_delete_items(self):
         """Test whether items are correctly deleted"""
@@ -717,13 +717,13 @@ class TestElastic(unittest.TestCase):
 
         elastic = ElasticSearch(self.es_con, self.target_index, GitOcean.mapping)
         new_items = elastic.bulk_upload(items, field_id="uuid")
-        self.assertEqual(new_items, 9)
+        self.assertEqual(new_items, 11)
 
         url = self.es_con + '/' + self.target_index + '/_count'
 
         elastic.delete_items(retention_time=90000000, time_field='timestamp')
         left_items = elastic.requests.get(url).json()['count']
-        self.assertEqual(left_items, 9)
+        self.assertEqual(left_items, 11)
 
         elastic.delete_items(retention_time=1, time_field='timestamp')
         left_items = elastic.requests.get(url).json()['count']
@@ -739,17 +739,17 @@ class TestElastic(unittest.TestCase):
 
         elastic = ElasticSearch(self.es_con, self.target_index, GitOcean.mapping)
         new_items = elastic.bulk_upload(items, field_id="uuid")
-        self.assertEqual(new_items, 9)
+        self.assertEqual(new_items, 11)
 
         url = self.es_con + '/' + self.target_index + '/_count'
 
         elastic.delete_items(retention_time=None, time_field='timestamp')
         left_items = elastic.requests.get(url).json()['count']
-        self.assertEqual(left_items, 9)
+        self.assertEqual(left_items, 11)
 
         elastic.delete_items(retention_time=-1, time_field='timestamp')
         left_items = elastic.requests.get(url).json()['count']
-        self.assertEqual(left_items, 9)
+        self.assertEqual(left_items, 11)
 
     def test_delete_items_error(self):
         """Test whether an error message is logged if the items aren't deleted"""
@@ -758,7 +758,7 @@ class TestElastic(unittest.TestCase):
 
         elastic = ElasticSearch(self.es_con, self.target_index, GitOcean.mapping)
         new_items = elastic.bulk_upload(items, field_id="uuid")
-        self.assertEqual(new_items, 9)
+        self.assertEqual(new_items, 11)
 
         with self.assertLogs(logger, level='ERROR') as cm:
             elastic.delete_items(retention_time=1, time_field='timestamp')

--- a/tests/test_enrich.py
+++ b/tests/test_enrich.py
@@ -28,7 +28,8 @@ from unittest.mock import MagicMock
 from grimoire_elk.elastic import logger
 from grimoire_elk.enriched.enrich import (Enrich,
                                           DEMOGRAPHICS_ALIAS,
-                                          HEADER_JSON)
+                                          HEADER_JSON,
+                                          anonymize_url)
 from sortinghat.db.model import UniqueIdentity, Profile
 from grimoire_elk.utils import get_connectors, get_elastic
 
@@ -641,7 +642,7 @@ class TestEnrich(unittest.TestCase):
 
         self.assertEqual(cm.output[0],
                          'INFO:grimoire_elk.elastic:Alias %s created on %s.'
-                         % (DEMOGRAPHICS_ALIAS, self._enrich.elastic.anonymize_url(tmp_index_url)))
+                         % (DEMOGRAPHICS_ALIAS, anonymize_url(tmp_index_url)))
 
         r = self._enrich.requests.get(self._enrich.elastic.index_url + "/_alias", headers=HEADER_JSON, verify=False)
         self.assertIn(DEMOGRAPHICS_ALIAS, r.json()[self._enrich.elastic.index]['aliases'])
@@ -652,7 +653,7 @@ class TestEnrich(unittest.TestCase):
 
         self.assertEqual(cm.output[0],
                          'DEBUG:grimoire_elk.elastic:Alias %s already exists on %s.'
-                         % (DEMOGRAPHICS_ALIAS, self._enrich.elastic.anonymize_url(tmp_index_url)))
+                         % (DEMOGRAPHICS_ALIAS, anonymize_url(tmp_index_url)))
 
         requests.delete(tmp_index_url, verify=False)
 

--- a/tests/test_gerrit.py
+++ b/tests/test_gerrit.py
@@ -25,7 +25,8 @@ import unittest
 
 from base import TestBaseBackend, DB_SORTINGHAT
 from grimoire_elk.enriched.enrich import (logger,
-                                          DEMOGRAPHICS_ALIAS)
+                                          DEMOGRAPHICS_ALIAS,
+                                          anonymize_url)
 from grimoire_elk.enriched.utils import REPO_LABELS
 
 
@@ -217,10 +218,10 @@ class TestGerrit(TestBaseBackend):
             self.assertEqual(cm.output[0],
                              'INFO:grimoire_elk.enriched.enrich:[gerrit] '
                              'Demography starting study %s/test_gerrit_enrich'
-                             % enrich_backend.elastic.anonymize_url(self.es_con))
+                             % anonymize_url(self.es_con))
             self.assertEqual(cm.output[-1],
                              'INFO:grimoire_elk.enriched.enrich:[gerrit] Demography end %s/test_gerrit_enrich'
-                             % enrich_backend.elastic.anonymize_url(self.es_con))
+                             % anonymize_url(self.es_con))
 
         time.sleep(5)  # HACK: Wait until git enrich index has been written
         items = [i for i in enrich_backend.fetch()]

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -305,7 +305,7 @@ class TestGit(TestBaseBackend):
         with self.assertLogs(logger, level='INFO') as cm:
 
             if study.__name__ == "enrich_forecast_activity":
-                study(ocean_backend, enrich_backend, out_index='git_study_forecast_activity', observations=2)
+                study(ocean_backend, enrich_backend, out_index='test_git_study_forecast_activity', observations=2)
 
                 self.assertEqual(cm.output[0], 'INFO:grimoire_elk.enriched.enrich:'
                                                '[enrich-forecast-activity] Start study')
@@ -313,7 +313,7 @@ class TestGit(TestBaseBackend):
                                                 '[enrich-forecast-activity] End study')
 
         time.sleep(5)  # HACK: Wait until git enrich index has been written
-        url = self.es_con + "/git_study_forecast_activity/_search?size=20"
+        url = self.es_con + "/test_git_study_forecast_activity/_search?size=20"
         response = enrich_backend.requests.get(url, verify=False).json()
         for hit in response['hits']['hits']:
             source = hit['_source']
@@ -342,22 +342,19 @@ class TestGit(TestBaseBackend):
             self.assertIn('metadata__gelk_backend_name', source)
             self.assertIn('metadata__enriched_on', source)
 
-        delete_survival = self.es_con + "/git_study_forecast_activity"
-        requests.delete(delete_survival, verify=False)
-
     def test_onion_study(self):
         """ Test that the onion study works correctly """
 
         study, ocean_backend, enrich_backend = self._test_study('enrich_onion')
-        study(ocean_backend, enrich_backend, in_index='test_git_enrich')
+        study(ocean_backend, enrich_backend, in_index='test_git_enrich', out_index='test_git_onion')
 
         url = self.es_con + "/_aliases"
         response = requests.get(url, verify=False).json()
-        self.assertTrue('git_onion-enriched' in response)
+        self.assertTrue('test_git_onion' in response)
 
         time.sleep(1)
 
-        url = self.es_con + "/git_onion-enriched/_search?size=20"
+        url = self.es_con + "/test_git_onion/_search?size=20"
         response = requests.get(url, verify=False).json()
         hits = response['hits']['hits']
         self.assertEqual(len(hits), 12)
@@ -377,9 +374,6 @@ class TestGit(TestBaseBackend):
             self.assertIn('metadata__enriched_on', source)
             self.assertIn('data_source', source)
             self.assertIn('grimoire_creation_date', source)
-
-        delete_onion = self.es_con + "/git_onion-enriched"
-        requests.delete(delete_onion, verify=False)
 
     def test_enrich_areas_of_code(self):
         """ Test that areas of code works correctly"""
@@ -403,9 +397,9 @@ class TestGit(TestBaseBackend):
                                                                 prjs_map=prjs_map,
                                                                 projects_json_repo=projects_json_repo)
 
-        study(ocean_backend, enrich_backend, in_index='test_git')
+        study(ocean_backend, enrich_backend, in_index='test_git', out_index='test_git_aoc')
         time.sleep(5)  # HACK: Wait until git area of code has been written
-        url = self.es_con + "/git_aoc-enriched/_search?size=20"
+        url = self.es_con + "/test_git_aoc/_search?size=20"
         response = enrich_backend.requests.get(url, verify=False).json()
         hits = response['hits']['hits']
         self.assertEqual(len(hits), 12)
@@ -451,9 +445,6 @@ class TestGit(TestBaseBackend):
             self.assertEqual(source['origin'], '/tmp/perceval_mc84igfc/gittest')
             self.assertEqual(source['repository'], '/tmp/perceval_mc84igfc/gittest')
 
-        delete_aoc = self.es_con + "/git_aoc-enriched"
-        requests.delete(delete_aoc, verify=False)
-
     def test_enrich_areas_of_code_private_repo(self):
         """ Test that areas of code works correctly for git private repos"""
 
@@ -476,9 +467,9 @@ class TestGit(TestBaseBackend):
                                                                 prjs_map=prjs_map,
                                                                 projects_json_repo=projects_json_repo)
 
-        study(ocean_backend, enrich_backend, in_index='test_git')
+        study(ocean_backend, enrich_backend, in_index='test_git', out_index='test_git_aoc_anonymized')
         time.sleep(5)  # HACK: Wait until git area of code has been written
-        url = self.es_con + "/git_aoc-enriched_anonymized/_search?size=20"
+        url = self.es_con + "/test_git_aoc_anonymized/_search?size=20"
         response = enrich_backend.requests.get(url, verify=False).json()
         hits = response['hits']['hits']
         self.assertEqual(len(hits), 2)
@@ -523,9 +514,6 @@ class TestGit(TestBaseBackend):
             self.assertIn('uuid', source)
             self.assertEqual(source['origin'], 'https://github.com/acme/errors')
             self.assertEqual(source['repository'], 'https://github.com/acme/errors')
-
-        delete_aoc = self.es_con + "/git_aoc-enriched_anonymized"
-        requests.delete(delete_aoc, verify=False)
 
     def test_perceval_params(self):
         """Test the extraction of perceval params from an URL"""

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -27,7 +27,8 @@ import unittest
 from base import TestBaseBackend
 from grimoire_elk.raw.git import GitOcean
 from grimoire_elk.enriched.enrich import (logger,
-                                          DEMOGRAPHICS_ALIAS)
+                                          DEMOGRAPHICS_ALIAS,
+                                          anonymize_url)
 from grimoire_elk.enriched.utils import REPO_LABELS
 
 
@@ -244,10 +245,10 @@ class TestGit(TestBaseBackend):
 
             self.assertEqual(cm.output[0], 'INFO:grimoire_elk.enriched.enrich:[git] Demography '
                                            'starting study %s/test_git_enrich'
-                             % enrich_backend.elastic.anonymize_url(self.es_con))
+                             % anonymize_url(self.es_con))
             self.assertEqual(cm.output[-1], 'INFO:grimoire_elk.enriched.enrich:[git] Demography '
                                             'end %s/test_git_enrich'
-                             % enrich_backend.elastic.anonymize_url(self.es_con))
+                             % anonymize_url(self.es_con))
 
         time.sleep(5)  # HACK: Wait until git enrich index has been written
         for item in enrich_backend.fetch():

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -26,7 +26,7 @@ import unittest
 from base import TestBaseBackend
 from grimoire_elk.enriched.enrich import logger
 from grimoire_elk.enriched.github import logger as logger_github
-from grimoire_elk.enriched.utils import REPO_LABELS
+from grimoire_elk.enriched.utils import REPO_LABELS, anonymize_url
 from grimoire_elk.raw.github import GitHubOcean
 
 
@@ -214,10 +214,10 @@ class TestGitHub(TestBaseBackend):
 
             self.assertEqual(cm.output[0], 'INFO:grimoire_elk.enriched.enrich:[github] Geolocation '
                                            'starting study %s/test_github_enrich'
-                             % enrich_backend.elastic.anonymize_url(self.es_con))
+                             % anonymize_url(self.es_con))
             self.assertEqual(cm.output[-1], 'INFO:grimoire_elk.enriched.enrich:[github] Geolocation '
                                             'end %s/test_github_enrich'
-                             % enrich_backend.elastic.anonymize_url(self.es_con))
+                             % anonymize_url(self.es_con))
 
         time.sleep(5)  # HACK: Wait until github enrich index has been written
         items = [item for item in enrich_backend.fetch() if 'user_location' in item]

--- a/tests/test_github2.py
+++ b/tests/test_github2.py
@@ -26,7 +26,7 @@ from unittest.mock import MagicMock
 
 from base import TestBaseBackend
 from grimoire_elk.enriched.enrich import logger
-from grimoire_elk.enriched.utils import REPO_LABELS
+from grimoire_elk.enriched.utils import REPO_LABELS, anonymize_url
 from grimoire_elk.raw.github import GitHubOcean
 
 
@@ -210,10 +210,10 @@ class TestGitHub2(TestBaseBackend):
 
             self.assertEqual(cm.output[0], 'INFO:grimoire_elk.enriched.enrich:[github] Geolocation '
                                            'starting study %s/test_github2_enrich'
-                             % enrich_backend.elastic.anonymize_url(self.es_con))
+                             % anonymize_url(self.es_con))
             self.assertEqual(cm.output[-1], 'INFO:grimoire_elk.enriched.enrich:[github] Geolocation '
                                             'end %s/test_github2_enrich'
-                             % enrich_backend.elastic.anonymize_url(self.es_con))
+                             % anonymize_url(self.es_con))
 
         time.sleep(5)  # HACK: Wait until github enrich index has been written
         items = [item for item in enrich_backend.fetch() if 'user_location' in item]


### PR DESCRIPTION
This code allows to handle Git private repos, which credentials are passed via the projects.json. To achieve this, the method `anonymize_url` in grimoire_elk/elastic.py has been removed and an equivalent function has been added to enriched/utils. This change is needed to ease the use of the
anonymize url feature across ELK.

The Git raw connector has been modified to include the method `_fix_item`, which takes care of removing the credentials that may appear in the origin. This change is needed to prevent storing in the raw index the credentials to access the Git private repos.

The method `get_repository_filter` in the enriched/utils has been modified to omit the credentials that may appear on the repo origin when creating the filter to get the data from the corresponding
raw index.

The study areas of code and git branches have been modified to omit the credentials in the repo urls to process. This change requires to also improve the way the attribute `project` is assigned to a repository. In the case of a private repo, the corresponding data source in the projects.json is accessed, each repo is anonymized and the output is compared with current repo (which value
is stored in the raw/enrich indexes).

Tests have been updated accordingly.