### PR TITLE
[enriched/mattermost] Fix KeyError 'parent_id'

### DIFF
--- a/grimoire_elk/enriched/mattermost.py
+++ b/grimoire_elk/enriched/mattermost.py
@@ -164,10 +164,9 @@ class MattermostEnrich(Enrich):
             eitem['channel_team_id'] = channel_data['team_id']
 
         eitem['is_reply'] = False
-        eitem['parent_id'] = None
-        if message['parent_id']:
+        eitem['parent_id'] = message.get('parent_id', message.get('root_id', None))
+        if eitem['parent_id']:
             eitem['is_reply'] = True
-            eitem['parent_id'] = message['parent_id']
 
         eitem = self.__convert_booleans(eitem)
 


### PR DESCRIPTION
From mattermost v5.38.0 (released 2021-08-16) the data `parent_id`
does not longer exist.

This code fixes the error using the data `root_id`.

Signed-off-by: Quan Zhou <quan@bitergia.com>