### PR TITLE
[enriched-slack] Handle messages without user data/bot ID

### DIFF
--- a/grimoire_elk/enriched/slack.py
+++ b/grimoire_elk/enriched/slack.py
@@ -72,8 +72,9 @@ class SlackEnrich(Enrich):
         from_ = item
         if isinstance(item, dict) and 'data' in item:
             if self.get_field_author() not in item['data']:
-                # Message from bot
-                identity['username'] = item['data']['bot_id']
+                # Message from bot. For the rare cases where both user
+                # and bot_id are not present, an empty identity is returned
+                identity['username'] = item['data'].get('bot_id', None)
                 return identity
             from_ = item['data'][self.get_field_author()]
 

--- a/tests/data/slack.json
+++ b/tests/data/slack.json
@@ -1107,12 +1107,143 @@
     "perceval_version": "0.13.0",
     "search_fields": {
         "channel_id": "C011DUKE8",
-        "channel_name": "test channel",
+        "channel_name": "general",
         "item_id": "1588324642.0U08900H12100NA1V"
     },
     "tag": "https://slack.com/C011DUKE8",
     "timestamp": 1588324850.898842,
     "updated_on": 1588324642.0001,
     "uuid": "8bc7cbaa1fe5a6a56d5758a05100e838bf6f47c2"
+},
+{
+    "backend_name": "Slack",
+    "backend_version": "0.9.1",
+    "category": "message",
+    "classified_fields_filtered": null,
+    "data": {
+        "bot_id": "B0CELKA3V",
+        "channel_info": {
+            "created": 1417520065,
+            "creator": "U02K3A647",
+            "id": "C033RE5D6",
+            "is_archived": false,
+            "is_channel": true,
+            "is_ext_shared": false,
+            "is_general": false,
+            "is_group": false,
+            "is_im": false,
+            "is_member": false,
+            "is_mpim": false,
+            "is_org_shared": false,
+            "is_pending_ext_shared": false,
+            "is_private": false,
+            "is_shared": false,
+            "name": "darden",
+            "name_normalized": "darden",
+            "num_members": 4565,
+            "parent_conversation": null,
+            "pending_connected_team_ids": [],
+            "pending_shared": [],
+            "previous_names": [],
+            "purpose": {
+                "creator": "U05KN71R3",
+                "last_set": 1431689272,
+                "value": "Dardeners\u2019"
+            },
+            "shared_team_ids": [
+                "T02FL4A12"
+            ],
+            "topic": {
+                "creator": "U4YWUSQAJ",
+                "last_set": 1588855518,
+                "value": "Interrupt"
+            },
+            "unlinked": 0
+        },
+        "icons": {
+            "image_48": "https://example.png"
+        },
+        "subtype": "bot_message",
+        "text": ":rotating_light:",
+        "ts": "1487773145.012411",
+        "type": "message",
+        "username": "raiden"
+    },
+    "origin": "https://slack.com/C011DUKE8",
+    "perceval_version": "0.15.0",
+    "search_fields": {
+        "channel_id": "C011DUKE8",
+        "channel_name": "general",
+        "item_id": "1487773145.012411B0CELKA3V"
+    },
+    "tag": "https://slack.com/C011DUKE8",
+    "timestamp": 1592559490.170055,
+    "updated_on": 1487773145.012411,
+    "uuid": "aaac053b62e79c2d6b6d74334f6fb6741ac883df"
+},
+{
+    "backend_name": "Slack",
+    "backend_version": "0.9.1",
+    "category": "message",
+    "classified_fields_filtered": null,
+    "data": {
+        "channel_info": {
+            "created": 1417520069,
+            "creator": "U02K3A647",
+            "id": "C033RE5D6",
+            "is_archived": false,
+            "is_channel": true,
+            "is_ext_shared": false,
+            "is_general": false,
+            "is_group": false,
+            "is_im": false,
+            "is_member": false,
+            "is_mpim": false,
+            "is_org_shared": false,
+            "is_pending_ext_shared": false,
+            "is_private": false,
+            "is_shared": false,
+            "name": "darden",
+            "name_normalized": "darden",
+            "num_members": 4565,
+            "parent_conversation": null,
+            "pending_connected_team_ids": [],
+            "pending_shared": [],
+            "previous_names": [],
+            "purpose": {
+                "creator": "U05KN71R3",
+                "last_set": 1431689272,
+                "value": "Dardeners\u2019"
+            },
+            "shared_team_ids": [
+                "T02FL4A12"
+            ],
+            "topic": {
+                "creator": "U4YWUSQAJ",
+                "last_set": 1588855518,
+                "value": "Interrupt"
+            },
+            "unlinked": 0
+        },
+        "icons": {
+            "image_48": "https://example.png"
+        },
+        "subtype": "bot_message",
+        "text": ":+1:",
+        "ts": "1487773145.012415",
+        "type": "message",
+        "username": "raiden"
+    },
+    "origin": "https://slack.com/C011DUKE8",
+    "perceval_version": "0.15.0",
+    "search_fields": {
+        "channel_id": "C011DUKE8",
+        "channel_name": "general",
+        "item_id": "1487773145.012411B0CELKAZV"
+    },
+    "tag": "https://slack.com/C011DUKE8",
+    "timestamp": 1592559495.170057,
+    "updated_on": 1487773148.012413,
+    "uuid": "aaac053b62e79c2d6b6d74334f6fb6741ac883de"
 }
 ]

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -44,8 +44,8 @@ class TestSlack(TestBaseBackend):
         """Test whether JSON items are properly inserted into ES"""
 
         result = self._test_items_to_raw()
-        self.assertEqual(result['items'], 10)
-        self.assertEqual(result['raw'], 10)
+        self.assertEqual(result['items'], 12)
+        self.assertEqual(result['raw'], 12)
 
         for item in self.items:
             self.ocean_backend._fix_item(item)
@@ -56,8 +56,8 @@ class TestSlack(TestBaseBackend):
         """Test whether the raw index is properly enriched"""
 
         result = self._test_raw_to_enrich()
-        self.assertEqual(result['raw'], 10)
-        self.assertEqual(result['enrich'], 10)
+        self.assertEqual(result['raw'], 12)
+        self.assertEqual(result['enrich'], 12)
 
         enrich_backend = self.connectors[self.connector][2]()
 
@@ -90,8 +90,8 @@ class TestSlack(TestBaseBackend):
         """Test enrich with SortingHat"""
 
         result = self._test_raw_to_enrich(sortinghat=True)
-        self.assertEqual(result['raw'], 10)
-        self.assertEqual(result['enrich'], 10)
+        self.assertEqual(result['raw'], 12)
+        self.assertEqual(result['enrich'], 12)
 
         enrich_backend = self.connectors[self.connector][2]()
         enrich_backend.sortinghat = True
@@ -122,8 +122,8 @@ class TestSlack(TestBaseBackend):
         """Test enrich with Projects"""
 
         result = self._test_raw_to_enrich(projects=True)
-        self.assertEqual(result['raw'], 10)
-        self.assertEqual(result['enrich'], 10)
+        self.assertEqual(result['raw'], 12)
+        self.assertEqual(result['enrich'], 12)
 
         res = requests.get(self.es_con + "/" + self.enrich_index + "/_search", verify=False)
         for eitem in res.json()['hits']['hits']:


### PR DESCRIPTION
This code allows to handle the rare cases where neither the user data nor bot ID are present in
the Perceval document. For these cases, an empty identity is returned by the method `get_sh_identity`.

Tests have been added accordingly.

Related to https://github.com/chaoss/grimoirelab-perceval/pull/675