### PR TITLE
[raw/slack] Handle fields in 'data.file'

### DIFF
--- a/grimoire_elk/raw/slack.py
+++ b/grimoire_elk/raw/slack.py
@@ -58,6 +58,10 @@ class Mapping(BaseMapping):
                                         }
                                     }
                                 },
+                                "file": {
+                                    "dynamic": false,
+                                    "properties": {}
+                                },
                                 "files": {
                                     "dynamic": false,
                                     "properties": {}

--- a/releases/unreleased/[slack]-handle-fields-in-data.file.yml
+++ b/releases/unreleased/[slack]-handle-fields-in-data.file.yml
@@ -1,0 +1,9 @@
+---
+title: '[raw/slack] Handle fields in "data.file"'
+category: fixed
+author: Quan Zhou <quan@bitergia.com>
+issue: null
+notes: >
+    Avoid the 'Failed to insert data to ES' error when a
+    document contains at least one immense term in 'data.file'
+    (whose UTF8 encoding is longer than the max length 32766).


### PR DESCRIPTION
This code allows handling the fields in `data.file` to
avoid the error `Failed to insert data to ES`

Signed-off-by: Quan Zhou <quan@bitergia.com>