### PR TITLE
[enriched/gitlab] Fix unexpected keyword argument 'alias' in onion

### DIFF
--- a/grimoire_elk/enriched/gitlab.py
+++ b/grimoire_elk/enriched/gitlab.py
@@ -376,7 +376,7 @@ class GitLabEnrich(Enrich):
             if due_date_str:
                 eitem['milestone_due_date'] = str_to_datetime(due_date_str).replace(tzinfo=None).isoformat()
 
-    def enrich_onion(self, ocean_backend, enrich_backend,
+    def enrich_onion(self, ocean_backend, enrich_backend, alias,
                      in_index, out_index, data_source=None, no_incremental=False,
                      contribs_field='uuid',
                      timeframe_field='grimoire_creation_date',
@@ -391,6 +391,7 @@ class GitLabEnrich(Enrich):
                            data_source, GITLAB_ISSUES, GITLAB_MERGES))
 
         super().enrich_onion(enrich_backend=enrich_backend,
+                             alias=alias,
                              in_index=in_index,
                              out_index=out_index,
                              data_source=data_source,

--- a/releases/unreleased/onion-study-on-gitlab-fixed.yml
+++ b/releases/unreleased/onion-study-on-gitlab-fixed.yml
@@ -1,0 +1,8 @@
+---
+title: Onion study on Gitlab fixed
+category: fixed
+author: Quan Zhou <quan@bitergia.com>
+issue: null
+notes: >
+    Gitlab onion study is now updated to allow passing the study
+    alias name by parameter.


### PR DESCRIPTION
This code fixes TypeError since the name of the aliases is no longer harcoded, now it is passed by parameter.

Error:
```
TypeError: enrich_onion() got an unexpected keyword argument 'alias'
```

Test added accordingly.

Signed-off-by: Quan Zhou <quan@bitergia.com>