### PR TITLE
[tests] Add test for metadata__updated_on field

### DIFF
--- a/tests/test_elastic_ocean.py
+++ b/tests/test_elastic_ocean.py
@@ -22,6 +22,7 @@
 import unittest
 
 from grimoire_elk.raw.elastic import ElasticOcean
+from perceval.backends.core.git import Git
 from grimoire_elk.errors import ELKError
 
 
@@ -55,6 +56,13 @@ class TestElasticOcean(unittest.TestCase):
         with self.assertRaises(ELKError):
             _ = ElasticOcean.get_p2o_params_from_url("https://finosfoundation.atlassian.net/wiki/ "
                                                      "--filter-raw")
+
+    def test_get_field_date(self):
+        """Test whether the field date is correctly returned"""
+
+        perceval_backend = Git('http://example.com', '/tmp/foo')
+        eitems = ElasticOcean(perceval_backend)
+        self.assertEqual(eitems.get_field_date(), 'metadata__updated_on')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
test_elastic_ocean.py was missing coverage for line 80. This commit fixes that.

Signed-off-by: sevagenv <sevagenv@gmail.com>