### PR TITLE
[enriched-githubql] Add label attribute to closed events

### DIFF
--- a/grimoire_elk/enriched/githubql.py
+++ b/grimoire_elk/enriched/githubql.py
@@ -171,6 +171,7 @@ class GitHubQLEnrich(Enrich):
             rich_event['label_updated_at'] = label['updatedAt']
         elif rich_event['event_type'] in CLOSED_EVENTS:
             closer = event['closer']
+            rich_event['label'] = rich_event['issue_labels']
             if closer and closer['type'] == 'PullRequest':
                 rich_event['closer_event_url'] = event['url']
                 rich_event['closer_type'] = closer['type']


### PR DESCRIPTION
This code adds the attribute `label` which contains the issue labels to the closed events. This change is needed to allow calculations between label-related and closed events using a common attribute.