### PR TITLE
[git] Add more connectors to find out pair programming authors

### DIFF
--- a/grimoire_elk/enriched/git.py
+++ b/grimoire_elk/enriched/git.py
@@ -78,7 +78,7 @@ class GitEnrich(Enrich):
 
     # REGEX to extract authors from a multi author commit: several authors present
     # in the Author field in the commit. Used if self.pair_programming is True
-    AUTHOR_P2P_REGEX = re.compile(r'(?P<first_authors>.* .*) and (?P<last_author>.* .*) (?P<email>.*)')
+    AUTHOR_P2P_REGEX = re.compile(r'(?P<first_authors>.* .*) ([aA][nN][dD]|&|\+) (?P<last_author>.* .*) (?P<email>.*)')
     AUTHOR_P2P_NEW_REGEX = re.compile(r"Co-authored-by:(?P<first_authors>.* .*)<(?P<email>.*)>\n?")
 
     # REGEX to extract authors from the commit

--- a/releases/unreleased/add-more-connectors-to-find-out-pair-programming-authors.yml
+++ b/releases/unreleased/add-more-connectors-to-find-out-pair-programming-authors.yml
@@ -1,0 +1,13 @@
+---
+title: Pair programming regular expression improvement
+category: fixed
+author: Quan Zhou <quan@bitergia.com>
+issue: null
+notes: >
+    The regular expression to detect pair programming authors in git
+    datasource has been improved adding more connectors.
+
+    The following list shows the current connectors:
+    - `[aA][nN][dD]`
+    - `&`
+    - `+`

--- a/tests/data/git.json
+++ b/tests/data/git.json
@@ -109,9 +109,9 @@
     "backend_version": "0.8.10",
     "category": "commit",
     "data": {
-        "Author": "Eduardo Morais <companheiro.vermelho@gmail.com>",
+        "Author": "Eduardo Morais & Zhongpeng Lin <companheiro.vermelho@gmail.com>",
         "AuthorDate": "Tue Aug 14 14:33:27 2012 -0300",
-        "Commit": "Eduardo Morais <companheiro.vermelho@gmail.com>",
+        "Commit": "Eduardo Morais & Zhongpeng Lin <companheiro.vermelho@gmail.com>",
         "CommitDate": "Tue Aug 14 14:33:27 2012 -0300",
         "commit": "7debcf8a2f57f86663809c58b5c07a398be7674c",
         "files": [
@@ -147,9 +147,9 @@
     "backend_version": "0.8.10",
     "category": "commit",
     "data": {
-        "Author": "Eduardo Morais <companheiro.vermelho@gmail.com>",
+        "Author": "Eduardo Morais + Zhongpeng Lin <companheiro.vermelho@gmail.com>",
         "AuthorDate": "Tue Aug 14 14:35:02 2012 -0300",
-        "Commit": "Eduardo Morais <companheiro.vermelho@gmail.com>",
+        "Commit": "Eduardo Morais + Zhongpeng Lin <companheiro.vermelho@gmail.com>",
         "CommitDate": "Tue Aug 14 14:35:02 2012 -0300",
         "commit": "c0d66f92a95e31c77be08dc9d0f11a16715d1885",
         "files": [
@@ -200,9 +200,9 @@
     "backend_version": "0.8.10",
     "category": "commit",
     "data": {
-        "Author": "Eduardo Morais <companheiro.vermelho@gmail.com>",
+        "Author": "Eduardo Morais And Zhongpeng Lin <companheiro.vermelho@gmail.com>",
         "AuthorDate": "Tue Aug 14 14:45:51 2012 -0300",
-        "Commit": "Eduardo Morais <companheiro.vermelho@gmail.com>",
+        "Commit": "Eduardo Morais And Zhongpeng Lin <companheiro.vermelho@gmail.com>",
         "CommitDate": "Tue Aug 14 14:45:51 2012 -0300",
         "commit": "c6ba8f7a1058db3e6b4bc6f1090e932b107605fb",
         "files": [

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -156,7 +156,7 @@ class TestGit(TestBaseBackend):
 
         result = self._test_raw_to_enrich(pair_programming=True)
         self.assertEqual(result['raw'], 11)
-        self.assertEqual(result['enrich'], 13)
+        self.assertEqual(result['enrich'], 16)
 
         enrich_backend = self.connectors[self.connector][2](pair_programming=True)
         url = self.es_con + "/" + self.enrich_index + "/_search?size=20"


### PR DESCRIPTION
This code adds more connectors to find out pair programming users
more accurately when `pair-programming` is enabled.

Connectors updated:
- `[aA][nN][dD]`
- `&`
- `+`

Tests updated accordingly.

Signed-off-by: Quan Zhou <quan@bitergia.com>