### PR TITLE
[bugzilla] Include bug description in Bugzilla enriched

### DIFF
--- a/grimoire_elk/enriched/bugzilla.py
+++ b/grimoire_elk/enriched/bugzilla.py
@@ -53,6 +53,10 @@ class Mapping(BaseMapping):
                "summary_analyzed": {
                     "type": "text",
                     "index": true
+               },
+               "description_analyzed": {
+                    "type": "text",
+                    "index": true
                }
            }
         }"""
@@ -171,6 +175,12 @@ class BugzillaEnrich(Enrich):
             if "__text__" in issue["summary"][0]:
                 eitem["summary"] = issue['summary'][0]['__text__'][:self.KEYWORD_MAX_LENGTH]
                 eitem["summary_analyzed"] = issue['summary'][0]['__text__']
+        try:
+            eitem['description'] = issue['long_desc'][0]['thetext'][0]['__text__'][:self.KEYWORD_MAX_LENGTH]
+            eitem['description_analyzed'] = issue['long_desc'][0]['thetext'][0]['__text__']
+        except (KeyError, IndexError):
+            eitem['description'] = ""
+            eitem['description_analyzed'] = ""
 
         # Fix dates
         date_ts = str_to_datetime(issue['delta_ts'][0]['__text__'])

--- a/releases/unreleased/bug-description-in-bugzilla.yml
+++ b/releases/unreleased/bug-description-in-bugzilla.yml
@@ -1,0 +1,9 @@
+---
+title: Bug description in Bugzilla
+category: added
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Include the description of the bugs in Bugzilla. The new fields
+  are 'description' and 'description_analyzed'. The second allows
+  to query any of the words of the description.

--- a/schema/bugzilla.csv
+++ b/schema/bugzilla.csv
@@ -49,6 +49,8 @@ creator_detail_org_name,keyword
 creator_detail_user_name,keyword
 creator_detail_uuid,keyword
 delta_ts,date
+description,keyword
+description_analyzed,string
 grimoire_creation_date,date
 id,long
 is_bugzilla_bug,long

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -60,6 +60,10 @@ class TestBugzilla(TestBaseBackend):
         eitem = enrich_backend.get_rich_item(item)
         self.assertIn('main_description', eitem)
         self.assertIn('main_description_analyzed', eitem)
+        self.assertIn('description', eitem)
+        self.assertIn('description_analyzed', eitem)
+        self.assertRegex(eitem['description'], "Lorem ipsum dolor.*")
+        self.assertRegex(eitem['description_analyzed'], "Lorem ipsum dolor.*")
 
     def test_enrich_repo_labels(self):
         """Test whether the field REPO_LABELS is present in the enriched items"""


### PR DESCRIPTION
Include the description of the bugs in Bugzilla. The new fields are 'description' and 'description_analyzed'. The second allows to query any of the words of the description.