### PR TITLE
[elastic] Support for filter no-collection on multi params URLs

### DIFF
--- a/grimoire_elk/enriched/mediawiki.py
+++ b/grimoire_elk/enriched/mediawiki.py
@@ -24,6 +24,7 @@ import logging
 
 from grimoirelab_toolkit.datetime import str_to_datetime
 
+from ..raw.elastic import PRJ_JSON_FILTER_SEPARATOR
 from .enrich import Enrich, metadata, anonymize_url
 from ..elastic_mapping import Mapping as BaseMapping
 
@@ -161,6 +162,7 @@ class MediaWikiEnrich(Enrich):
             # And now some calculated fields
             if self.prjs_map and "mediawiki" in self.prjs_map:
                 for repo in self.prjs_map["mediawiki"].keys():
+                    repo = repo.split(PRJ_JSON_FILTER_SEPARATOR)[0].strip()
                     if erevision["page_origin"] in repo:
                         urls = repo.split()
                         # If only one URL is given, then we consider same URL for API and web server

--- a/grimoire_elk/raw/elastic.py
+++ b/grimoire_elk/raw/elastic.py
@@ -108,7 +108,7 @@ class ElasticOcean(ElasticItems):
             return {"url": url}
 
         # otherwise, add the url to the params
-        params = {'url': url.split(' ', 1)[0]}
+        params = {'url': url.split(PRJ_JSON_FILTER_SEPARATOR, 1)[0].strip()}
         # tokenize the filter and add them to the param dict
         tokens = url.split(PRJ_JSON_FILTER_SEPARATOR)[1:]
 

--- a/tests/data/mediawiki.json
+++ b/tests/data/mediawiki.json
@@ -111,7 +111,7 @@
         "type": "edit",
         "update": 1466557537.0
     },
-    "origin": "https://wiki.mozilla.org/",
+    "origin": "https://wiki-archive.opendaylight.org",
     "perceval_version": "0.9.10",
     "tag": "https://wiki.mozilla.org/",
     "timestamp": 1518170803.375229,

--- a/tests/data/projects-release.json
+++ b/tests/data/projects-release.json
@@ -73,7 +73,8 @@
             "metrics-grimoire /home/bitergia/.perceval/mbox"
         ],
         "mediawiki": [
-            "https://wiki.mozilla.org https://wiki.mozilla.org/view"
+            "https://wiki.mozilla.org https://wiki.mozilla.org/view",
+            "https://wiki-archive.opendaylight.org https://wiki-archive.opendaylight.org/view --filter-no-collection=true"
         ],
         "meetup": [
             "South-East-Puppet-User-Group"

--- a/tests/test_mediawiki.py
+++ b/tests/test_mediawiki.py
@@ -239,6 +239,24 @@ class TestMediawiki(TestBaseBackend):
         ]
         self.assertListEqual(MediaWikiOcean.get_perceval_params_from_url(url), expected_params)
 
+        url = "https://wiki-archive.opendaylight.org https://wiki-archive.opendaylight.org/view"
+        expected_params = [
+            "https://wiki-archive.opendaylight.org"
+        ]
+        self.assertListEqual(MediaWikiOcean.get_perceval_params_from_url(url), expected_params)
+
+    def test_p2o_params(self):
+        """Test the extraction of p2o params from an URL"""
+
+        url = "https://wiki-archive.opendaylight.org " \
+              "https://wiki-archive.opendaylight.org/view" \
+              "--filter-no-collection=true"
+        expected_params = {
+            'url': 'https://wiki-archive.opendaylight.org https://wiki-archive.opendaylight.org/view',
+            'filter-no-collection': 'true'
+        }
+        self.assertDictEqual(MediaWikiOcean.get_p2o_params_from_url(url), expected_params)
+
     def test_copy_raw_fields(self):
         """Test copied raw fields"""
 

--- a/tests/test_mediawiki.py
+++ b/tests/test_mediawiki.py
@@ -110,7 +110,8 @@ class TestMediawiki(TestBaseBackend):
         self.assertEqual(eitem['isrevision'], 1)
 
         eitem = eitems[4]
-        self.assertEqual(eitem['url'], 'https://wiki.mozilla.org//Technical_Collaboration_Guideline/Translation')
+        self.assertEqual(eitem['url'],
+                         'https://wiki-archive.opendaylight.org/Technical_Collaboration_Guideline/Translation')
         self.assertIn('metadata__gelk_version', eitem)
         self.assertIn('metadata__gelk_backend_name', eitem)
         self.assertIn('metadata__enriched_on', eitem)
@@ -122,7 +123,8 @@ class TestMediawiki(TestBaseBackend):
         self.assertEqual(eitem['isrevision'], 0)
 
         eitem = eitems[5]
-        self.assertEqual(eitem['url'], 'https://wiki.mozilla.org//Technical_Collaboration_Guideline/Translation')
+        self.assertEqual(eitem['url'],
+                         'https://wiki-archive.opendaylight.org/Technical_Collaboration_Guideline/Translation')
         self.assertIn('metadata__gelk_version', eitem)
         self.assertIn('metadata__gelk_backend_name', eitem)
         self.assertIn('metadata__enriched_on', eitem)
@@ -134,7 +136,8 @@ class TestMediawiki(TestBaseBackend):
         self.assertEqual(eitem['isrevision'], 1)
 
         eitem = eitems[6]
-        self.assertEqual(eitem['url'], 'https://wiki.mozilla.org//Technical_Collaboration_Guideline/Translation')
+        self.assertEqual(eitem['url'],
+                         'https://wiki-archive.opendaylight.org/Technical_Collaboration_Guideline/Translation')
         self.assertIn('metadata__gelk_version', eitem)
         self.assertIn('metadata__gelk_backend_name', eitem)
         self.assertIn('metadata__enriched_on', eitem)
@@ -146,7 +149,8 @@ class TestMediawiki(TestBaseBackend):
         self.assertEqual(eitem['isrevision'], 1)
 
         eitem = eitems[7]
-        self.assertEqual(eitem['url'], 'https://wiki.mozilla.org//Technical_Collaboration_Guideline/Translation')
+        self.assertEqual(eitem['url'],
+                         'https://wiki-archive.opendaylight.org/Technical_Collaboration_Guideline/Translation')
         self.assertIn('metadata__gelk_version', eitem)
         self.assertIn('metadata__gelk_backend_name', eitem)
         self.assertIn('metadata__enriched_on', eitem)


### PR DESCRIPTION
This code allows to support the filter no-collection for URLs composed of multiples params, for instance:
```
"https://wiki-archive.opendaylight.org https://wiki-archive.opendaylight.org/view"
```

Tests have been added accordingly.