### PR TITLE
Fix typo in SortingHat API fields

### DIFF
--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -730,8 +730,8 @@ class Enrich(ElasticItems):
             eitem_sh[rol + "_domain"] = self.get_email_domain(email)
 
             eitem_sh[rol + "_gender"] = profile.get('gender', self.unknown_gender)
-            eitem_sh[rol + "_gender_acc"] = profile.get('gender_acc', 0)
-            eitem_sh[rol + "_bot"] = profile.get('is_bot', False)
+            eitem_sh[rol + "_gender_acc"] = profile.get('genderAcc', 0)
+            eitem_sh[rol + "_bot"] = profile.get('isBot', False)
 
         # Ensure we always write gender fields
         if not eitem_sh.get(rol + "_gender"):

--- a/releases/unreleased/fix-typo-in-is_bot-field.yml
+++ b/releases/unreleased/fix-typo-in-is_bot-field.yml
@@ -1,0 +1,10 @@
+---
+title: Fix typo in SortingHat fields
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: |
+  Some fields were not updated from the old version of
+  SortingHat. Now the API returns 'isBot' and 'genderAcc'
+  instead of 'is_bot' and 'gender_acc'.
+

--- a/tests/test_enrich.py
+++ b/tests/test_enrich.py
@@ -142,8 +142,8 @@ class TestEnrich(unittest.TestCase):
                 "name": expected['author_name'],
                 "email": "pepepotamo@local.com",
                 "gender": expected['author_gender'],
-                "gender_acc": expected['author_gender_acc'],
-                "is_bot": expected['author_bot']
+                "genderAcc": expected['author_gender_acc'],
+                "isBot": expected['author_bot']
             },
             'enrollments': [
                 {
@@ -399,7 +399,7 @@ class TestEnrich(unittest.TestCase):
             'profile': {
                 "name": expected['author_name'],
                 "email": "pepepotamo@local.com",
-                "is_bot": expected['author_bot']
+                "isBot": expected['author_bot']
             },
             'enrollments': [
                 {
@@ -465,8 +465,8 @@ class TestEnrich(unittest.TestCase):
                 "name": expected['author_name'],
                 "email": "pepepotamo@local.com",
                 "gender": expected['author_gender'],
-                "gender_acc": expected['author_gender_acc'],
-                "is_bot": expected['author_bot']
+                "genderAcc": expected['author_gender_acc'],
+                "isBot": expected['author_bot']
             },
             'enrollments': [
                 {


### PR DESCRIPTION
This PR updates the name of the fields that are obtained from the SortingHat API. Previously the fields were `gender_acc` and `is_bot` but now are `genderAcc` and `isBot`.

Update tests accordingly.