### PR TITLE
[elk] Skip sources with wrong arguments

### DIFF
--- a/grimoire_elk/elk.py
+++ b/grimoire_elk/elk.py
@@ -203,8 +203,18 @@ def feed_backend(url, clean, fetch_archive, backend_name, backend_params,
         else:
             error_msg = "Error feeding raw from {}".format(ex)
             logger.error(error_msg, exc_info=True)
+    except SystemExit:
+        anonymized_params = anonymize_params(backend_params)
+        msg = "Wrong {} arguments: {}".format(backend_name, anonymized_params)
+        error_msg = "Error feeding raw. {}".format(msg)
+        logger.error(error_msg, exc_info=True)
 
-    logger.info("[{}] Done collection for {}".format(backend_name, anonymize_url(backend.origin)))
+    try:
+        msg = "[{}] Done collection for {}".format(backend_name, anonymize_url(backend.origin))
+    except AttributeError:
+        msg = "[{}] Done collection for {}".format(backend_name, anonymize_url(projects_json_repo))
+    logger.info(msg)
+
     return error_msg
 
 
@@ -603,8 +613,18 @@ def enrich_backend(url, clean, backend_name, backend_params, cfg_section_name,
                          backend_name, anonymize_url(backend.origin), ex), exc_info=True)
         else:
             logger.error("Error enriching raw {}".format(ex), exc_info=True)
+    except SystemExit:
+        anonymized_params = anonymize_params(backend_params)
+        msg = "Wrong {} arguments: {}".format(backend_name, anonymized_params)
+        error_msg = "Error enriching raw. {}".format(msg)
+        logger.error(error_msg, exc_info=True)
 
-    logger.info("[{}] Done enrichment for {}".format(backend_name, anonymize_url(backend.origin)))
+    try:
+        msg = "[{}] Done enrichment for {}".format(backend_name, anonymize_url(backend.origin))
+    except AttributeError:
+        msg = "[{}] Done enrichment for {}".format(backend_name, anonymize_url(projects_json_repo))
+
+    logger.info(msg)
 
 
 def delete_orphan_unique_identities(es, sortinghat_db, current_data_source, active_data_sources):

--- a/releases/unreleased/skip-sources-with-wrong-arguments.yml
+++ b/releases/unreleased/skip-sources-with-wrong-arguments.yml
@@ -1,0 +1,8 @@
+---
+title: Skip sources with wrong arguments
+category: fixed
+author: Quan Zhou <quan@bitergia.com>
+issue: null
+notes: >
+    Sources won't interrupt collection or enrichment processes when any
+    of their arguments are invalid. Instead, they will be skipped.


### PR DESCRIPTION
When the source has a wrong argument, the current behavior is that
the process stops without any error messages.

This code will write an error message with the arguments
(anonymized) and skip the source so as not to stop the process.

Test added accordingly.

Signed-off-by: Quan Zhou <quan@bitergia.com>