### PR TITLE
[enrich] Fix enrich items with multiple enrollments

### DIFF
--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -916,8 +916,7 @@ class Enrich(ElasticItems):
         if not roles:
             roles = [author_field]
 
-        date = str_to_datetime(eitem[self.get_field_date()])
-
+        date = eitem[self.get_field_date()]
         for rol in roles:
             if rol + "_id" not in eitem:
                 # For example assignee in github it is usual that it does not appears
@@ -957,7 +956,7 @@ class Enrich(ElasticItems):
 
         eitem_meta_sh = {}  # Item enriched
 
-        date = str_to_datetime(eitem[self.get_field_date()])
+        date = eitem[self.get_field_date()]
 
         for rol in roles:
             if rol + "_uuids" not in eitem:

--- a/releases/unreleased/datetime-format-fixed-in-the-enrichment-process.yml
+++ b/releases/unreleased/datetime-format-fixed-in-the-enrichment-process.yml
@@ -1,0 +1,8 @@
+---
+title: Enrich items with multiple enrollments
+category: fixed
+author: Quan Zhou <quan@bitergia.com>
+issue: null
+notes: |
+  The `date` field must be a string since improved performance
+  by decreasing calls to the `str_to_datetime` method.


### PR DESCRIPTION
This commit fixes the date format when there are several enrollments in profiles. Since the number of times the `str_to_datetime` method is executed has been reduced to improve performance the `date` field in `get_item_sh_from_id` and `get_item_sh_meta_fields` must be strings.

Test to enrich a profile with multiple enrollments added.