### PR TITLE
[enriched/weblate] Fix unexpected keyword argument 'alias' in demography

### DIFF
--- a/grimoire_elk/enriched/weblate.py
+++ b/grimoire_elk/enriched/weblate.py
@@ -174,7 +174,7 @@ class WeblateEnrich(Enrich):
         self.add_metadata_filter_raw(eitem)
         return eitem
 
-    def enrich_demography(self, ocean_backend, enrich_backend, date_field="grimoire_creation_date",
+    def enrich_demography(self, ocean_backend, enrich_backend, alias, date_field="grimoire_creation_date",
                           author_field="author_uuid"):
 
-        super().enrich_demography(ocean_backend, enrich_backend, date_field, author_field=author_field)
+        super().enrich_demography(ocean_backend, enrich_backend, alias, date_field, author_field=author_field)

--- a/releases/unreleased/demographic-study-on-weblate-fixed.yml
+++ b/releases/unreleased/demographic-study-on-weblate-fixed.yml
@@ -1,0 +1,8 @@
+---
+title: Demographic study on Weblate fixed
+category: fixed
+author: Quan Zhou <quan@bitergia.com>
+issue: null
+notes: >
+    Weblate demographic study is now updated to allow passing the study
+    alias name by parameter.


### PR DESCRIPTION
This code fixes TypeError in weblate since the name of the aliases is no longer harcoded, now it is passed by parameter.

Error:
```
TypeError: enrich_demography() got an unexpected keyword argument 'alias'
```

Test added accordingly.

Signed-off-by: Quan Zhou <quan@bitergia.com>