### PR TITLE
[enriched/twitter] Remove deprecated attributes from enriched item

### DIFF
--- a/grimoire_elk/enriched/twitter.py
+++ b/grimoire_elk/enriched/twitter.py
@@ -142,8 +142,8 @@ class TwitterEnrich(Enrich):
 
         # data fields to copy from user
         copy_fields = ["created_at", "description", "followers_count",
-                       "friends_count", "id_str", "lang", "location", "name",
-                       "url", "utc_offset", "verified"]
+                       "friends_count", "id_str", "location", "name",
+                       "url", "verified"]
         for f in copy_fields:
             if f in tweet['user']:
                 eitem["user_" + f] = tweet['user'][f]


### PR DESCRIPTION
The data returned from Twitter has deprecated fields that are set to null. We can remove these fields from the enriched twitter object since they are always going to be returned as null and are not going to be of much use. You can cross-check the deprecated fields [here.](https://developer.twitter.com/en/docs/twitter-api/v1/data-dictionary/object-model/user)