### PR TITLE
[grimoire_elk] Remove tzinfo for date comparison

### DIFF
--- a/grimoire_elk/elk.py
+++ b/grimoire_elk/elk.py
@@ -154,7 +154,7 @@ def feed_backend(url, clean, fetch_archive, backend_name, backend_params,
             params['branches'] = branches
         if filter_classified:
             params['filter_classified'] = filter_classified
-        if from_date and (from_date.replace(tzinfo=None) != str_to_datetime("1970-01-01")):
+        if from_date and (from_date.replace(tzinfo=None) != str_to_datetime("1970-01-01").replace(tzinfo=None)):
             params['from_date'] = from_date
         if offset:
             params['from_offset'] = offset

--- a/grimoire_elk/enriched/utils.py
+++ b/grimoire_elk/enriched/utils.py
@@ -176,7 +176,7 @@ def get_last_enrich(backend_cmd, enrich_backend, filter_raw=None):
                 offset = backend_cmd.parsed_args.offset
 
         if from_date:
-            if from_date.replace(tzinfo=None) != str_to_datetime("1970-01-01"):
+            if from_date.replace(tzinfo=None) != str_to_datetime("1970-01-01").replace(tzinfo=None):
                 last_enrich = from_date
             # if the index is empty, set the last enrich to None
             elif not enrich_backend.from_date:


### PR DESCRIPTION
This code removes the tzinfo used to compare the `from_date` value with the default one (1970-01-01) to perform the incremental fetching.

This change is needed to fix a bug introduced at:
- https://github.com/chaoss/grimoirelab-elk/commit/e2994480c6e4c40c7736f911e4287660e2863f31#diff-a94b51d8c8a4c2e33e52cff8968a0b3cR158
- https://github.com/chaoss/grimoirelab-elk/commit/e2994480c6e4c40c7736f911e4287660e2863f31#diff-928a29f9b639dcb91b5081e292e0d1c3R170

The bug consists in not removing the tzinfo from the value obtained from the method `str_to_datetime`.