### PR TITLE
[enriched/githubql] Update references in related indexes

### DIFF
--- a/schema/github2_issues.csv
+++ b/schema/github2_issues.csv
@@ -1,4 +1,5 @@
 name,type,aggregatable,description
+<Cross-references fields>,NA,NA,"Fields coming from cross references study (available only when it is active), see cross_references.csv."
 assignee_data_bot,boolean,true,"True/False if the assignee is a bot or not."
 assignee_data_domain,keyword,true,"Assignee's domain name from SortingHat profile."
 assignee_data_gender,keyword,true,"Assignee gender."

--- a/schema/github2_pull_requests.csv
+++ b/schema/github2_pull_requests.csv
@@ -1,4 +1,5 @@
 name,type,aggregatable,description
+<Cross-references fields>,NA,NA,"Fields coming from cross references study (available only when it is active), see cross_references.csv."
 assignee_geolocation,geo_point,true,"Pull request assignee geolocation from GitHub."
 author_bot,boolean,true,"True/False if the Pull request author is a bot or not from SortingHat profile."
 author_domain,keyword,true,"Pull request author domain name from SortingHat profile."

--- a/schema/github_issues.csv
+++ b/schema/github_issues.csv
@@ -1,4 +1,5 @@
 name,type,aggregatable,description
+<Cross-references fields>,NA,NA,"Fields coming from cross references study (available only when it is active), see cross_references.csv."
 assignee_data_bot,boolean,true,"True/False if the assignee is a bot or not."
 assignee_data_domain,keyword,true,"Assignee's domain name from SortingHat profile."
 assignee_data_id,keyword,true,"Assignee's id from SortingHat profile."

--- a/schema/github_pull_requests.csv
+++ b/schema/github_pull_requests.csv
@@ -1,4 +1,5 @@
 name,type,aggregatable,description
+<Cross-references fields>,NA,NA,"Fields coming from cross references study (available only when it is active), see cross_references.csv."
 assignee_geolocation,geo_point,true,"Pull Request assignee geolocation from GitHub."
 author_bot,boolean,true,"True/False if the Pull Request author is a bot or not from SortingHat profile."
 author_domain,keyword,true,"Pull Request author domain name from SortingHat profile."


### PR DESCRIPTION
The cross reference study now accepts a list of related ES aliases or indices to be updated with the obtained references
between GitHub issues and Pull Requests, for all the elements identified by a given `issue_url`.

E.g., `github_issues` alias, which points to the corresponding enriched indexes from GitHub issues. Note that if the referenced
aliases or indexes do not contain the `issue_url` field, the affected elements can't be updated.

This is an example about how the `setup.cfg` has to be updated:

```
[githubql]
...
studies = [..., enrich_reference_analysis]

[enrich_reference_analysis]]
aliases_update = [github_issues, github2_issues, github2_pull_requests]
```

The affected index patters have been updated in this PR: https://github.com/chaoss/grimoirelab-sigils/pull/476

**Note**: as soon as this PR and https://github.com/chaoss/grimoirelab-sigils/pull/476 get merged, the index pattern for `github_issues` has to be updated to include the field `issue_url`, after the changes from https://github.com/chaoss/grimoirelab-elk/pull/942.