### PR TITLE
[enriched/githubql] Add new study 'enrich_reference_analysis'

### DIFF
--- a/schema/cross_references.csv
+++ b/schema/cross_references.csv
@@ -1,0 +1,3 @@
+name,type,aggregatable,description
+referenced_by_<element>,keyword,true,"Array of URLs of the elements (GitHub Issues `issues` or Pull Requests `prs`) referencing a given Issue or Pull request from the same repository."
+referenced_by_external_<element>,keyword,true,"Array of URLs of the elements (GitHub Issues or Pull Requests) referencing a given Issue or Pull request. These elements belong to a different repository than the Issue or PR they are referencing."

--- a/schema/github_events.csv
+++ b/schema/github_events.csv
@@ -1,4 +1,5 @@
 name,type,aggregatable,description
+<Cross-references fields>,NA,NA,"Fields coming from cross references study (available only when it is active), see cross_references.csv."
 actor_bot,boolean,true,"True/False if the event actor is a bot or not from SortingHat profile."
 actor_domain,keyword,true,"Event actor domain name from SortingHat profile."
 actor_gender,keyword,true,"Event actor gender, based on her name, from SortingHat (disabled by default)."


### PR DESCRIPTION
The purpose of this study is to gather all the issues and pull requests which are mutually referenced.
Once these references are obtained, all of the events for the given issue or pull request are updated with the corresponding list of URLs from the referenced items.

The following fields are added:
* `referenced_by_issues`: List of issues referenced by a given Issue or Pull Request, from the same repository.
* `referenced_by_prs`: List of pull requests referenced by a given Issue or Pull Request, from the same repository.
* `referenced_by_external_issues`: List of issues referenced by a given Issue or Pull Request, from different (external) repositories.
* `referenced_by_external_prs`: List of pull requests referenced by a given Issue or Pull Request, from different (external) repositories.

Schema CSV files have been updated accordingly.

Note: This feature also needs PR https://github.com/chaoss/grimoirelab-sirmordred/pull/488 to be merged.