### PR TITLE
[poetry] Include sortinghat as extra dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ include = [
 
 [tool.poetry.extras]
 mysql = ["PyMySQL"]
+sortinghat = ["sortinghat"]
 
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/chaoss/grimoirelab-elk/issues"


### PR DESCRIPTION
Currently SortingHat is an optional package of Grimoirelab-elk and
it is not installed by default.

In order to install sortinghat with grimoirelab-elk it must be
declared as [extra](https://python-poetry.org/docs/pyproject/#extras).

This PR includes sortinghat as an extra so it can now be installed with 
grimoirelab-elk in external packages like sirmordred or cereslib.
