### PR TITLE
[github] Fix get_identities method not returning all identities

### DIFF
--- a/releases/unreleased/undefined-identities-in-github-comments.yml
+++ b/releases/unreleased/undefined-identities-in-github-comments.yml
@@ -1,0 +1,9 @@
+---
+title: Undefined identities in GitHub comments
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Fix a bug that causes certain identities from commentaries
+  to not be imported into SortingHat, resulting in them appearing
+  as UNDEFINED in OpenSearch.


### PR DESCRIPTION
This PR fixes a bug that cause that some identities were not loaded in SortingHat and in OpenSearch were displayed as UNDEFINED.

The method `get_identities` was not returning the identities from `reviews_data`.