### PR TITLE
[enrich/demographics] Fix fetching authors with min and max dates

### DIFF
--- a/releases/unreleased/fix-fetching-authors-with-min-and-max-dates.yml
+++ b/releases/unreleased/fix-fetching-authors-with-min-and-max-dates.yml
@@ -1,0 +1,8 @@
+---
+title: Fix fetching authors with min and max dates
+category: fixed
+author: Quan Zhou <quan@bitergia.com>
+issue: null
+notes: >
+    The old query only returns 10000 items due to ElasticSearch and
+    OpenSearch now use `composite` aggregation to paginate all buckets.

--- a/tests/data/author_min_max_dates_1.json
+++ b/tests/data/author_min_max_dates_1.json
@@ -1,0 +1,55 @@
+{
+  "took" : 2,
+  "timed_out" : false,
+  "_shards" : {
+    "total" : 2,
+    "successful" : 2,
+    "skipped" : 0,
+    "failed" : 0
+  },
+  "hits" : {
+    "total" : {
+      "value" : 10000,
+      "relation" : "gte"
+    },
+    "max_score" : null,
+    "hits" : [ ]
+  },
+  "aggregations" : {
+    "author" : {
+      "after_key" : {
+        "author_uuid" : "007a56d0322c518859dde2a0c6ed9143fa141c61"
+      },
+      "buckets" : [
+        {
+          "key" : {
+            "author_uuid" : "00032fabbbf033467d7bd307df81b654c0fa53d8"
+          },
+          "doc_count" : 1,
+          "min" : {
+            "value" : 1.623225379E12,
+            "value_as_string" : "2021-06-09T07:56:19.000Z"
+          },
+          "max" : {
+            "value" : 1.623225379E12,
+            "value_as_string" : "2021-06-09T07:56:19.000Z"
+          }
+        },
+        {
+          "key" : {
+            "author_uuid" : "007a56d0322c518859dde2a0c6ed9143fa141c61"
+          },
+          "doc_count" : 1,
+          "min" : {
+            "value" : 1.626183289E12,
+            "value_as_string" : "2021-07-13T13:34:49.000Z"
+          },
+          "max" : {
+            "value" : 1.626183289E12,
+            "value_as_string" : "2021-07-13T13:34:49.000Z"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/data/author_min_max_dates_2.json
+++ b/tests/data/author_min_max_dates_2.json
@@ -1,0 +1,55 @@
+{
+  "took" : 4,
+  "timed_out" : false,
+  "_shards" : {
+    "total" : 4,
+    "successful" : 4,
+    "skipped" : 0,
+    "failed" : 0
+  },
+  "hits" : {
+    "total" : {
+      "value" : 10000,
+      "relation" : "gte"
+    },
+    "max_score" : null,
+    "hits" : [ ]
+  },
+  "aggregations" : {
+    "author" : {
+      "after_key" : {
+        "author_uuid" : "00d36515f739794b941586e5d0a102b5ff3a0cc2"
+      },
+      "buckets" : [
+        {
+          "key" : {
+            "author_uuid" : "00cc95a5950523a42c969f15c7c36c4530417f13"
+          },
+          "doc_count" : 1,
+          "min" : {
+            "value" : 1.474160034E12,
+            "value_as_string" : "2016-09-18T00:53:54.000Z"
+          },
+          "max" : {
+            "value" : 1.474160034E12,
+            "value_as_string" : "2016-09-18T00:53:54.000Z"
+          }
+        },
+        {
+          "key" : {
+            "author_uuid" : "00d36515f739794b941586e5d0a102b5ff3a0cc2"
+          },
+          "doc_count" : 1,
+          "min" : {
+            "value" : 1.526521972E12,
+            "value_as_string" : "2018-05-17T01:52:52.000Z"
+          },
+          "max" : {
+            "value" : 1.526521972E12,
+            "value_as_string" : "2018-05-17T01:52:52.000Z"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/data/author_min_max_dates_empty.json
+++ b/tests/data/author_min_max_dates_empty.json
@@ -1,0 +1,20 @@
+{
+  "took" : 4,
+  "timed_out" : false,
+  "_shards" : {
+    "total" : 4,
+    "successful" : 4,
+    "skipped" : 0,
+    "failed" : 0
+  },
+  "hits" : {
+    "total" : 4,
+    "max_score" : 0.0,
+    "hits" : [ ]
+  },
+  "aggregations" : {
+    "author" : {
+      "buckets" : [ ]
+    }
+  }
+}


### PR DESCRIPTION
This code fixes fetching all authors with min and max dates.
Currently, ElasticSearch and OpenSearch use `composite` aggregation
to paginate all buckets.

The old query only returns 10000 items and also returns the
following warning message:

```
Deprecation: This aggregation creates too many buckets (10001) and
will throw an error in future versions. You should update the
[search.max_buckets] cluster setting or use the [composite]
aggregation to paginate all buckets in multiple requests.
```

Tests added acconrdingly.

Signed-off-by: Quan Zhou <quan@bitergia.com>