### PR TITLE
Add methods to add identities from Enrich class

### DIFF
--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -1019,6 +1019,14 @@ class Enrich(ElasticItems):
         """ Get the SH identity uuid from the id """
         return SortingHat.get_uuid_from_id(self.sh_db, sh_id)
 
+    def add_sh_identities(self, identities):
+        SortingHat.add_identities(self.sh_db, identities,
+                                  self.get_connector_name())
+
+    def add_sh_identity(self, identity):
+        SortingHat.add_identity(self.sh_db, identity,
+                                self.get_connector_name())
+
     def get_sh_ids(self, identity, backend_name):
         """ Return the Sorting Hat id and uuid for an identity """
         # Convert the dict to tuple so it is hashable

--- a/grimoire_elk/enriched/finosmeetings.py
+++ b/grimoire_elk/enriched/finosmeetings.py
@@ -23,7 +23,6 @@ import logging
 
 from .enrich import Enrich, metadata
 from ..elastic_mapping import Mapping as BaseMapping
-from .sortinghat_gelk import SortingHat
 
 
 logger = logging.getLogger(__name__)
@@ -85,7 +84,7 @@ class FinosMeetingsEnrich(Enrich):
             'name': None
         }
 
-        SortingHat.add_identity(self.sh_db, identity, GITHUB_BACKEND)
+        self.add_sh_identity(identity)
 
     def get_identities(self, item):
         """ Return the identities from an item """

--- a/grimoire_elk/enriched/git.py
+++ b/grimoire_elk/enriched/git.py
@@ -38,7 +38,6 @@ from perceval.backends.core.git import (GitCommand,
                                         EmptyRepositoryError,
                                         RepositoryError)
 from .enrich import Enrich, metadata
-from .sortinghat_gelk import SortingHat
 from .study_ceres_aoc import areas_of_code, ESPandasConnector
 from ..elastic_mapping import Mapping as BaseMapping
 from ..elastic_items import HEADER_JSON, MAX_BULK_UPDATE_SIZE
@@ -379,7 +378,7 @@ class GitEnrich(Enrich):
 
             if self.sortinghat:
                 # Create SH identity if it does not exist
-                SortingHat.add_identity(self.sh_db, identity, self.get_connector_name())
+                self.add_sh_identity(identity)
                 item_date = str_to_datetime(eitem[self.get_field_date()])
                 sh_fields = self.get_item_sh_fields(identity, item_date, rol=meta_field)
             else:

--- a/releases/unreleased/support-to-add-identities-from-enrich-class.yml
+++ b/releases/unreleased/support-to-add-identities-from-enrich-class.yml
@@ -1,0 +1,10 @@
+---
+title: Support to add identities to SortingHat from Enrich class
+category: added
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: null
+notes: >
+  New methods `add_identities` and `add_identity` are available
+  on `Enrich` class to add new identities to a `SortingHat` database.
+  Libraries using `elk` won't need to use `sortinghat` library to
+  store new identities while enriching items.


### PR DESCRIPTION
The methods 'add_identities' and 'add_identity' have been added to 'Enrich' class to add new identities to a SortingHat
database. Libraries using elk won't need to use sortinghat library to store new identities while enriching items.

This helps to fix https://github.com/chaoss/grimoirelab/issues/489.