### PR TITLE
[gitlab] Autodetect gitlab enterprise-url arg

### DIFF
--- a/grimoire_elk/raw/gitlab.py
+++ b/grimoire_elk/raw/gitlab.py
@@ -80,6 +80,12 @@ class GitLabOcean(ElasticOcean):
         tokens = url.split(' ')
         repo = tokens[0]
 
+        # This removes the last two components from the URL (user & project) leaving only
+        # the host and protocol
+        host = '/'.join(repo.split('/')[:-2])
+        if host != 'https://gitlab.com':
+            params.extend(("--enterprise-url", host))
+
         owner = repo.split('/')[-2]
         repository = repo.split('/')[-1]
 


### PR DESCRIPTION
The `enterprise-url` parameter of the `gitlab` backend is currently left to be specified by the user in the config file.  This commit removes this burden from the user by automatically detecting the enterprise URL from the url passed to get_perceval_params_from_url()`.

This aims to make it easier for users to work with enterprise GitLab instances by removing the need to use the `enterprise-url` at all.

As far as I know, this does not introduce any backwards-compatibility issues.