### PR TITLE
[enriched-enrich] Set user-agent for geopy

### DIFF
--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -1390,7 +1390,7 @@ class Enrich(ElasticItems):
 
         locations_no_geo_points = es_in.search(index=in_index, body=query_locations_no_geo_points)
         locations = [loc['key'] for loc in locations_no_geo_points['aggregations']['locations'].get('buckets', [])]
-        geolocator = Nominatim()
+        geolocator = Nominatim(user_agent='grimoirelab-elk')
 
         for location in locations:
             # Default lat and lon coordinates point to the Null Island https://en.wikipedia.org/wiki/Null_Island

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ elasticsearch-dsl==6.3.1
 requests==2.21.0
 urllib3==1.24.3
 PyMySQL>=0.7.0
-geopy>=1.20.0
+geopy>=2.0.0
 pandas>=0.22.0,<=0.25.3
 numpy<=1.18.3
 statsmodels >= 0.9.0

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(name="grimoire-elk",
           'PyMySQL>=0.7.0',
           'pandas>=0.22.0,<=0.25.3',
           'numpy<=1.18.3',
-          'geopy>=1.20.0',
+          'geopy>=2.0.0',
           'statsmodels >= 0.9.0'
       ],
       zip_safe=False


### PR DESCRIPTION
This code sets the user-agent used by the study enrich_geolocation. This change is needed to support
geopy 2.0.0, which requires the declaration of a custom user-agent.