### PR TITLE
Fix mapping and bulk URL for ES 8.X and OS 2.X

### DIFF
--- a/grimoire_elk/elastic.py
+++ b/grimoire_elk/elastic.py
@@ -298,8 +298,8 @@ class ElasticSearch(object):
     def get_bulk_url(self):
         """Get the bulk URL endpoint"""
 
-        if (self.major == '7' and self.distribution == 'elasticsearch') or \
-           (self.major == '1' and self.distribution == 'opensearch'):
+        if (int(self.major) >= 7 and self.distribution == 'elasticsearch') or \
+           (int(self.major) >= 1 and self.distribution == 'opensearch'):
             bulk_url = self.index_url + '/_bulk'
         else:
             bulk_url = self.index_url + '/items/_bulk'

--- a/grimoire_elk/elastic.py
+++ b/grimoire_elk/elastic.py
@@ -298,8 +298,7 @@ class ElasticSearch(object):
     def get_bulk_url(self):
         """Get the bulk URL endpoint"""
 
-        if (int(self.major) >= 7 and self.distribution == 'elasticsearch') or \
-           (int(self.major) >= 1 and self.distribution == 'opensearch'):
+        if not self.is_legacy():
             bulk_url = self.index_url + '/_bulk'
         else:
             bulk_url = self.index_url + '/items/_bulk'
@@ -311,8 +310,7 @@ class ElasticSearch(object):
 
         :param _type: type of the mapping. In case of ES >= 7, it is None
         """
-        if (int(self.major) >= 7 and self.distribution == 'elasticsearch') or \
-           (int(self.major) >= 1 and self.distribution == 'opensearch'):
+        if not self.is_legacy():
             mapping_url = self.index_url + "/_mapping"
         else:
             mapping_url = self.index_url + "/" + _type + "/_mapping"
@@ -609,3 +607,15 @@ class ElasticSearch(object):
             return
 
         return properties
+
+    def is_legacy(self):
+        """ Simply calls the static version with it's own values """
+        return ElasticSearch.is_legacy_static(self.major, self.distribution)
+
+    @staticmethod
+    def is_legacy_static(major, distribution):
+        """ Returns true if ES < 7 or OS < 1, false otherwise.
+        Static version exists because not every place that uses this check has an ES object."""
+        int_maj = int(major)
+        return ((int_maj < 7 and distribution == 'elasticsearch')
+            or (int_maj < 1 and distribution == 'opensearch'))

--- a/grimoire_elk/elastic.py
+++ b/grimoire_elk/elastic.py
@@ -309,10 +309,10 @@ class ElasticSearch(object):
     def get_mapping_url(self, _type=None):
         """Get the mapping URL endpoint
 
-        :param _type: type of the mapping. In case of ES7, it is None
+        :param _type: type of the mapping. In case of ES >= 7, it is None
         """
-        if (self.major == '7' and self.distribution == 'elasticsearch') or \
-           (self.major == '1' and self.distribution == 'opensearch'):
+        if (int(self.major) >= 7 and self.distribution == 'elasticsearch') or \
+           (int(self.major) >= 1 and self.distribution == 'opensearch'):
             mapping_url = self.index_url + "/_mapping"
         else:
             mapping_url = self.index_url + "/" + _type + "/_mapping"

--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -1137,8 +1137,7 @@ class Enrich(ElasticItems):
         # Onion currently does not support incremental option
         logger.info("{} Creating out ES index".format(log_prefix))
         # Initialize out index
-        if (self.elastic.major == '7' and self.elastic.distribution == 'elasticsearch') or \
-           (self.elastic.major == '1' and self.elastic.distribution == 'opensearch'):
+        if not self.elastic.is_legacy():
             filename = pkg_resources.resource_filename('grimoire_elk', 'enriched/mappings/onion_es7.json')
         else:
             filename = pkg_resources.resource_filename('grimoire_elk', 'enriched/mappings/onion.json')

--- a/grimoire_elk/enriched/git.py
+++ b/grimoire_elk/enriched/git.py
@@ -603,8 +603,7 @@ class GitEnrich(Enrich):
             logger.info("{} Creating out ES index".format(log_prefix))
             # Initialize out index
 
-            if (self.elastic.major == '7' and self.elastic.distribution == 'elasticsearch') or \
-               (self.elastic.major == '1' and self.elastic.distribution == 'opensearch'):
+            if not self.elastic.is_legacy():
                 filename = pkg_resources.resource_filename('grimoire_elk', 'enriched/mappings/git_aoc_es7.json')
             else:
                 filename = pkg_resources.resource_filename('grimoire_elk', 'enriched/mappings/git_aoc.json')

--- a/grimoire_elk/enriched/study_ceres_aoc.py
+++ b/grimoire_elk/enriched/study_ceres_aoc.py
@@ -28,6 +28,7 @@ from cereslib.enrich.enrich import FileType, FilePath, ToUTF8
 from cereslib.events.events import Git, Events
 
 from grimoire_elk.enriched.ceres_base import ESConnector, CeresBase
+from grimoire_elk.elastic import ElasticSearch
 
 
 logger = logging.getLogger(__name__)
@@ -132,8 +133,7 @@ class ESPandasConnector(ESConnector):
                 "_source": row
             }
 
-            if (self._es_major == '7' and self._es_distribution == 'elasticsearch') or\
-               (self._es_major == '1' and self._es_distribution == 'opensearch'):
+            if not ElasticSearch.is_legacy_static(self._es_major, self._es_distribution):
                 doc.pop('_type')
 
             docs.append(doc)

--- a/grimoire_elk/enriched/study_ceres_onion.py
+++ b/grimoire_elk/enriched/study_ceres_onion.py
@@ -29,6 +29,7 @@ from elasticsearch_dsl import Search, Q
 from cereslib.enrich.enrich import Onion
 from grimoirelab_toolkit import datetime as gl_dt
 from grimoire_elk.enriched.ceres_base import ESConnector, CeresBase
+from grimoire_elk.elastic import ElasticSearch
 
 
 logger = logging.getLogger(__name__)
@@ -172,8 +173,7 @@ class ESOnionConnector(ESConnector):
                 "_source": row
             }
 
-            if (self._es_major == '7' and self._es_distribution == 'elasticsearch') or \
-               (self._es_major == '1' and self._es_distribution == 'opensearch'):
+            if not ElasticSearch.is_legacy_static(self._es_major, self._es_distribution):
                 doc.pop('_type')
 
             docs.append(doc)

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -343,8 +343,8 @@ class TestElastic(unittest.TestCase):
 
         elastic = MockElasticSearch(self.es_con, self.target_index)
 
-        if (elastic.major == '7' and elastic.distribution == ES_DISTRIBUTION) or \
-           (elastic.major == '1' and elastic.distribution == OS_DISTRIBUTION):
+        if (int(elastic.major) >= 7 and elastic.distribution == ES_DISTRIBUTION) or \
+           (int(elastic.major) >= 1 and elastic.distribution == OS_DISTRIBUTION):
             url = elastic.index_url + "/_mapping"
         else:
             url = elastic.index_url + "/items/_mapping"
@@ -367,8 +367,8 @@ class TestElastic(unittest.TestCase):
 
         elastic = MockElasticSearch(self.es_con, self.target_index)
 
-        if (elastic.major == '7' and elastic.distribution == ES_DISTRIBUTION) or \
-           (elastic.major == '1' and elastic.distribution == OS_DISTRIBUTION):
+        if (int(elastic.major) >= 7 and elastic.distribution == ES_DISTRIBUTION) or \
+           (int(elastic.major) >= 1 and elastic.distribution == OS_DISTRIBUTION):
             url = elastic.index_url + "/_mapping"
         else:
             url = elastic.index_url + "/items/_mapping"
@@ -633,8 +633,8 @@ class TestElastic(unittest.TestCase):
     def test_all_properties_error(self):
         """Test whether an error message is logged when the properties aren't retrieved"""
 
-        if (self.es_major == '7' and self.es_distribution == 'elasticsearch') or \
-           (self.es_major == '1' and self.es_distribution == 'opensearch'):
+        if (int(elastic.major) >= 7 and elastic.distribution == ES_DISTRIBUTION) or \
+           (int(elastic.major) >= 1 and elastic.distribution == OS_DISTRIBUTION):
             url = self.es_con + '/' + self.target_index + '/_mapping'
         else:
             url = self.es_con + '/' + self.target_index + '/items/_mapping'

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -633,8 +633,8 @@ class TestElastic(unittest.TestCase):
     def test_all_properties_error(self):
         """Test whether an error message is logged when the properties aren't retrieved"""
 
-        if (int(elastic.major) >= 7 and elastic.distribution == ES_DISTRIBUTION) or \
-           (int(elastic.major) >= 1 and elastic.distribution == OS_DISTRIBUTION):
+        if (int(self.es_major) >= 7 and self.es_distribution == 'elasticsearch') or \
+           (int(self.es_major) >= 1 and self.es_distribution == 'opensearch'):
             url = self.es_con + '/' + self.target_index + '/_mapping'
         else:
             url = self.es_con + '/' + self.target_index + '/items/_mapping'

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -343,8 +343,7 @@ class TestElastic(unittest.TestCase):
 
         elastic = MockElasticSearch(self.es_con, self.target_index)
 
-        if (int(elastic.major) >= 7 and elastic.distribution == ES_DISTRIBUTION) or \
-           (int(elastic.major) >= 1 and elastic.distribution == OS_DISTRIBUTION):
+        if not elastic.is_legacy():
             url = elastic.index_url + "/_mapping"
         else:
             url = elastic.index_url + "/items/_mapping"
@@ -367,8 +366,7 @@ class TestElastic(unittest.TestCase):
 
         elastic = MockElasticSearch(self.es_con, self.target_index)
 
-        if (int(elastic.major) >= 7 and elastic.distribution == ES_DISTRIBUTION) or \
-           (int(elastic.major) >= 1 and elastic.distribution == OS_DISTRIBUTION):
+        if not elastic.is_legacy():
             url = elastic.index_url + "/_mapping"
         else:
             url = elastic.index_url + "/items/_mapping"
@@ -633,8 +631,7 @@ class TestElastic(unittest.TestCase):
     def test_all_properties_error(self):
         """Test whether an error message is logged when the properties aren't retrieved"""
 
-        if (int(self.es_major) >= 7 and self.es_distribution == 'elasticsearch') or \
-           (int(self.es_major) >= 1 and self.es_distribution == 'opensearch'):
+        if not ElasticSearch.is_legacy_static(self.es_major, self.es_distribution):
             url = self.es_con + '/' + self.target_index + '/_mapping'
         else:
             url = self.es_con + '/' + self.target_index + '/items/_mapping'


### PR DESCRIPTION
The way support for ES 7.X and OS 1.X was originally implemented meant that any major version that was not EXACTLY 7/1 would revert to old behavior. This is obviously wrong and simply changing this check to allow versions >= 7/1 seems to just work (at least in the context of using mordred to import git data from perceval).

I can not guarantee that everything works, and I know that at least kibash still needs some work as discussed here. But in any case, the check was wrong, and this PR should at least fix that.

:edit: Recreated this PR as I messed up what branch I used as the source for this PR and the old one got unclean.