### PR TITLE
[enriched/github:prs] Add fields for Pull Requests-related data

### DIFF
--- a/grimoire_elk/enriched/github.py
+++ b/grimoire_elk/enriched/github.py
@@ -488,6 +488,9 @@ class GitHubEnrich(Enrich):
         rich_pr['merged_at'] = pull_request['merged_at']
         rich_pr['closed_at'] = pull_request['closed_at']
         rich_pr['url'] = pull_request['html_url']
+        rich_pr['additions'] = pull_request['additions']
+        rich_pr['deletions'] = pull_request['deletions']
+        rich_pr['changed_files'] = pull_request['changed_files']
         # Adding this field for consistency with the rest of github-related enrichers
         rich_pr['issue_url'] = pull_request['html_url']
         labels = []

--- a/schema/github_pull_requests.csv
+++ b/schema/github_pull_requests.csv
@@ -1,5 +1,6 @@
 name,type,aggregatable,description
 <Cross-references fields>,NA,NA,"Fields coming from cross references study (available only when it is active), see cross_references.csv."
+additions,long,true,"Number of additions in the Pull Request."
 assignee_geolocation,geo_point,true,"Pull Request assignee geolocation from GitHub."
 author_bot,boolean,true,"True/False if the Pull Request author is a bot or not from SortingHat profile."
 author_domain,keyword,true,"Pull Request author domain name from SortingHat profile."
@@ -11,9 +12,11 @@ author_org_name,keyword,true,"Pull Request author organization name from Sorting
 author_multi_org_names,keyword,true,"List of the author organizations from SortingHat profile."
 author_user_name,keyword,true,"Pull Request author username from SortingHat profile."
 author_uuid,keyword,true,"Pull Request author UUID from SortingHat profile."
+changed_files,long,true,"Number of changed files in the Pull Request."
 closed_at,date,true,"Date in which the Issue was closed."
 code_merge_duration,float,true,"Difference in days between creation and merging dates."
 created_at,date,true,"Date in which the Issue was created."
+deletions,long,true,"Number of deletions in the Pull Request."
 forks,long,true,"Number of repository forks."
 github_repo,keyword,true,"GitHub repository name."
 grimoire_creation_date,date,true,"Pull Request creation date."

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -91,6 +91,9 @@ class TestGitHub(TestBaseBackend):
         self.assertEqual(eitem['user_data_domain'], 'zhquan_example.com')
         self.assertEqual(eitem['merged_by_data_uuid'], '5f9d42ce000e46e9eee60a3c64a353b560051a2e')
         self.assertEqual(eitem['merged_by_data_domain'], 'zhquan_example.com')
+        self.assertEqual(eitem['additions'], 528)
+        self.assertEqual(eitem['deletions'], 0)
+        self.assertEqual(eitem['changed_files'], 4)
 
         self.assertEqual(eitem['url'], 'https://github.com/zhquan_example/repo/pull/1')
         self.assertEqual(eitem['issue_url'], 'https://github.com/zhquan_example/repo/pull/1')
@@ -151,6 +154,9 @@ class TestGitHub(TestBaseBackend):
         self.assertEqual(eitem['user_data_name'], 'acs')
         self.assertEqual(eitem['user_data_uuid'], 'e8cc482634f2095c935b6a586ddb9ed8215d5cb8')
         self.assertIsNone(eitem['user_data_domain'])
+        self.assertEqual(eitem['additions'], 5)
+        self.assertEqual(eitem['deletions'], 1)
+        self.assertEqual(eitem['changed_files'], 1)
 
         self.assertEqual(eitem['url'], 'https://github.com/chaoss/grimoirelab-perceval/pull/4')
         self.assertEqual(eitem['issue_url'], 'https://github.com/chaoss/grimoirelab-perceval/pull/4')


### PR DESCRIPTION
The new fields added to the enricher are the number of additions, deletions and changed files in a GitHub Pull Request.

The related schema file has been updated with these three new fields.

**Note**: This PR is related to another related PR updating the `github_issues` index pattern with these new fields (https://github.com/chaoss/grimoirelab-sigils/pull/482).