### PR TITLE
[enrich] Fix IndexError when getting main organization

### DIFF
--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -703,7 +703,8 @@ class Enrich(ElasticItems):
                     enrolls.append(enrollment.organization.name)
                 elif enrollment.start <= item_date <= enrollment.end:
                     enrolls.append(enrollment.organization.name)
-        else:
+
+        if not enrolls:
             enrolls.append(self.unaffiliated_group)
 
         return enrolls


### PR DESCRIPTION
This code adds `unaffiliated_group` to enrolls when it is empty
to fix the `IndexError`.

Signed-off-by: Quan Zhou <quan@bitergia.com>