### PR TITLE
[weblate] New enricher to handle changes

### DIFF
--- a/grimoire_elk/enriched/weblate.py
+++ b/grimoire_elk/enriched/weblate.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#   Quan Zhou <quan@bitergia.com>
+#
+
+
+import logging
+
+from grimoirelab_toolkit.datetime import str_to_datetime
+
+from .enrich import Enrich, metadata
+from ..elastic_mapping import Mapping as BaseMapping
+
+
+logger = logging.getLogger(__name__)
+
+
+class Mapping(BaseMapping):
+
+    @staticmethod
+    def get_elastic_mappings(es_major):
+        """Get Elasticsearch mapping.
+
+        :param es_major: major version of Elasticsearch, as string
+        :returns: dictionary with a key, 'items', with the mapping
+        """
+
+        mapping = """
+        {
+            "properties": {
+                "text_analyzed": {
+                  "type": "text",
+                  "fielddata": true,
+                  "index": true
+                }
+           }
+        } """
+
+        return {"items": mapping}
+
+
+class WeblateEnrich(Enrich):
+
+    mapping = Mapping
+
+    def __init__(self, db_sortinghat=None, db_projects_map=None, json_projects_map=None,
+                 db_user='', db_password='', db_host=''):
+        super().__init__(db_sortinghat, db_projects_map, json_projects_map,
+                         db_user, db_password, db_host)
+
+        self.studies = []
+        self.studies.append(self.enrich_demography)
+
+    def get_field_author(self):
+        return "author_data"
+
+    def get_sh_identity(self, item, identity_field=None):
+        # email not available for gitter
+        identity = {
+            'username': None,
+            'name': None,
+            'email': None
+        }
+
+        author = item['data'][self.get_field_author()]
+        if not author:
+            return identity
+
+        identity['username'] = author.get('username', None)
+        identity['name'] = author.get('full_name', None)
+        identity['email'] = author.get('email', None)
+
+        return identity
+
+    def get_identities(self, item):
+        """ Return the identities from an item """
+
+        identity = self.get_sh_identity(item)
+        yield identity
+
+    def get_project_repository(self, eitem):
+        repo = eitem['origin']
+        return repo
+
+    @metadata
+    def get_rich_item(self, item):
+
+        eitem = {}
+
+        self.copy_raw_fields(self.RAW_FIELDS_COPY, item, eitem)
+
+        change = item['data']
+
+        change_timestamp = str_to_datetime(eitem['metadata__updated_on'])
+        eitem['tz'] = int(change_timestamp.strftime("%H"))
+        eitem['action'] = change['action']
+        eitem['action_name'] = change['action_name']
+        eitem['glossary_term'] = change['glossary_term']
+        eitem['change_id'] = change['id']
+        eitem['target'] = change['target']
+        eitem['change_api_url'] = change['url']
+
+        eitem['author_api_url'] = change['author']
+        if change['author_data']:
+            user_data = change['author_data']
+            for data in user_data:
+                eitem['author_' + data] = user_data[data]
+
+        eitem['user_api_url'] = change['user']
+        if change['user']:
+            eitem['user_name'] = change['user'].split('api/users/')[1].split('/')[0]
+        if change['user_data']:
+            user_data = change['user_data']
+            for data in user_data:
+                eitem['user_' + data] = user_data[data]
+
+        eitem['unit_api_url'] = change['unit']
+        if change['unit_data']:
+            user_data = change['unit_data']
+            for data in user_data:
+                if 'has_' in data:
+                    eitem['unit_' + data] = 1 if user_data[data] else 0
+                else:
+                    eitem['unit_' + data] = user_data[data]
+
+        eitem['component_api_url'] = change['component']
+        if change['component']:
+            component = change['component']
+            # component = <source>/api/components/<project>/<component>
+            project_name = component.split('api/components/')[1].split('/')[0]
+            component_name = component.split('api/components/')[1].split('/')[1]
+            eitem['project_name'] = project_name
+            eitem['component_name'] = component_name
+
+        eitem['translation_api_url'] = change['translation']
+        if change['translation']:
+            translation = change['translation']
+            # component = <source>/api/components/<project>/<component>/<translation>
+            project_name = translation.split('api/translations/')[1].split('/')[0]
+            component_name = translation.split('api/translations/')[1].split('/')[1]
+            translation_name = translation.split('api/translations/')[1].split('/')[2]
+            eitem['project_name'] = project_name
+            eitem['component_name'] = component_name
+            eitem['translation_name'] = translation_name
+
+        if self.sortinghat:
+            eitem.update(self.get_item_sh(item))
+
+        if self.prjs_map:
+            eitem.update(self.get_item_project(eitem))
+
+        eitem.update(self.get_grimoire_fields(item["metadata__updated_on"], "message"))
+
+        self.add_repository_labels(eitem)
+        self.add_metadata_filter_raw(eitem)
+        return eitem
+
+    def enrich_demography(self, ocean_backend, enrich_backend, date_field="grimoire_creation_date",
+                          author_field="author_uuid"):
+
+        super().enrich_demography(ocean_backend, enrich_backend, date_field, author_field=author_field)

--- a/grimoire_elk/raw/weblate.py
+++ b/grimoire_elk/raw/weblate.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#   Quan Zhou <quan@bitergia.com>
+#
+
+from .elastic import ElasticOcean
+from ..elastic_mapping import Mapping as BaseMapping
+
+
+class Mapping(BaseMapping):
+
+    @staticmethod
+    def get_elastic_mappings(es_major):
+        """Get Elasticsearch mapping.
+
+        :param es_major: major version of Elasticsearch, as string
+        :returns: dictionary with a key, 'items', with the mapping
+        """
+
+        mapping = '''
+             {
+                "dynamic":true,
+                "properties": {
+                    "data": {
+                        "dynamic":false,
+                        "properties": {}
+                    }
+                }
+            }
+            '''
+
+        return {"items": mapping}
+
+
+class WeblateOcean(ElasticOcean):
+    """Weblate Ocean feeder"""
+
+    mapping = Mapping
+
+    def _fix_item(self, item):
+        change = item['data']
+        if change['author_data'] or not change['author']:
+            return
+
+        name = change['author'].split('api/users/')[1].split('/')[0]
+        author_data = {
+            'username': name,
+            'full_name': None,
+            'email': None
+        }
+        change['author_data'] = author_data

--- a/grimoire_elk/utils.py
+++ b/grimoire_elk/utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2020 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,6 +17,7 @@
 #
 # Authors:
 #   Alvaro del Castillo San Felix <acs@bitergia.com>
+#   Quan Zhou <quan@bitergia.com>
 #
 
 import argparse
@@ -75,6 +76,8 @@ from perceval.backends.mozilla.kitsune import Kitsune, KitsuneCommand
 from perceval.backends.mozilla.mozillaclub import MozillaClub, MozillaClubCommand
 from perceval.backends.mozilla.remo import ReMo, ReMoCommand
 from perceval.backends.opnfv.functest import Functest, FunctestCommand
+from perceval.backends.weblate.weblate import Weblate, WeblateCommand
+
 # Connectors for EnrichOcean
 from .enriched.askbot import AskbotEnrich
 from .enriched.bugzilla import BugzillaEnrich
@@ -122,6 +125,7 @@ from .enriched.stackexchange import StackExchangeEnrich
 from .enriched.supybot import SupybotEnrich
 from .enriched.telegram import TelegramEnrich
 from .enriched.twitter import TwitterEnrich
+from .enriched.weblate import WeblateEnrich
 # Connectors for Ocean
 from .raw.askbot import AskbotOcean
 from .raw.bugzilla import BugzillaOcean
@@ -165,6 +169,7 @@ from .raw.stackexchange import StackExchangeOcean
 from .raw.supybot import SupybotOcean
 from .raw.telegram import TelegramOcean
 from .raw.twitter import TwitterOcean
+from .raw.weblate import WeblateOcean
 
 logger = logging.getLogger(__name__)
 
@@ -267,7 +272,8 @@ def get_connectors():
                               StackExchangeEnrich, StackExchangeCommand],
             "supybot": [Supybot, SupybotOcean, SupybotEnrich, SupybotCommand],
             "telegram": [Telegram, TelegramOcean, TelegramEnrich, TelegramCommand],
-            "twitter": [Twitter, TwitterOcean, TwitterEnrich, TwitterCommand]
+            "twitter": [Twitter, TwitterOcean, TwitterEnrich, TwitterCommand],
+            "weblate": [Weblate, WeblateOcean, WeblateEnrich, WeblateCommand]
             }  # Will come from Registry
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,5 @@ statsmodels >= 0.9.0
 -e git+https://github.com/chaoss/grimoirelab-perceval-mozilla/#egg=grimoirelab-perceval-mozilla
 -e git+https://github.com/chaoss/grimoirelab-perceval-opnfv/#egg=grimoirelab-perceval-opnfv
 -e git+https://github.com/chaoss/grimoirelab-perceval-puppet/#egg=grimoirelab-perceval-puppet
+-e git+https://github.com/chaoss/grimoirelab-perceval-weblate/#egg=grimoirelab-perceval-weblate
 -e git+https://github.com/Bitergia/grimoirelab-perceval-finos/#egg=grimoirelab-perceval-finos

--- a/tests/data/projects-release.json
+++ b/tests/data/projects-release.json
@@ -122,6 +122,9 @@
         ],
         "twitter": [
             ""
+        ],
+        "weblate": [
+            "https://my.weblate.org"
         ]
     },
     "unknown": {

--- a/tests/data/weblate.json
+++ b/tests/data/weblate.json
@@ -1,0 +1,220 @@
+[
+    {
+        "backend_name": "Weblate",
+        "backend_version": "0.1.0",
+        "perceval_version": "0.17.1",
+        "timestamp": 1600344221.316199,
+        "origin": "https://my.weblate.org",
+        "uuid": "83a1ea675884a0cdeff02d30a7013e1600907524",
+        "updated_on": 1562862020.95807,
+        "classified_fields_filtered": null,
+        "category": "changes",
+        "search_fields": {
+            "item_id": "1"
+        },
+        "tag": "https://my.weblate.org",
+        "data": {
+            "unit": "https://my.weblate.org/api/units/1",
+            "unit_data": {
+                "approved": false,
+                "content_hash": -4676561869944754315,
+                "context": "content.text",
+                "flags": "",
+                "fuzzy": false,
+                "has_comment": false,
+                "has_failing_check": false,
+                "has_suggestion": false,
+                "id": 1,
+                "id_hash": -4676561869944754315,
+                "location": "Error.ulf",
+                "note": "iEw33",
+                "num_words": 11,
+                "position": 1,
+                "previous_source": "",
+                "priority": 100,
+                "source": "Contact your support personnel.",
+                "target": "Modul",
+                "translated": true,
+                "translation": "https://my.weblate.org/api/translations/project/com/de/",
+                "url": "https://my.weblate.org/api/units/1/",
+                "web_url": "https://my.weblate.org/translate/project/com/de/?checksum=aaaaaaaa"
+            },
+            "component": null,
+            "translation": null,
+            "glossary_term": null,
+            "user": "https://my.weblate.org/api/users/1",
+            "author": "https://my.weblate.org/api/users/1",
+            "timestamp": "2019-07-11T16:20:20.958070Z",
+            "action": 50,
+            "target": "",
+            "id": 1,
+            "action_name": "Created project",
+            "url": "https://my.weblate.org/api/changes/1/",
+            "user_data": {
+                "email": "quan@bitergia.com",
+                "full_name": "quan zhou",
+                "username": "quan",
+                "groups": [
+                    "https://my.weblate.org/api/groups/2/",
+                    "https://my.weblate.org/api/groups/3/"
+                ],
+                "is_superuser": false,
+                "is_active": true,
+                "date_joined": "2020-09-16T09:03:33.581180Z",
+                "url": "https://my.weblate.org/api/users/1/"
+            },
+            "author_data": {
+                "email": "quan@bitergia.com",
+                "full_name": "quan zhou",
+                "username": "quan",
+                "groups": [
+                    "https://my.weblate.org/api/groups/2/",
+                    "https://my.weblate.org/api/groups/3/"
+                ],
+                "is_superuser": false,
+                "is_active": true,
+                "date_joined": "2020-09-16T09:03:33.581180Z",
+                "url": "https://my.weblate.org/api/users/1/"
+            }
+        }
+    },
+    {
+        "backend_name": "Weblate",
+        "backend_version": "0.1.0",
+        "perceval_version": "0.17.1",
+        "timestamp": 1600344221.351258,
+        "origin": "https://my.weblate.org",
+        "uuid": "ca17062e0fe54ffb3bb80d2f6967f56709d43bfe",
+        "updated_on": 1562862071.939033,
+        "classified_fields_filtered": null,
+        "category": "changes",
+        "search_fields": {
+            "item_id": "2"
+        },
+        "tag": "https://my.weblate.org",
+        "data": {
+            "unit": null,
+            "component": null,
+            "translation": null,
+            "glossary_term": null,
+            "user": "https://my.weblate.org/api/users/2",
+            "author": "https://my.weblate.org/api/users/2",
+            "timestamp": "2019-07-11T16:21:11.939033Z",
+            "action": 50,
+            "target": "",
+            "id": 2,
+            "action_name": "Created project",
+            "url": "https://my.weblate.org/api/changes/2/",
+            "user_data": {
+                "email": "tom@jerry.com",
+                "full_name": "tom jerry",
+                "username": "tom",
+                "groups": [
+                    "https://my.weblate.org/api/groups/2/",
+                    "https://my.weblate.org/api/groups/3/"
+                ],
+                "is_superuser": false,
+                "is_active": true,
+                "date_joined": "2020-09-17T09:03:33.581180Z",
+                "url": "https://my.weblate.org/api/users/2/"
+            },
+            "author_data": {
+                "email": "tom@jerry.com",
+                "full_name": "tom jerry",
+                "username": "tom",
+                "groups": [
+                    "https://my.weblate.org/api/groups/2/",
+                    "https://my.weblate.org/api/groups/3/"
+                ],
+                "is_superuser": false,
+                "is_active": true,
+                "date_joined": "2020-09-17T09:03:33.581180Z",
+                "url": "https://my.weblate.org/api/users/2/"
+            }
+        }
+    },
+    {
+        "backend_name": "Weblate",
+        "backend_version": "0.1.0",
+        "perceval_version": "0.17.1",
+        "timestamp": 1600344221.399991,
+        "origin": "https://my.weblate.org",
+        "uuid": "957659c9f35d7b35795296ff69f69b87356e6fe6",
+        "updated_on": 1594488063.378436,
+        "classified_fields_filtered": null,
+        "category": "changes",
+        "search_fields": {
+            "item_id": "3"
+        },
+        "tag": "https://my.weblate.org",
+        "data": {
+            "unit": null,
+            "component": "https://my.weblate.org/api/components/master/native/",
+            "translation": "https://my.weblate.org/api/translations/master/native/es",
+            "glossary_term": null,
+            "user": "https://my.weblate.org/api/users/2",
+            "author": "https://my.weblate.org/api/users/2",
+            "timestamp": "2020-07-11T17:21:03.378436Z",
+            "action": 51,
+            "target": "",
+            "id": 3,
+            "action_name": "Created component",
+            "url": "https://my.weblate.org/api/changes/3/",
+            "user_data": {
+                "email": "tom@jerry.com",
+                "full_name": "tom jerry",
+                "username": "tom",
+                "groups": [
+                    "https://my.weblate.org/api/groups/2/",
+                    "https://my.weblate.org/api/groups/3/"
+                ],
+                "is_superuser": false,
+                "is_active": true,
+                "date_joined": "2020-09-17T09:03:33.581180Z",
+                "url": "https://my.weblate.org/api/users/2/"
+            },
+            "author_data": {
+                "email": "tom@jerry.com",
+                "full_name": "tom jerry",
+                "username": "tom",
+                "groups": [
+                    "https://my.weblate.org/api/groups/2/",
+                    "https://my.weblate.org/api/groups/3/"
+                ],
+                "is_superuser": false,
+                "is_active": true,
+                "date_joined": "2020-09-17T09:03:33.581180Z",
+                "url": "https://my.weblate.org/api/users/2/"
+            }
+        }
+    },
+    {
+        "backend_name": "Weblate",
+        "backend_version": "0.1.0",
+        "perceval_version": "0.17.1",
+        "timestamp": 1600344221.401215,
+        "origin": "https://my.weblate.org",
+        "uuid": "eab568229e67d6f630832ee1446e247d6207a3b3",
+        "updated_on": 1594488064.609924,
+        "classified_fields_filtered": null,
+        "category": "changes",
+        "search_fields": {
+            "item_id": "4"
+        },
+        "tag": "https://my.weblate.org",
+        "data": {
+            "unit": null,
+            "component": "https://my.weblate.org/api/components/italian/nativo/",
+            "translation": "https://my.weblate.org/api/translations/italian/nativo/it",
+            "glossary_term": null,
+            "user": null,
+            "author": null,
+            "timestamp": "2020-07-11T17:21:04.609924Z",
+            "action": 21,
+            "target": "",
+            "id": 4,
+            "action_name": "Rebased repository",
+            "url": "https://my.weblate.org/api/changes/4/"
+        }
+    }
+]

--- a/tests/test_weblate.py
+++ b/tests/test_weblate.py
@@ -1,0 +1,232 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Quan Zhou <quan@bitergia.com>
+#
+
+
+import logging
+import unittest
+
+import requests
+from base import TestBaseBackend
+from grimoire_elk.enriched.utils import REPO_LABELS
+
+
+class TestWeblate(TestBaseBackend):
+    """Test Weblate backend"""
+
+    connector = "weblate"
+    ocean_index = "test_" + connector
+    enrich_index = "test_" + connector + "_enrich"
+
+    def test_has_identites(self):
+        """Test value of has_identities method"""
+
+        enrich_backend = self.connectors[self.connector][2]()
+        self.assertTrue(enrich_backend.has_identities())
+
+    def test_items_to_raw(self):
+        """Test whether JSON items are properly inserted into ES"""
+
+        result = self._test_items_to_raw()
+        self.assertEqual(result['items'], 4)
+        self.assertEqual(result['raw'], 4)
+
+        author_data = [
+            {
+                "email": "quan@bitergia.com",
+                "full_name": "quan zhou",
+                "username": "quan",
+                "groups": [
+                    "https://my.weblate.org/api/groups/2/",
+                    "https://my.weblate.org/api/groups/3/"
+                ],
+                "is_superuser": False,
+                "is_active": True,
+                "date_joined": "2020-09-16T09:03:33.581180Z",
+                "url": "https://my.weblate.org/api/users/1/"
+            },
+            {
+                "email": "tom@jerry.com",
+                "full_name": "tom jerry",
+                "username": "tom",
+                "groups": [
+                    "https://my.weblate.org/api/groups/2/",
+                    "https://my.weblate.org/api/groups/3/"
+                ],
+                "is_superuser": False,
+                "is_active": True,
+                "date_joined": "2020-09-17T09:03:33.581180Z",
+                "url": "https://my.weblate.org/api/users/2/"
+            },
+            {
+                "email": "tom@jerry.com",
+                "full_name": "tom jerry",
+                "username": "tom",
+                "groups": [
+                    "https://my.weblate.org/api/groups/2/",
+                    "https://my.weblate.org/api/groups/3/"
+                ],
+                "is_superuser": False,
+                "is_active": True,
+                "date_joined": "2020-09-17T09:03:33.581180Z",
+                "url": "https://my.weblate.org/api/users/2/"
+            }
+        ]
+        for i, item in enumerate(self.items):
+            self.ocean_backend._fix_item(item)
+
+            if i == 3:
+                self.assertNotIn('author_data', item['data'])
+                self.assertIsNone(item['data']['author'])
+            else:
+                self.assertEqual(author_data[i], item['data']['author_data'])
+
+    def test_raw_to_enrich(self):
+        """Test whether the raw index is properly enriched"""
+
+        result = self._test_raw_to_enrich()
+        self.assertEqual(result['raw'], 4)
+        self.assertEqual(result['enrich'], 4)
+
+        enrich_backend = self.connectors[self.connector][2]()
+
+        item = self.items[0]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['author_full_name'], 'quan zhou')
+        self.assertEqual(eitem['change_id'], 1)
+        self.assertEqual(eitem['change_api_url'], 'https://my.weblate.org/api/changes/1/')
+        self.assertIsNone(eitem['component_api_url'])
+        self.assertIsNone(eitem['translation_api_url'])
+        self.assertEqual(eitem['unit_id'], 1)
+        self.assertEqual(eitem['unit_context'], 'content.text')
+        self.assertEqual(eitem['unit_api_url'], 'https://my.weblate.org/api/units/1')
+
+        item = self.items[1]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['author_full_name'], 'tom jerry')
+        self.assertEqual(eitem['change_id'], 2)
+        self.assertEqual(eitem['change_api_url'], 'https://my.weblate.org/api/changes/2/')
+        self.assertIsNone(eitem['component_api_url'])
+        self.assertIsNone(eitem['translation_api_url'])
+        self.assertNotIn('unit_context', eitem)
+
+        item = self.items[2]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['author_full_name'], 'tom jerry')
+        self.assertEqual(eitem['change_id'], 3)
+        self.assertEqual(eitem['change_api_url'], 'https://my.weblate.org/api/changes/3/')
+        self.assertEqual(eitem['component_api_url'], 'https://my.weblate.org/api/components/master/native/')
+        self.assertEqual(eitem['component_name'], 'native')
+        self.assertEqual(eitem['translation_api_url'], 'https://my.weblate.org/api/translations/master/native/es')
+        self.assertEqual(eitem['translation_name'], 'es')
+        self.assertEqual(eitem['project_name'], 'master')
+        self.assertNotIn('unit_context', eitem)
+
+        item = self.items[3]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertNotIn('author_full_name', eitem)
+        self.assertEqual(eitem['change_id'], 4)
+        self.assertEqual(eitem['change_api_url'], 'https://my.weblate.org/api/changes/4/')
+        self.assertEqual(eitem['component_api_url'], 'https://my.weblate.org/api/components/italian/nativo/')
+        self.assertEqual(eitem['component_name'], 'nativo')
+        self.assertEqual(eitem['translation_api_url'], 'https://my.weblate.org/api/translations/italian/nativo/it')
+        self.assertEqual(eitem['translation_name'], 'it')
+        self.assertEqual(eitem['project_name'], 'italian')
+        self.assertNotIn('unit_context', eitem)
+
+    def test_enrich_repo_labels(self):
+        """Test whether the field REPO_LABELS is present in the enriched items"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            self.assertIn(REPO_LABELS, eitem)
+
+    def test_raw_to_enrich_sorting_hat(self):
+        """Test enrich with SortingHat"""
+
+        result = self._test_raw_to_enrich(sortinghat=True)
+        self.assertEqual(result['raw'], 4)
+        self.assertEqual(result['enrich'], 4)
+
+        enrich_backend = self.connectors[self.connector][2]()
+        enrich_backend.sortinghat = True
+
+        item = self.items[0]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['author_name'], 'quan zhou')
+        self.assertEqual(eitem['author_user_name'], 'quan')
+        self.assertEqual(eitem['author_org_name'], 'Unknown')
+        self.assertEqual(eitem['author_multi_org_names'], ['Unknown'])
+
+        item = self.items[1]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['author_name'], 'tom jerry')
+        self.assertEqual(eitem['author_user_name'], 'tom')
+        self.assertEqual(eitem['author_org_name'], 'Unknown')
+        self.assertEqual(eitem['author_multi_org_names'], ['Unknown'])
+
+        item = self.items[2]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertEqual(eitem['author_name'], 'tom jerry')
+        self.assertEqual(eitem['author_user_name'], 'tom')
+        self.assertEqual(eitem['author_org_name'], 'Unknown')
+        self.assertEqual(eitem['author_multi_org_names'], ['Unknown'])
+
+        item = self.items[3]
+        eitem = enrich_backend.get_rich_item(item)
+        self.assertNotIn('author_name', eitem)
+        self.assertNotIn('author_user_name', eitem)
+        self.assertNotIn('author_org_name', eitem)
+        self.assertNotIn('author_multi_org_names', eitem)
+
+    def test_raw_to_enrich_projects(self):
+        """Test enrich with Projects"""
+
+        result = self._test_raw_to_enrich(projects=True)
+        self.assertEqual(result['raw'], 4)
+        self.assertEqual(result['enrich'], 4)
+
+        res = requests.get(self.es_con + "/" + self.enrich_index + "/_search", verify=False)
+        for eitem in res.json()['hits']['hits']:
+            self.assertEqual(eitem['_source']['project'], "grimoire")
+
+    def test_copy_raw_fields(self):
+        """Test copied raw fields"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        for item in self.items:
+            eitem = enrich_backend.get_rich_item(item)
+            for attribute in enrich_backend.RAW_FIELDS_COPY:
+                if attribute in item:
+                    self.assertEqual(item[attribute], eitem[attribute])
+                else:
+                    self.assertIsNone(eitem[attribute])
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+    logging.getLogger("requests").setLevel(logging.WARNING)
+    unittest.main(warnings='ignore')


### PR DESCRIPTION
This code proposes a new weblate enricher to handle changes
including their units and author information.

Demography study included.

The new enricher is added to the list of connetors and can be
defined in the mordred setup.cfg as follows:
```
[weblate]
raw_index = weblate_chaoss_raw
enriched_index = weblate_chaoss_enriched
api-token= ...
no-archive = true
sleep-for-rate = true
studies = [enrich_demography:weblate]

[enrich_demography:weblate]
```

projects.json
```
{
  "chaoss": {
    "weblate": [
      "my.weblate.org"
    ]
  }
}
```

Tests added accordingly.

Signed-off-by: Quan Zhou <quan@bitergia.com>