### PR TITLE
[enrich] Get main enrollment for *_org_name field

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
-        elasticsearch-version: [6.1.0, 7.2.0]
+        elasticsearch-version: [6.8.6, 7.2.0]
     
     steps:
     - name: Checkout

--- a/tests/test_enrich.py
+++ b/tests/test_enrich.py
@@ -595,6 +595,12 @@ class TestEnrich(unittest.TestCase):
         self.assertEqual(eitem_sh['author_bot'], False)
         self.assertEqual(eitem_sh['author_multi_org_names'], ['-- UNDEFINED --'])
 
+    def test_get_main_enrollments(self):
+        """Test get the main enrollment given the list of enrollments"""
+        enrollments = ['Bitergia::Eng', 'Chaoss']
+        main_enrolls = self._enrich.get_main_enrollments(enrollments)
+        self.assertListEqual(main_enrolls, ['Bitergia', 'Chaoss'])
+
     def test_no_params(self):
         """Neither identity nor sh_id are passed as arguments"""
 


### PR DESCRIPTION
This code gets the main enrollment for `*_org_name` when
there are several enrollments.

If the enrollment contains :: the main one is the first part.

For example:
- Enrollment: Chaoss::Eng
- Main: Chaoss

If there is more than one, it will return the first one ordered
alphabetically.

Test added accordingly.

Signed-off-by: Quan Zhou <quan@bitergia.com>