### PR TITLE
[enriched/jira] Add `is_closed` and `status_category_key` fields

### DIFF
--- a/grimoire_elk/enriched/jira.py
+++ b/grimoire_elk/enriched/jira.py
@@ -33,6 +33,7 @@ from .utils import get_time_diff_days
 MAX_SIZE_BULK_ENRICHED_ITEMS = 200
 ISSUE_TYPE = 'issue'
 COMMENT_TYPE = 'comment'
+CLOSED_STATUS_CATEGORY_KEY = 'done'
 
 logger = logging.getLogger(__name__)
 
@@ -291,6 +292,10 @@ class JiraEnrich(Enrich):
         eitem['resolution_date'] = issue['fields']['resolutiondate']
         eitem['status_description'] = issue['fields']['status']['description']
         eitem['status'] = issue['fields']['status']['name']
+        eitem['status_category_key'] = issue['fields']['status']['statusCategory']['key']
+        eitem['is_closed'] = 0
+        if eitem['status_category_key'] == CLOSED_STATUS_CATEGORY_KEY:
+            eitem['is_closed'] = 1
         eitem['summary'] = issue['fields']['summary']
         if 'timeoriginalestimate' in issue['fields']:
             eitem['original_time_estimation'] = issue['fields']['timeoriginalestimate']

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -74,6 +74,8 @@ class TestJira(TestBaseBackend):
         self.assertIn("main_description", eitem)
         self.assertIn("main_description_analyzed", eitem)
         self.assertEqual(eitem['author_type'], 'assignee')
+        self.assertEqual(eitem['status_category_key'], 'done')
+        self.assertEqual(eitem['is_closed'], 1)
 
         item = self.items[0]
         eitem = enrich_backend.get_rich_item(item, author_type='reporter')
@@ -90,6 +92,8 @@ class TestJira(TestBaseBackend):
         self.assertEqual(eitem['id'], "d6b4168fd458f910fb9af1df0e9edcfaa188cc67_issue_10008_user_creator")
         self.assertEqual(eitem['number_of_comments'], 0)
         self.assertEqual(eitem['author_type'], 'creator')
+        self.assertEqual(eitem['status_category_key'], 'done')
+        self.assertEqual(eitem['is_closed'], 1)
 
         item = self.items[3]
         eitem = enrich_backend.get_rich_item(item)
@@ -97,6 +101,8 @@ class TestJira(TestBaseBackend):
         self.assertEqual(eitem['id'], "305dbd15b1f250cb6941d8b9270af3d3a4405084_issue_10017_user_creator")
         self.assertEqual(eitem['number_of_comments'], 0)
         self.assertEqual(eitem['author_type'], 'creator')
+        self.assertEqual(eitem['status_category_key'], 'done')
+        self.assertEqual(eitem['is_closed'], 1)
 
         item = self.items[4]
         eitem = enrich_backend.get_rich_item(item)
@@ -104,6 +110,8 @@ class TestJira(TestBaseBackend):
         self.assertEqual(eitem['id'], "929182e386ddb7d290c0dbd2eb34140993c8f567_issue_10018_user_creator")
         self.assertEqual(eitem['number_of_comments'], 2)
         self.assertEqual(eitem['author_type'], 'creator')
+        self.assertEqual(eitem['status_category_key'], 'done')
+        self.assertEqual(eitem['is_closed'], 1)
 
     def test_enrich_repo_labels(self):
         """Test whether the field REPO_LABELS is present in the enriched items"""


### PR DESCRIPTION
These fields allow us to know if the issue is closed or open:
- `is_closed`: 1 if the issue is closed or 0 if not.
- `status_category_key`: The key of the issue status.

Test added accordingly.

Signed-off-by: Quan Zhou <quan@bitergia.com>