### PR TITLE
[elk] Pass 'no_update' to pereceval

### DIFF
--- a/grimoire_elk/elk.py
+++ b/grimoire_elk/elk.py
@@ -75,6 +75,7 @@ def feed_backend(url, clean, fetch_archive, backend_name, backend_params,
         branches = None
         latest_items = None
         filter_classified = None
+        no_update = None
 
         backend_cmd = klass(*backend_params)
 
@@ -145,6 +146,12 @@ def feed_backend(url, clean, fetch_archive, backend_name, backend_params,
             except AttributeError:
                 latest_items = backend_cmd.parsed_args.latest_items
 
+        if 'no_update' in signature.parameters:
+            try:
+                no_update = backend_cmd.no_update
+            except AttributeError:
+                no_update = backend_cmd.parsed_args.no_update
+
         params = {}
         if latest_items:
             params['latest_items'] = latest_items
@@ -158,6 +165,8 @@ def feed_backend(url, clean, fetch_archive, backend_name, backend_params,
             params['from_date'] = from_date
         if offset:
             params['from_offset'] = offset
+        if no_update:
+            params['no_update'] = no_update
 
         ocean_backend.feed(**params)
 

--- a/grimoire_elk/raw/elastic.py
+++ b/grimoire_elk/raw/elastic.py
@@ -153,7 +153,7 @@ class ElasticOcean(ElasticItems):
         item['metadata__timestamp'] = timestamp.isoformat()
 
     def feed(self, from_date=None, from_offset=None, category=None, branches=None,
-             latest_items=None, filter_classified=None):
+             latest_items=None, filter_classified=None, no_update=None):
         """Feed data in Elastic from Perceval"""
 
         if self.fetch_archive:
@@ -209,10 +209,13 @@ class ElasticOcean(ElasticItems):
         if filter_classified is not None:
             params['filter_classified'] = filter_classified
 
-        # latest items, from_date and offset cannot be used together,
+        # no_update, latest_items, from_date and offset cannot be used together,
         # thus, the params dictionary is filled with the param available
         # and Perceval is executed
-        if latest_items:
+        if no_update:
+            params['no_update'] = no_update
+            items = self.perceval_backend.fetch(**params)
+        elif latest_items:
             params['latest_items'] = latest_items
             items = self.perceval_backend.fetch(**params)
         elif last_update:


### PR DESCRIPTION
This code passes the `no_update` parameter set in the
`setup.cfg` to perceval to fetch items. Also, this parameter
cannot be used together with `latest_items`.

Fixes #996

Signed-off-by: Quan Zhou <quan@bitergia.com>