### PR TITLE
[elk] Add method to anonymize parameters

### DIFF
--- a/grimoire_elk/elk.py
+++ b/grimoire_elk/elk.py
@@ -35,11 +35,34 @@ from .enriched.utils import get_last_enrich, grimoire_con, get_diff_current_date
 from .utils import get_connectors, get_connector_from_name, get_elastic
 
 IDENTITIES_INDEX = "grimoirelab_identities_cache"
+SECRET_PARAMETERS = ["--api-token", "--backend-password"]
 SIZE_SCROLL_IDENTITIES_INDEX = 1000
 
 logger = logging.getLogger(__name__)
 
 requests_ses = grimoire_con()
+
+
+def anonymize_params(parameters):
+    """ The following parameters after SECRET_PARAMETERS will be
+    replaced by 'xxxxx' until the parameter starts with '-'.
+
+    :param parameters: list of parameters
+    :return: list of anonymized parameter
+    """
+
+    secret_param = False
+    param_list = list(parameters)
+    for i, param in enumerate(param_list):
+        if secret_param and param.startswith('-'):
+            secret_param = False
+
+        if not secret_param and param in SECRET_PARAMETERS:
+            secret_param = True
+        elif secret_param:
+            param_list[i] = "xxxxx"
+
+    return tuple(param_list)
 
 
 def feed_backend(url, clean, fetch_archive, backend_name, backend_params,

--- a/releases/unreleased/anonymize-parameters.yml
+++ b/releases/unreleased/anonymize-parameters.yml
@@ -1,0 +1,10 @@
+---
+title: Anonymize parameters
+category: added
+author: Quan Zhou <quan@bitergia.com>
+issue: null
+notes: >
+    A new API function `anonymize_params(params)` allows to anonymize
+    a list of parameters that developers might consider secrets. It will only
+    take effect for those parameters which their names are defined on
+    `SECRET_PARAMETERS` constant.

--- a/tests/test_elk.py
+++ b/tests/test_elk.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+#
+# Authors:
+#   Quan Zhou <quan@bitergia.com>
+#
+
+import configparser
+import unittest
+
+from grimoire_elk.elk import anonymize_params
+
+
+CONFIG_FILE = 'tests.conf'
+
+
+class TestElk(unittest.TestCase):
+    """Unit tests for elk class"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.config = configparser.ConfigParser()
+        cls.config.read(CONFIG_FILE)
+        cls.es_con = dict(cls.config.items('ElasticSearch'))['url']
+
+    def test_anonymize_params(self):
+        """Test anonymize parameters"""
+
+        expected_params = ("repo", "--api-token", "xxxxx", "xxxxx", "--sleep-for-rate")
+        params = ("repo", "--api-token", "token1", "token2", "--sleep-for-rate")
+        anonymized_params = anonymize_params(params)
+        self.assertTupleEqual(anonymized_params, expected_params)
+
+        expected_params = ("--backend-password", "xxxxx", "--no-archive", "--api-token", "xxxxx")
+        params = ("--backend-password", "mypassword", "--no-archive", "--api-token", "token")
+        anonymized_params = anonymize_params(params)
+        self.assertTupleEqual(anonymized_params, expected_params)


### PR DESCRIPTION
This code adds a new method to anonymize parameters in case you
want to write it in a log message.

All parameters after `--api-token` or `--backend-password` will
be replaced by `xxxxx` until the next parameter starts with `-`

Test added accordingly.

Signed-off-by: Quan Zhou <quan@bitergia.com>