### PR TITLE
[enriched/github2] Use user_data fields to set identities values

### DIFF
--- a/grimoire_elk/enriched/github2.py
+++ b/grimoire_elk/enriched/github2.py
@@ -163,9 +163,9 @@ class GitHubEnrich2(Enrich):
         if not user:
             return identity
 
-        identity['name'] = user.get('login', None)
-        identity['username'] = user.get('username', None)
+        identity['name'] = user.get('name', user.get('login', None))
         identity['email'] = user.get('email', None)
+        identity['username'] = user.get('username', user.get('login', None))
 
         return identity
 


### PR DESCRIPTION
Name and username fields on the identities were using incorrect values. In the case of 'name' it was using 'login' value and not the name under 'user_data'. For the username it was using a field that doesn't not exist.

This patch fixes the problem using 'name' and 'login' for the two fields.