### PR TITLE
[enriched/github2] Add ghost user to calculate first attention

### DIFF
--- a/tests/data/github2.json
+++ b/tests/data/github2.json
@@ -1084,7 +1084,7 @@
                     "author_association": "OWNER",
                     "body": "This module is not used. It should be removed.\n",
                     "commit_id": "cc134f32fa8c518abe5f0501836af69741b25a64",
-                    "created_at": "2015-12-04T19:07:22Z",
+                    "created_at": "2016-01-04T23:46:04Z",
                     "diff_hunk": "@@ -0,0 +1,315 @@\n+# -*- coding: utf-8 -*-\n+#\n+# Copyright (C) 2015 Bitergia\n+#\n+# This program is free software; you can redistribute it and/or modify\n+# it under the terms of the GNU General Public License as published by\n+# the Free Software Foundation; either version 3 of the License, or\n+# (at your option) any later version.\n+#\n+# This program is distributed in the hope that it will be useful,\n+# but WITHOUT ANY WARRANTY; without even the implied warranty of\n+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the\n+# GNU General Public License for more details.\n+#\n+# You should have received a copy of the GNU General Public License\n+# along with this program; if not, write to the Free Software\n+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.\n+#\n+# Authors:\n+#   Alvaro del Castillo San Felix <acs@bitergia.com>\n+#\n+\n+'''Gerrit backend for Perseval'''\n+\n+\n+from datetime import datetime\n+from dateutil import parser",
                     "html_url": "https://github.com/zhquan_example/repo/pull/1#discussion_r46718983",
                     "id": 1,

--- a/tests/test_github2.py
+++ b/tests/test_github2.py
@@ -81,7 +81,7 @@ class TestGitHub2(TestBaseBackend):
         self.assertNotIn('reaction_confused', eitem)
         self.assertNotIn('reaction_laugh', eitem)
         self.assertNotIn('reaction_total_count', eitem)
-        self.assertEqual(eitem['time_to_merge_request_response'], 335.81)
+        self.assertEqual(eitem['time_to_merge_request_response'], 1.0)
         self.assertEqual(eitem['user_login'], 'zhquan_example')
 
         item = self.items[2]


### PR DESCRIPTION
This code takes into account the deleted (ghost) users to
calculate the first attention and the first response. Also, fix
the `TypeError: 'NoneType'` error when the attention was made by
the ghost user.

Signed-off-by: Quan Zhou <quan@bitergia.com>