### PR TITLE
[enriched/githubql] Classify merged PRs within cross-references study

### DIFF
--- a/schema/cross_references.csv
+++ b/schema/cross_references.csv
@@ -1,3 +1,5 @@
 name,type,aggregatable,description
 referenced_by_<element>,keyword,true,"Array of URLs of the elements (GitHub Issues `issues` or Pull Requests `prs`) referencing a given Issue or Pull request from the same repository."
 referenced_by_external_<element>,keyword,true,"Array of URLs of the elements (GitHub Issues or Pull Requests) referencing a given Issue or Pull request. These elements belong to a different repository than the Issue or PR they are referencing."
+referenced_by_merged_prs,keyword,true,"Array of URLs of the merged GitHub Pull Requests referencing a given Issue or Pull request from the same repository."
+referenced_by_external_merged_prs,keyword,true,"Array of URLs of the merged GitHub Pull Requests referencing a given Issue or Pull request. These elements belong to a different repository than the merged PR they are referencing."

--- a/tests/data/githubql.json
+++ b/tests/data/githubql.json
@@ -1331,5 +1331,104 @@
         "timestamp": 1603367283.883483,
         "updated_on": 1398278714.0,
         "uuid": "ab5185ff2db57d4aad3bc8963634c3cb86bfc7b8"
+    },
+    {
+        "backend_name": "GitHubQL",
+        "backend_version": "0.2.0",
+        "category": "event",
+        "classified_fields_filtered": null,
+        "data": {
+            "actor": {
+                "login": "valeriocos"
+            },
+            "createdAt": "2020-04-12T07:51:05Z",
+            "eventType": "MergedEvent",
+            "id": "MDExOk1lcmdlZEV2ZW50MzIyNDg1NzkwNg==",
+            "issue": {
+                "active_lock_reason": null,
+                "assignee": null,
+                "assignees": [],
+                "author_association": "OWNER",
+                "body": "Fixes #1 ",
+                "closed_at": "2020-04-12T07:51:05Z",
+                "comments": 0,
+                "comments_url": "https://api.github.com/repos/valeriocos/test-issues-update/issues/3/comments",
+                "created_at": "2020-04-12T07:50:25Z",
+                "events_url": "https://api.github.com/repos/valeriocos/test-issues-update/issues/3/events",
+                "html_url": "https://github.com/valeriocos/test-issues-update/pull/3",
+                "id": 598431445,
+                "labels": [],
+                "labels_url": "https://api.github.com/repos/valeriocos/test-issues-update/issues/3/labels{/name}",
+                "locked": false,
+                "milestone": null,
+                "node_id": "MDExOlB1bGxSZXF1ZXN0NDAyMzAyMjU5",
+                "number": 3,
+                "performed_via_github_app": null,
+                "pull_request": {
+                    "diff_url": "https://github.com/valeriocos/test-issues-update/pull/3.diff",
+                    "html_url": "https://github.com/valeriocos/test-issues-update/pull/3",
+                    "patch_url": "https://github.com/valeriocos/test-issues-update/pull/3.patch",
+                    "url": "https://api.github.com/repos/valeriocos/test-issues-update/pulls/3"
+                },
+                "reactions": {
+                    "+1": 0,
+                    "-1": 0,
+                    "confused": 0,
+                    "eyes": 0,
+                    "heart": 0,
+                    "hooray": 0,
+                    "laugh": 0,
+                    "rocket": 0,
+                    "total_count": 0,
+                    "url": "https://api.github.com/repos/valeriocos/test-issues-update/issues/3/reactions"
+                },
+                "repository_url": "https://api.github.com/repos/valeriocos/test-issues-update",
+                "state": "closed",
+                "title": "first pr",
+                "updated_at": "2020-04-12T07:51:05Z",
+                "url": "https://api.github.com/repos/valeriocos/test-issues-update/issues/3",
+                "user": {
+                    "avatar_url": "https://avatars2.githubusercontent.com/u/6515067?v=4",
+                    "events_url": "https://api.github.com/users/valeriocos/events{/privacy}",
+                    "followers_url": "https://api.github.com/users/valeriocos/followers",
+                    "following_url": "https://api.github.com/users/valeriocos/following{/other_user}",
+                    "gists_url": "https://api.github.com/users/valeriocos/gists{/gist_id}",
+                    "gravatar_id": "",
+                    "html_url": "https://github.com/valeriocos",
+                    "id": 6515067,
+                    "login": "valeriocos",
+                    "node_id": "MDQ6VXNlcjY1MTUwNjc=",
+                    "organizations_url": "https://api.github.com/users/valeriocos/orgs",
+                    "received_events_url": "https://api.github.com/users/valeriocos/received_events",
+                    "repos_url": "https://api.github.com/users/valeriocos/repos",
+                    "site_admin": false,
+                    "starred_url": "https://api.github.com/users/valeriocos/starred{/owner}{/repo}",
+                    "subscriptions_url": "https://api.github.com/users/valeriocos/subscriptions",
+                    "type": "User",
+                    "url": "https://api.github.com/users/valeriocos"
+                }
+            },
+            "pullRequest": {
+                "closed": true,
+                "closedAt": "2020-04-12T07:51:05Z",
+                "createdAt": "2020-04-12T07:50:25Z",
+                "merged": true,
+                "mergedAt": "2020-04-12T07:51:05Z",
+                "updatedAt": "2020-04-12T07:51:05Z",
+                "url": "https://github.com/valeriocos/test-issues-update/pull/3"
+            },
+            "url": "https://github.com/valeriocos/test-issues-update/pull/3#event-3224857906"
+        },
+        "origin": "https://github.com/valeriocos/test-issues-update",
+        "perceval_version": "0.17.1",
+        "search_fields": {
+            "item_id": "MDExOk1lcmdlZEV2ZW50MzIyNDg1NzkwNg==",
+            "owner": "valeriocos",
+            "repo": "test-issues-update"
+        },
+        "tag": "https://github.com/valeriocos/test-issues-update",
+        "timestamp": 1603726681.688073,
+        "updated_on": 1586677865,
+        "uuid": "bd94b736428477b4a56ca30a2db2d6c5b89a5564"
     }
 ]

--- a/tests/test_githubql.py
+++ b/tests/test_githubql.py
@@ -395,8 +395,10 @@ class TestGitHubQL(TestBaseBackend):
         for item in referenced_items:
             self.assertIn('referenced_by_issues', item)
             self.assertIn('referenced_by_prs', item)
+            self.assertIn('referenced_by_merged_prs', item)
             self.assertIn('referenced_by_external_issues', item)
             self.assertIn('referenced_by_external_prs', item)
+            self.assertIn('referenced_by_external_merged_prs', item)
 
             ref_issues = item['referenced_by_issues']
             self.assertEqual(len(ref_issues), 1)
@@ -405,9 +407,15 @@ class TestGitHubQL(TestBaseBackend):
             self.assertEqual(ref, 'https://github.com/valeriocos/test-issues-update/issues/2')
 
             ref_prs = item['referenced_by_prs']
-            self.assertEqual(len(ref_issues), 1)
+            self.assertEqual(len(ref_prs), 1)
 
             ref = ref_prs[0]
+            self.assertEqual(ref, 'https://github.com/valeriocos/test-issues-update/pull/3')
+
+            ref_merged_prs = item['referenced_by_merged_prs']
+            self.assertEqual(len(ref_merged_prs), 1)
+
+            ref = ref_merged_prs[0]
             self.assertEqual(ref, 'https://github.com/valeriocos/test-issues-update/pull/3')
 
             ref_ext_issues = item['referenced_by_external_issues']
@@ -415,6 +423,9 @@ class TestGitHubQL(TestBaseBackend):
 
             ref_ext_prs = item['referenced_by_external_prs']
             self.assertEqual(len(ref_ext_prs), 0)
+
+            ref_ext_merged_prs = item['referenced_by_external_merged_prs']
+            self.assertEqual(len(ref_ext_merged_prs), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The cross reference study now classifies merged GitHub PRs based on a list obtained from `MergedEvents` items. These merged PRs are divided in the following two new fields:
* `referenced_by_merged_prs`: Referenced, merged PRs from the same repository as the issue or PR referencing it.
* `referenced_by_external_merged_prs`: Referenced, merged PRs from a different repository of the one from the issue or referencing it.

These new fields are also updated for the rest of GitHub-related indexes for all the affected elements identified by `issue_url`.

- [x] Update `githubql` CSV schema.
- [x] Wait for both PRs https://github.com/chaoss/grimoirelab-perceval/pull/697 and https://github.com/chaoss/grimoirelab-elk/pull/947 get accepted and merged (to test if the changes from this PR work with the rest of the chain as expected).
- [x] Ready for review.

Note: I'm preparing another PR to `grimoirelab-sigils` repository to update `githubql` and the rest of github-related index patterns with new fields. **EDIT**: PR available at https://github.com/chaoss/grimoirelab-sigils/pull/480.