### PR TITLE
[pyproject] Fix pyproject syntax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ packages = [
 ]
 
 include = [
-    "grimoire_elk/enriched/mappings/*.json",
+    { path = "grimoire_elk/enriched/mappings/*.json"},
     { path = "AUTHORS", format = "sdist" },
     { path = "NEWS", format = "sdist" },
     { path = "README.md", format = "sdist" },


### PR DESCRIPTION
This commit fixes the 'include' list. It was a mix of dictionaries and strings.
