### PR TITLE
Improve enrichment process performance

### DIFF
--- a/grimoire_elk/elk.py
+++ b/grimoire_elk/elk.py
@@ -371,7 +371,7 @@ def load_identities(ocean_backend, enrich_backend):
     return identities_count
 
 
-@lru_cache(1024)
+@lru_cache(4096)
 def add_sh_identity_cache(identity_tuple, sh_db, backend):
     """Cache add_sh_identity calls. Identity must be in tuple format"""
 

--- a/grimoire_elk/enriched/sortinghat_gelk.py
+++ b/grimoire_elk/enriched/sortinghat_gelk.py
@@ -102,13 +102,6 @@ class SortingHat(object):
         try:
             uuid = cls.add_id(db, backend, email=identity['email'],
                               name=identity['name'], username=identity['username'])
-
-            profile = {"name": identity['name'] if identity['name'] else identity['username'],
-                       "email": identity['email']}
-            profile_without_empty = {k: v for k, v in profile.items() if v}
-
-            cls.update_profile(db, uuid, profile_without_empty)
-
         except UnicodeEncodeError:
             logger.warning("[sortinghat] UnicodeEncodeError. Ignoring it. {} {} {}".format(
                            identity['email'], identity['name'], identity['username']))

--- a/releases/unreleased/enrichment-process-performance-improved.yml
+++ b/releases/unreleased/enrichment-process-performance-improved.yml
@@ -1,0 +1,12 @@
+---
+title: Enrichment processing time reduced by 50%
+category: performance
+author: Quan Zhou <quan@bitergia.com>
+issue: null
+notes: |
+  The general performance was improved reducing the number of calls
+  to the identities manager (i.g. `SortingHat`). There were some deprecated
+  calls that weren't needed any longer and also, we increased the cache of
+  individuals in ELKs.
+  We were also able to reduce the processing time of the Git backend by
+  converting commit dates only once.


### PR DESCRIPTION
This commit improves the performance of the enrichment process.

- Reduce the number of requests to get the backend name (`_connecto_name`).
- Reduce the number of queries to get information from SortingHat.
- Removes an unused method called `get_uuid`.
- Refactor and rename the `__fix_field_date` method to `__cast_str_to_datetime` to convert str to datetime and fix possible date format errors. With this method we reduce the number of calls of the `str_to_datetime` method.
- In the `__add_commit_meta_fields` method it only creates a new identity when it doesn't exist in SortingHat.
- In the `add_identity` method, remove the `update_profile` mutation; this is no longer necessary as we are using GraphQL.