### PR TITLE
[enriched-git] Sync AOC and Git raw index

### DIFF
--- a/releases/unreleased/sync-aoc-and-git-indexes.yml
+++ b/releases/unreleased/sync-aoc-and-git-indexes.yml
@@ -1,0 +1,11 @@
+---
+title: Sync AOC and Git raw indexes
+category: added
+author: Valerio Cosentino <valcos@bitergia.com>
+issue: 884
+notes: >
+  Git commits can be deleted over time from the original repo (e.g., 
+  deleting working/test branches). Currently, this information is 
+  propagated to the raw and enriched indexes, but not the AOC 
+  index. This new feature allows to sync the Git raw data with 
+  the AOC one.


### PR DESCRIPTION
This code allows to delete the documents corresponding to commits that don't exist anymore in upstream. This is achieved by calculating the difference between the commit hashes in the AOC and raw indexes, the obtained hashes are deleted from the AOC index.

This approach is similar to the one implemented in the method `update_items`, which allows to sync the Git raw and enriched indexes with the local clone.

This PR also extends the support for private git repositories when deleting commits from the git indexes (raw, enrich and aoc).