### PR TITLE
Specify exact mappings for date fields in git documents

### DIFF
--- a/grimoire_elk/raw/git.py
+++ b/grimoire_elk/raw/git.py
@@ -46,6 +46,14 @@ class Mapping(BaseMapping):
                         "message": {
                             "type": "text",
                             "index": true
+                        },
+                        "AuthorDate": {
+                            "type": "date",
+                            "format": "EEE MMM dd HH:mm:ss yyyy Z||strict_date_optional_time||epoch_millis"
+                        },
+                        "CommitDate": {
+                            "type": "date",
+                            "format": "EEE MMM dd HH:mm:ss yyyy Z||strict_date_optional_time||epoch_millis"
                         }
                     }
                 }

--- a/tests/data/git.json
+++ b/tests/data/git.json
@@ -417,9 +417,9 @@
         "HEAD -> refs/heads/master"
       ],
       "Author": "Owl Capone <owlcapone@boss.io>",
-      "AuthorDate": "Tue Oct 10 12:48:51 2019 -0700",
+      "AuthorDate": "Thu Oct 10 12:48:51 2019 -0700",
       "Commit": "GitHub <noreply@github.com>",
-      "CommitDate": "Tue Oct 10 12:48:51 2019 -0700",
+      "CommitDate": "Thu Oct 10 12:48:51 2019 -0700",
       "message": "Update README.md",
       "files": [
         {
@@ -461,9 +461,9 @@
         "HEAD -> refs/heads/master"
       ],
       "Author": "Owl Capone <owlcapone@boss.io>",
-      "AuthorDate": "Tue Oct 11 14:48:51 2019 -0700",
+      "AuthorDate": "Fri Oct 11 14:48:51 2019 -0700",
       "Commit": "GitHub <noreply@github.com>",
-      "CommitDate": "Tue Oct 11 14:48:51 2019 -0700",
+      "CommitDate": "Fri Oct 11 14:48:51 2019 -0700",
       "message": "Update README.md",
       "files": [
         {

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -612,6 +612,14 @@ class TestElastic(unittest.TestCase):
                 'properties': {
                     'message': {
                         'type': 'text'
+                    },
+                    'AuthorDate': {
+                        'type': 'date',
+                        'format': 'EEE MMM dd HH:mm:ss yyyy Z||strict_date_optional_time||epoch_millis'
+                    },
+                    'CommitDate': {
+                        'type': 'date',
+                        'format': 'EEE MMM dd HH:mm:ss yyyy Z||strict_date_optional_time||epoch_millis'
                     }
                 }
             }


### PR DESCRIPTION
Simple PR, just specifies that `AuthorDate` and `CommitDate` are date fields in ES. This allows us to later do better filtering such as being able to specify `AuthorDate <= {Some Date}`.