### PR TITLE
[enriched/github2] Add 'user_login' field

### DIFF
--- a/grimoire_elk/enriched/github2.py
+++ b/grimoire_elk/enriched/github2.py
@@ -285,6 +285,9 @@ class GitHubEnrich2(Enrich):
             ecomment['is_github_{}'.format(ISSUE_COMMENT_TYPE)] = 1
             ecomment['is_github_comment'] = 1
 
+            # Add user_login
+            ecomment['user_login'] = comment['user_data']['login']
+
             if self.sortinghat:
                 ecomment.update(self.get_item_sh(comment, self.comment_roles, 'updated_at'))
 
@@ -357,6 +360,9 @@ class GitHubEnrich2(Enrich):
             ecomment.pop('is_github2_{}'.format(REVIEW_COMMENT_TYPE))
             ecomment['is_github_{}'.format(REVIEW_COMMENT_TYPE)] = 1
             ecomment['is_github_comment'] = 1
+
+            # Add user_login
+            ecomment['user_login'] = comment['user_data']['login']
 
             if self.sortinghat:
                 ecomment.update(self.get_item_sh(comment, self.comment_roles, 'updated_at'))

--- a/tests/test_github2.py
+++ b/tests/test_github2.py
@@ -70,6 +70,7 @@ class TestGitHub2(TestBaseBackend):
         self.assertEqual(eitem['reaction_laugh'], 0)
         self.assertEqual(eitem['reaction_total_count'], 0)
         self.assertEqual(item['category'], 'issue')
+        self.assertEqual(eitem['user_login'], 'zhquan_example')
 
         item = self.items[1]
         eitem = enrich_backend.get_rich_item(item)
@@ -81,6 +82,7 @@ class TestGitHub2(TestBaseBackend):
         self.assertNotIn('reaction_laugh', eitem)
         self.assertNotIn('reaction_total_count', eitem)
         self.assertEqual(eitem['time_to_merge_request_response'], 335.81)
+        self.assertEqual(eitem['user_login'], 'zhquan_example')
 
         item = self.items[2]
         eitem = enrich_backend.get_rich_item(item)
@@ -121,6 +123,7 @@ class TestGitHub2(TestBaseBackend):
         self.assertEqual(eitem['reaction_confused'], 0)
         self.assertEqual(eitem['reaction_laugh'], 0)
         self.assertEqual(eitem['reaction_total_count'], 0)
+        self.assertEqual(eitem['user_login'], 'acs')
 
         item = self.items[6]
         eitem = enrich_backend.get_rich_item(item)
@@ -137,6 +140,7 @@ class TestGitHub2(TestBaseBackend):
         self.assertNotIn('reaction_confused', eitem)
         self.assertNotIn('reaction_laugh', eitem)
         self.assertNotIn('reaction_total_count', eitem)
+        self.assertEqual(eitem['user_login'], 'acs')
 
     def test_enrich_repo_labels(self):
         """Test whether the field REPO_LABELS is present in the enriched items"""


### PR DESCRIPTION
This code adds the field `user_login` for all enriched items
when the category is `issue` or `pull_request`.

Test updated accordingly.

Signed-off-by: Quan Zhou <quan@bitergia.com>