### PR TITLE
[enriched/mediawiki] Add `repository_labels` field

### DIFF
--- a/grimoire_elk/enriched/mediawiki.py
+++ b/grimoire_elk/enriched/mediawiki.py
@@ -190,6 +190,7 @@ class MediaWikiEnrich(Enrich):
             erevision['metadata__gelk_version'] = eitem['metadata__gelk_version']
             erevision['metadata__gelk_backend_name'] = eitem['metadata__gelk_backend_name']
             erevision['metadata__enriched_on'] = eitem['metadata__enriched_on']
+            erevision['repository_labels'] = eitem['repository_labels']
 
             erevision.update(self.get_grimoire_fields(erevision['creation_date'], REVISION_TYPE))
 

--- a/tests/test_mediawiki.py
+++ b/tests/test_mediawiki.py
@@ -167,9 +167,11 @@ class TestMediawiki(TestBaseBackend):
         self._test_raw_to_enrich()
         enrich_backend = self.connectors[self.connector][2]()
 
-        for item in self.items:
-            eitem = enrich_backend.get_rich_item(item)
-            self.assertIn(REPO_LABELS, eitem)
+        item = self.items[0]
+        eitems = enrich_backend.get_rich_item_reviews(item)
+
+        for ei in eitems:
+            self.assertIn(REPO_LABELS, ei)
 
     def test_raw_to_enrich_sorting_hat(self):
         """Test enrich with SortingHat"""


### PR DESCRIPTION
This code adds the `repository_labels` field to the enriched index.

Test updated accordingly.

Signed-off-by: Quan Zhou <quan@bitergia.com>