### PR TITLE
[raw/mattermost] Fix mapping for 'data.props.meeting_id'

### DIFF
--- a/grimoire_elk/raw/mattermost.py
+++ b/grimoire_elk/raw/mattermost.py
@@ -37,30 +37,39 @@ class Mapping(BaseMapping):
         """
 
         mapping = '''
-             {
+            {
                 "dynamic":true,
-                    "properties": {
-                        "data": {
-                            "properties": {
-                                "attachments": {
-                                    "dynamic":false,
-                                    "properties": {}
-                                },
-                                "channel_info": {
-                                    "properties": {
-                                        "latest": {
-                                            "dynamic": false,
-                                            "properties": {}
-                                        }
+                "properties": {
+                    "data": {
+                        "properties": {
+                            "attachments": {
+                                "dynamic":false,
+                                "properties": {}
+                            },
+                            "channel_info": {
+                                "properties": {
+                                    "latest": {
+                                        "dynamic": false,
+                                        "properties": {}
                                     }
-                                },
-                                "root": {
-                                   "dynamic":false,
-                                    "properties": {}
                                 }
+                            },
+                            "props": {
+                                "dynamic":false,
+                                "properties": {
+                                    "meeting_id": {
+                                        "type": "text",
+                                        "index": true
+                                    }
+                                }
+                            },
+                            "root": {
+                               "dynamic":false,
+                                "properties": {}
                             }
                         }
                     }
+                }
             }
             '''
 


### PR DESCRIPTION
This change allows mapping the attribute
`data.props.meeting_id` to a text type to avoid the error
`failed to parse field [data.props.meeting_id] of type [long] ..`.

Signed-off-by: Quan Zhou <quan@bitergia.com>