### PR TITLE
[utils] Use entry points to support plugin mechanism

### DIFF
--- a/grimoire_elk/utils.py
+++ b/grimoire_elk/utils.py
@@ -25,6 +25,8 @@ import sys
 
 import requests
 
+import pkg_resources
+
 from grimoire_elk.errors import ElasticError
 from grimoire_elk.elastic import ElasticSearch
 # Connectors for Graal
@@ -170,6 +172,7 @@ logger = logging.getLogger(__name__)
 
 kibiter_version = None
 
+ENTRY_POINT_NAME = "grimoire_elk"
 
 def get_connector_from_name(name):
 
@@ -221,7 +224,7 @@ def get_connector_name_from_cls_name(cls_name):
 
 def get_connectors():
 
-    return {"askbot": [Askbot, AskbotOcean, AskbotEnrich, AskbotCommand],
+    connectors = {"askbot": [Askbot, AskbotOcean, AskbotEnrich, AskbotCommand],
             "bugzilla": [Bugzilla, BugzillaOcean, BugzillaEnrich, BugzillaCommand],
             "bugzillarest": [BugzillaREST, BugzillaRESTOcean, BugzillaRESTEnrich, BugzillaRESTCommand],
             "cocom": [CoCom, GraalOcean, CocomEnrich, CoComCommand],
@@ -269,6 +272,11 @@ def get_connectors():
             "telegram": [Telegram, TelegramOcean, TelegramEnrich, TelegramCommand],
             "twitter": [Twitter, TwitterOcean, TwitterEnrich, TwitterCommand]
             }  # Will come from Registry
+
+    for entry_point in pkg_resources.iter_entry_points(ENTRY_POINT_NAME):
+        connectors.update(entry_point.load()())
+
+    return connectors
 
 
 def get_elastic(url, es_index, clean=None, backend=None, es_aliases=None, mapping=None):


### PR DESCRIPTION
This PR aims to support plugin mechanism for ELK. Related with #880 .

This code uses `pkg_resources.iter_entry_points()` to discover the registered entry point `grimoire_elk` and then load the `connectors` of external backends : 
```python
ENTRY_POINT_NAME = "grimoire_elk"

def get_connectors():
    # The default connectors
    connectors = {}
    for entry_point in pkg_resources.iter_entry_points(ENTRY_POINT_NAME):
        connectors.update(entry_point.load()())
    return connectors
```

Maybe we need pick up anothe suitable definition for `ENTRY_POINT_NAME` instead of `grimoire_elk`, I guess.

I will write some documentation for external packages about how to register themselves if necessary. 

Please @valeriocos @sduenas @WillemJiang help look into this and any feedback or suggestions are appreciated.

Signed-off-by: LinHaiming <lhming23@outlook.com>