### PR TITLE
[enriched-git] Execute update_items when local repo commits are returned

### DIFF
--- a/grimoire_elk/enriched/git.py
+++ b/grimoire_elk/enriched/git.py
@@ -762,8 +762,10 @@ class GitEnrich(Enrich):
         except RepositoryError:
             logger.warning("No commits retrieved from {}, repo doesn't exist locally".format(repo_origin))
         except Exception as e:
-            logger.error("[git] No commits retrieved from {}, "
-                         "git rev-list command failed: {}".format(repo_origin, e))
+            logger.error("[git] No commits retrieved from {}, git rev-list command failed: {}".format(repo_origin, e))
+
+        if not current_hashes:
+            return current_hashes
 
         current_hashes = set(current_hashes)
         raw_hashes = set([item['data']['commit']


### PR DESCRIPTION
This code prevents to delete commits from the raw and enriched indexes when no commits are returned from the local Git repository. This change is needed to cover the cases when an error is thrown during the execution of `rev_list` or when the location of the local repo has changed.