### PR TITLE
[deps] Constrain numpy version to <= 1.18.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ urllib3==1.24.3
 PyMySQL>=0.7.0
 geopy>=1.20.0
 pandas>=0.22.0,<=0.25.3
+numpy<=1.18.3
 statsmodels >= 0.9.0
 -e git+https://github.com/chaoss/grimoirelab-sortinghat/#egg=grimoirelab-sortinghat
 -e git+https://github.com/chaoss/grimoirelab-toolkit/#egg=grimoirelab-toolkit

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ setup(name="grimoire-elk",
           'urllib3==1.24.3',
           'PyMySQL>=0.7.0',
           'pandas>=0.22.0,<=0.25.3',
+          'numpy<=1.18.3',
           'geopy>=1.20.0',
           'statsmodels >= 0.9.0'
       ],


### PR DESCRIPTION
The numpy dependency is constrained to <= 1.18.3. This change is needed since from version 1.19.x the support for python 3.5 has been discontinued.

Refs:
- https://numpy.org/devdocs/release/1.19.0-notes.html#id1
- https://github.com/numpy/numpy/issues/16294