### PR TITLE
Update poetry builder version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,5 +61,5 @@ flake8 = "^3.9.2"
 coverage = "^5.5"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/releases/unreleased/poetry-build-version-updated.yml
+++ b/releases/unreleased/poetry-build-version-updated.yml
@@ -1,0 +1,12 @@
+---
+title: Poetry build version updated
+category: fixed
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: null
+notes: >
+  The current version of the `poetry` builder
+  was old and caused some problems when installing
+  packages in developer mode. With this
+  new version, it's possible to install ELK in
+  developer or editable mode without using
+  `setuptools` files (i.e. `setup.cfg` and `setup.py`).


### PR DESCRIPTION
The current version of the poetry builder was old and caused some problems when installing packages in developer mode. With this new version, it's possible to install ELK in developer or editable mode without using setuptools files (i.e. `setup.cfg` and `setup.py`).