### PR TITLE
[raw/confluence] Remove credentials from raw items

### DIFF
--- a/grimoire_elk/raw/confluence.py
+++ b/grimoire_elk/raw/confluence.py
@@ -22,6 +22,7 @@
 from .elastic import ElasticOcean
 from ..elastic_mapping import Mapping as BaseMapping
 from ..elastic_items import ElasticItems
+from ..enriched.utils import anonymize_url
 
 
 class Mapping(BaseMapping):
@@ -72,6 +73,11 @@ class ConfluenceOcean(ElasticOcean):
     """Confluence Ocean feeder"""
 
     mapping = Mapping
+
+    def _fix_item(self, item):
+        item['origin'] = anonymize_url(item['origin'])
+        item['tag'] = anonymize_url(item['tag'])
+        item['data']['content_url'] = anonymize_url(item['data']['content_url'])
 
     @classmethod
     def get_perceval_params_from_url(cls, url):

--- a/releases/unreleased/remove-confluence-credentials.yml
+++ b/releases/unreleased/remove-confluence-credentials.yml
@@ -1,0 +1,9 @@
+---
+title: Confluence credentials not stored in raw indexes
+category: fixed
+author: Quan Zhou <quan@bitergia.com>
+issue: null
+notes: >
+    Credentials for Confluence datasource were stored in raw indices
+    as part of the URL. For now on, credentials that are part of URLs
+    are removed before any data is stored.

--- a/tests/data/confluence_with_credentials.json
+++ b/tests/data/confluence_with_credentials.json
@@ -1,0 +1,233 @@
+[
+    {
+        "backend_name": "Confluence",
+        "backend_version": "0.13.0",
+        "category": "historical content",
+        "data": {
+            "_expandable": {
+                "ancestors": "",
+                "children": "/rest/api/content/1/child",
+                "container": "",
+                "descendants": "/rest/api/content/1/descendant",
+                "metadata": "",
+                "operations": "",
+                "space": "/rest/api/space/DEV"
+            },
+            "_links": {
+                "base": "http://example-creds.com",
+                "collection": "/rest/api/content",
+                "context": "",
+                "self": "http://example-creds.com/rest/api/content/1?status=historical&version=1",
+                "tinyui": "/x/zx5o",
+                "webui": "/pages/viewpage.action?pageId=1"
+            },
+            "ancestors": [
+                {
+                    "id": "128548867",
+                    "type": "page",
+                    "status": "current",
+                    "title": "Title 1",
+                    "_links" : {
+                        "webui" : "/spaces/TEST/title1"
+                    }
+                },
+                {
+                    "id": "167848895",
+                    "type": "page",
+                    "status": "current",
+                    "title": "Title 2",
+                    "_links" : {
+                        "webui" : "/spaces/TEST/title2"
+                    }
+                },
+                {
+                    "id": "128548921",
+                    "type": "page",
+                    "status": "current",
+                    "title": "Title 3",
+                    "_links" : {
+                        "webui" : "/spaces/TEST/title3"
+                    }
+                }
+            ],
+            "body": {
+                "_expandable": {
+                    "anonymous_export_view": "",
+                    "editor": "",
+                    "export_view": "",
+                    "styled_view": "",
+                    "view": ""
+                },
+                "storage": {
+                    "_expandable": {
+                        "content": "/rest/api/content/1"
+                    },
+                    "representation": "storage",
+                    "value": "<p>done</p>"
+                }
+            },
+            "content_url": "http://user:token@example-creds.com/display/meetings/TSC",
+            "extensions": {
+                "position": "none"
+            },
+            "history": {
+                "_expandable": {
+                    "lastUpdated": "",
+                    "nextVersion": "",
+                    "previousVersion": ""
+                },
+                "_links": {
+                    "self": "http://example-creds.com/rest/api/content/1/history"
+                },
+                "createdBy": {
+                    "displayName": "John Doe",
+                    "profilePicture": {
+                        "height": 48,
+                        "isDefault": false,
+                        "path": "/s/en_GB/6210/1/_/download/attachments/1/user-avatar?version=1&modificationDate=1452188900000&api=v2",
+                        "width": 48
+                    },
+                    "type": "known",
+                    "userKey": "2c9e48d5521d22bb01521d2fd9110002",
+                    "username": "jdoe"
+                },
+                "createdDate": "2016-06-10T20:05:21.000Z",
+                "latest": false
+            },
+            "id": "1",
+            "status": "historical",
+            "title": "Steady State Project - 2016-06-17 Goals",
+            "type": "page",
+            "version": {
+                "by": {
+                    "displayName": "John Doe",
+                    "profilePicture": {
+                        "height": 48,
+                        "isDefault": false,
+                        "path": "/s/en_GB/6210/1/_/download/attachments/1/user-avatar?version=1&modificationDate=1452188900000&api=v2",
+                        "width": 48
+                    },
+                    "type": "known",
+                    "userKey": "2c9e48d5521d22bb01521d2fd9110002",
+                    "publicName": "jdoe"
+                },
+                "message": "",
+                "minorEdit": false,
+                "number": 1,
+                "when": "2016-06-10T20:05:21.000Z"
+            }
+        },
+        "origin": "http://user:token@example-creds.com",
+        "perceval_version": "0.17.17",
+        "tag": "http://user:token@example-creds.com",
+        "timestamp": 1518164951.463518,
+        "updated_on": 1465589121.0,
+        "uuid": "5b8bf26bfd906214ec82f5a682649e8f6fe87984"
+    },
+    {
+        "backend_name": "Confluence",
+        "backend_version": "0.13.0",
+        "category": "historical content",
+        "data": {
+            "_expandable": {
+                "ancestors": "",
+                "children": "/rest/api/content/1/child",
+                "container": "/rest/api/space/DEV",
+                "descendants": "/rest/api/content/1/descendant",
+                "metadata": "",
+                "operations": "",
+                "space": "/rest/api/space/DEV"
+            },
+            "_links": {
+                "base": "http://example-creds.com",
+                "collection": "/rest/api/content",
+                "context": "",
+                "self": "http://example-creds.com/rest/api/content/1",
+                "tinyui": "/x/zB5o",
+                "webui": "/display/DEV/Steady+State+Project+-+2016-06-17+Goals"
+            },
+            "ancestors": [
+                {
+                    "id": "128548867",
+                    "type": "page",
+                    "status": "current",
+                    "_links" : {
+                        "webui" : "/spaces/TEST/title1"
+                    }
+                }
+            ],
+            "body": {
+                "_expandable": {
+                    "anonymous_export_view": "",
+                    "editor": "",
+                    "export_view": "",
+                    "styled_view": "",
+                    "view": ""
+                },
+                "storage": {
+                    "_expandable": {
+                        "content": "/rest/api/content/1"
+                    },
+                    "representation": "storage",
+                    "value": "<p>value</p>"
+                }
+            },
+            "content_url": "http://user:token@example-creds.com/display/meetings/TSC",
+            "extensions": {
+                "position": "none"
+            },
+            "history": {
+                "_expandable": {
+                    "lastUpdated": "",
+                    "nextVersion": "",
+                    "previousVersion": ""
+                },
+                "_links": {
+                    "self": "http://example-creds.com/rest/api/content/6823628/history"
+                },
+                "createdBy": {
+                    "displayName": "John Doe",
+                    "profilePicture": {
+                        "height": 48,
+                        "isDefault": false,
+                        "path": "/s/en_GB/6210/1/_/download/attachments/1/user-avatar?version=1&modificationDate=1452188900000&api=v2",
+                        "width": 48
+                    },
+                    "type": "known",
+                    "userKey": "2c9e48d5521d22bb01521d2fd9110002",
+                    "username": "jdoe"
+                },
+                "createdDate": "2016-06-10T20:05:21.000Z",
+                "latest": true
+            },
+            "id": "1",
+            "status": "current",
+            "title": "Steady State Project - 2016-06-17 Goals",
+            "type": "page",
+            "version": {
+                "by": {
+                    "displayName": "John Smith",
+                    "profilePicture": {
+                        "height": 48,
+                        "isDefault": false,
+                        "path": "/s/en_GB/6210/1/_/download/attachments/1/user-avatar?version=1&modificationDate=1464975020000&api=v2",
+                        "width": 48
+                    },
+                    "type": "known",
+                    "userKey": "2c9e48d553c3b7db015516fa640b00bd",
+                    "username": "jsmith"
+                },
+                "message": "Task marked complete",
+                "minorEdit": false,
+                "number": 2,
+                "when": "2016-06-16T19:58:30.000Z"
+            }
+        },
+        "origin": "http://user:token@example-creds.com",
+        "perceval_version": "0.17.17",
+        "tag": "http://user:token@example-creds.com",
+        "timestamp": 1518164951.466256,
+        "updated_on": 1466107110.0,
+        "uuid": "94b8015bcb52fca1155ecee14153c8634856f1bc"
+    }
+]


### PR DESCRIPTION
This code redefines the method _fix_item for the confluence raw
data in order to remove credentials that may appear in the origin,
tag and data.content_url fields.

This change is needed to prevent storing the credentials in the
raw index.

Signed-off-by: Quan Zhou <quan@bitergia.com>