### PR TITLE
[enrich] Arguments in wrong order in some backends

### DIFF
--- a/grimoire_elk/enriched/cocom.py
+++ b/grimoire_elk/enriched/cocom.py
@@ -149,10 +149,10 @@ class CocomEnrich(Enrich):
     metrics = ["ccn", "num_funs", "tokens", "loc", "comments", "blanks"]
 
     def __init__(self, db_sortinghat=None, json_projects_map=None,
-                 db_user='', db_password='', db_host='', db_path=None,
-                 db_port=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
+                 db_user='', db_password='', db_host='', insecure=True, db_port=None,
+                 db_path=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
         super().__init__(db_sortinghat=db_sortinghat, json_projects_map=json_projects_map,
-                         db_user=db_user, db_password=db_password, db_host=db_host,
+                         db_user=db_user, db_password=db_password, db_host=db_host, insecure=insecure,
                          db_port=db_port, db_path=db_path, db_ssl=db_ssl, db_verify_ssl=db_verify_ssl,
                          db_tenant=db_tenant)
 

--- a/grimoire_elk/enriched/colic.py
+++ b/grimoire_elk/enriched/colic.py
@@ -85,10 +85,10 @@ class Mapping(BaseMapping):
 class ColicEnrich(Enrich):
 
     def __init__(self, db_sortinghat=None, json_projects_map=None,
-                 db_user='', db_password='', db_host='', db_path=None,
-                 db_port=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
+                 db_user='', db_password='', db_host='', insecure=True, db_port=None,
+                 db_path=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
         super().__init__(db_sortinghat=db_sortinghat, json_projects_map=json_projects_map,
-                         db_user=db_user, db_password=db_password, db_host=db_host,
+                         db_user=db_user, db_password=db_password, db_host=db_host, insecure=insecure,
                          db_port=db_port, db_path=db_path, db_ssl=db_ssl, db_verify_ssl=db_verify_ssl,
                          db_tenant=db_tenant)
 

--- a/grimoire_elk/enriched/discourse.py
+++ b/grimoire_elk/enriched/discourse.py
@@ -63,10 +63,10 @@ class DiscourseEnrich(Enrich):
     mapping = Mapping
 
     def __init__(self, db_sortinghat=None, json_projects_map=None,
-                 db_user='', db_password='', db_host='', db_path=None,
-                 db_port=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
+                 db_user='', db_password='', db_host='', insecure=True, db_port=None,
+                 db_path=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
         super().__init__(db_sortinghat=db_sortinghat, json_projects_map=json_projects_map,
-                         db_user=db_user, db_password=db_password, db_host=db_host,
+                         db_user=db_user, db_password=db_password, db_host=db_host, insecure=insecure,
                          db_port=db_port, db_path=db_path, db_ssl=db_ssl, db_verify_ssl=db_verify_ssl,
                          db_tenant=db_tenant)
         self.categories = {}  # Map from category_id to category_name

--- a/grimoire_elk/enriched/dockerdeps.py
+++ b/grimoire_elk/enriched/dockerdeps.py
@@ -73,10 +73,10 @@ class Mapping(BaseMapping):
 class Dockerdeps(Enrich):
 
     def __init__(self, db_sortinghat=None, json_projects_map=None,
-                 db_user='', db_password='', db_host='', db_path=None,
-                 db_port=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
+                 db_user='', db_password='', db_host='', insecure=True, db_port=None,
+                 db_path=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
         super().__init__(db_sortinghat=db_sortinghat, json_projects_map=json_projects_map,
-                         db_user=db_user, db_password=db_password, db_host=db_host,
+                         db_user=db_user, db_password=db_password, db_host=db_host, insecure=insecure,
                          db_port=db_port, db_path=db_path, db_ssl=db_ssl, db_verify_ssl=db_verify_ssl,
                          db_tenant=db_tenant)
 

--- a/grimoire_elk/enriched/dockersmells.py
+++ b/grimoire_elk/enriched/dockersmells.py
@@ -73,10 +73,10 @@ class Mapping(BaseMapping):
 class Dockersmells(Enrich):
 
     def __init__(self, db_sortinghat=None, json_projects_map=None,
-                 db_user='', db_password='', db_host='', db_path=None,
-                 db_port=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
+                 db_user='', db_password='', db_host='', insecure=True, db_port=None,
+                 db_path=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
         super().__init__(db_sortinghat=db_sortinghat, json_projects_map=json_projects_map,
-                         db_user=db_user, db_password=db_password, db_host=db_host,
+                         db_user=db_user, db_password=db_password, db_host=db_host, insecure=insecure,
                          db_port=db_port, db_path=db_path, db_ssl=db_ssl, db_verify_ssl=db_verify_ssl,
                          db_tenant=db_tenant)
 

--- a/grimoire_elk/enriched/gerrit.py
+++ b/grimoire_elk/enriched/gerrit.py
@@ -88,10 +88,10 @@ class GerritEnrich(Enrich):
     mapping = Mapping
 
     def __init__(self, db_sortinghat=None, json_projects_map=None,
-                 db_user='', db_password='', db_host='', db_path=None,
-                 db_port=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
+                 db_user='', db_password='', db_host='', insecure=True, db_port=None,
+                 db_path=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
         super().__init__(db_sortinghat=db_sortinghat, json_projects_map=json_projects_map,
-                         db_user=db_user, db_password=db_password, db_host=db_host,
+                         db_user=db_user, db_password=db_password, db_host=db_host, insecure=insecure,
                          db_port=db_port, db_path=db_path, db_ssl=db_ssl, db_verify_ssl=db_verify_ssl,
                          db_tenant=db_tenant)
 

--- a/grimoire_elk/enriched/git.py
+++ b/grimoire_elk/enriched/git.py
@@ -93,11 +93,11 @@ class GitEnrich(Enrich):
     meta_non_authored_prefix = 'non_authored_'
 
     def __init__(self, db_sortinghat=None, json_projects_map=None,
-                 db_user='', db_password='', db_host='', db_path=None,
-                 db_port=None, db_ssl=False, db_verify_ssl=True, db_tenant=None,
+                 db_user='', db_password='', db_host='', insecure=True, db_port=None,
+                 db_path=None, db_ssl=False, db_verify_ssl=True, db_tenant=None,
                  pair_programming=False):
         super().__init__(db_sortinghat=db_sortinghat, json_projects_map=json_projects_map,
-                         db_user=db_user, db_password=db_password, db_host=db_host,
+                         db_user=db_user, db_password=db_password, db_host=db_host, insecure=insecure,
                          db_port=db_port, db_path=db_path, db_ssl=db_ssl, db_verify_ssl=db_verify_ssl,
                          db_tenant=db_tenant)
 

--- a/grimoire_elk/enriched/github.py
+++ b/grimoire_elk/enriched/github.py
@@ -105,10 +105,10 @@ class GitHubEnrich(Enrich):
     roles = ['assignee_data', 'merged_by_data', 'user_data']
 
     def __init__(self, db_sortinghat=None, json_projects_map=None,
-                 db_user='', db_password='', db_host='', db_path=None,
-                 db_port=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
+                 db_user='', db_password='', db_host='', insecure=True, db_port=None,
+                 db_path=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
         super().__init__(db_sortinghat=db_sortinghat, json_projects_map=json_projects_map,
-                         db_user=db_user, db_password=db_password, db_host=db_host,
+                         db_user=db_user, db_password=db_password, db_host=db_host, insecure=insecure,
                          db_port=db_port, db_path=db_path, db_ssl=db_ssl, db_verify_ssl=db_verify_ssl,
                          db_tenant=db_tenant)
 

--- a/grimoire_elk/enriched/github2.py
+++ b/grimoire_elk/enriched/github2.py
@@ -106,10 +106,10 @@ class GitHubEnrich2(Enrich):
     roles = ['assignee_data', 'merged_by_data', 'user_data']
 
     def __init__(self, db_sortinghat=None, json_projects_map=None,
-                 db_user='', db_password='', db_host='', db_path=None,
-                 db_port=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
+                 db_user='', db_password='', db_host='', insecure=True, db_port=None,
+                 db_path=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
         super().__init__(db_sortinghat=db_sortinghat, json_projects_map=json_projects_map,
-                         db_user=db_user, db_password=db_password, db_host=db_host,
+                         db_user=db_user, db_password=db_password, db_host=db_host, insecure=insecure,
                          db_port=db_port, db_path=db_path, db_ssl=db_ssl, db_verify_ssl=db_verify_ssl,
                          db_tenant=db_tenant)
 

--- a/grimoire_elk/enriched/githubql.py
+++ b/grimoire_elk/enriched/githubql.py
@@ -77,10 +77,10 @@ class GitHubQLEnrich(Enrich):
     event_roles = ['actor', 'reporter', 'submitter']
 
     def __init__(self, db_sortinghat=None, json_projects_map=None,
-                 db_user='', db_password='', db_host='', db_path=None,
-                 db_port=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
+                 db_user='', db_password='', db_host='', insecure=True, db_port=None,
+                 db_path=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
         super().__init__(db_sortinghat=db_sortinghat, json_projects_map=json_projects_map,
-                         db_user=db_user, db_password=db_password, db_host=db_host,
+                         db_user=db_user, db_password=db_password, db_host=db_host, insecure=insecure,
                          db_port=db_port, db_path=db_path, db_ssl=db_ssl, db_verify_ssl=db_verify_ssl,
                          db_tenant=db_tenant)
 

--- a/grimoire_elk/enriched/gitlab.py
+++ b/grimoire_elk/enriched/gitlab.py
@@ -75,10 +75,10 @@ class GitLabEnrich(Enrich):
     merge_roles = ['author']
 
     def __init__(self, db_sortinghat=None, json_projects_map=None,
-                 db_user='', db_password='', db_host='', db_path=None,
-                 db_port=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
+                 db_user='', db_password='', db_host='', insecure=True, db_port=None,
+                 db_path=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
         super().__init__(db_sortinghat=db_sortinghat, json_projects_map=json_projects_map,
-                         db_user=db_user, db_password=db_password, db_host=db_host,
+                         db_user=db_user, db_password=db_password, db_host=db_host, insecure=insecure,
                          db_port=db_port, db_path=db_path, db_ssl=db_ssl, db_verify_ssl=db_verify_ssl,
                          db_tenant=db_tenant)
 

--- a/grimoire_elk/enriched/gitter.py
+++ b/grimoire_elk/enriched/gitter.py
@@ -64,10 +64,10 @@ class GitterEnrich(Enrich):
     HTML_LINK_REGEX = re.compile("href=[\"\'](.*?)[\"\']")
 
     def __init__(self, db_sortinghat=None, json_projects_map=None,
-                 db_user='', db_password='', db_host='', db_path=None,
-                 db_port=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
+                 db_user='', db_password='', db_host='', insecure=True, db_port=None,
+                 db_path=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
         super().__init__(db_sortinghat=db_sortinghat, json_projects_map=json_projects_map,
-                         db_user=db_user, db_password=db_password, db_host=db_host,
+                         db_user=db_user, db_password=db_password, db_host=db_host, insecure=insecure,
                          db_port=db_port, db_path=db_path, db_ssl=db_ssl, db_verify_ssl=db_verify_ssl,
                          db_tenant=db_tenant)
 

--- a/grimoire_elk/enriched/jenkins.py
+++ b/grimoire_elk/enriched/jenkins.py
@@ -60,11 +60,11 @@ class JenkinsEnrich(Enrich):
     MAIN_NODE_NAME = "main"
 
     def __init__(self, db_sortinghat=None, json_projects_map=None,
-                 db_user='', db_password='', db_host='', db_path=None,
-                 db_port=None, db_ssl=False, db_verify_ssl=True, db_tenant=None,
+                 db_user='', db_password='', db_host='', insecure=True, db_port=None,
+                 db_path=None, db_ssl=False, db_verify_ssl=True, db_tenant=None,
                  node_regex=None):
         super().__init__(db_sortinghat=db_sortinghat, json_projects_map=json_projects_map,
-                         db_user=db_user, db_password=db_password, db_host=db_host,
+                         db_user=db_user, db_password=db_password, db_host=db_host, insecure=insecure,
                          db_port=db_port, db_path=db_path, db_ssl=db_ssl, db_verify_ssl=db_verify_ssl,
                          db_tenant=db_tenant)
         self.nodes_rename_file = None

--- a/grimoire_elk/enriched/launchpad.py
+++ b/grimoire_elk/enriched/launchpad.py
@@ -62,10 +62,10 @@ class LaunchpadEnrich(Enrich):
     roles = ['assignee_data', 'owner_data']
 
     def __init__(self, db_sortinghat=None, json_projects_map=None,
-                 db_user='', db_password='', db_host='', db_path=None,
-                 db_port=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
+                 db_user='', db_password='', db_host='', insecure=True, db_port=None,
+                 db_path=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
         super().__init__(db_sortinghat=db_sortinghat, json_projects_map=json_projects_map,
-                         db_user=db_user, db_password=db_password, db_host=db_host,
+                         db_user=db_user, db_password=db_password, db_host=db_host, insecure=insecure,
                          db_port=db_port, db_path=db_path, db_ssl=db_ssl, db_verify_ssl=db_verify_ssl,
                          db_tenant=db_tenant)
 

--- a/grimoire_elk/enriched/mattermost.py
+++ b/grimoire_elk/enriched/mattermost.py
@@ -59,10 +59,10 @@ class MattermostEnrich(Enrich):
     mapping = Mapping
 
     def __init__(self, db_sortinghat=None, json_projects_map=None,
-                 db_user='', db_password='', db_host='', db_path=None,
-                 db_port=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
+                 db_user='', db_password='', db_host='', insecure=True, db_port=None,
+                 db_path=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
         super().__init__(db_sortinghat=db_sortinghat, json_projects_map=json_projects_map,
-                         db_user=db_user, db_password=db_password, db_host=db_host,
+                         db_user=db_user, db_password=db_password, db_host=db_host, insecure=insecure,
                          db_port=db_port, db_path=db_path, db_ssl=db_ssl, db_verify_ssl=db_verify_ssl,
                          db_tenant=db_tenant)
 

--- a/grimoire_elk/enriched/mbox.py
+++ b/grimoire_elk/enriched/mbox.py
@@ -66,10 +66,10 @@ class MBoxEnrich(Enrich):
     mapping = Mapping
 
     def __init__(self, db_sortinghat=None, json_projects_map=None,
-                 db_user='', db_password='', db_host='', db_path=None,
-                 db_port=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
+                 db_user='', db_password='', db_host='', insecure=True, db_port=None,
+                 db_path=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
         super().__init__(db_sortinghat=db_sortinghat, json_projects_map=json_projects_map,
-                         db_user=db_user, db_password=db_password, db_host=db_host,
+                         db_user=db_user, db_password=db_password, db_host=db_host, insecure=insecure,
                          db_port=db_port, db_path=db_path, db_ssl=db_ssl, db_verify_ssl=db_verify_ssl,
                          db_tenant=db_tenant)
 

--- a/grimoire_elk/enriched/pagure.py
+++ b/grimoire_elk/enriched/pagure.py
@@ -73,10 +73,10 @@ class PagureEnrich(Enrich):
     issue_roles = ['user', 'assignee']
 
     def __init__(self, db_sortinghat=None, json_projects_map=None,
-                 db_user='', db_password='', db_host='', db_path=None,
-                 db_port=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
+                 db_user='', db_password='', db_host='', insecure=True, db_port=None,
+                 db_path=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
         super().__init__(db_sortinghat=db_sortinghat, json_projects_map=json_projects_map,
-                         db_user=db_user, db_password=db_password, db_host=db_host,
+                         db_user=db_user, db_password=db_password, db_host=db_host, insecure=insecure,
                          db_port=db_port, db_path=db_path, db_ssl=db_ssl, db_verify_ssl=db_verify_ssl,
                          db_tenant=db_tenant)
 

--- a/grimoire_elk/enriched/phabricator.py
+++ b/grimoire_elk/enriched/phabricator.py
@@ -76,10 +76,10 @@ class PhabricatorEnrich(Enrich):
     roles = ['authorData', 'ownerData']
 
     def __init__(self, db_sortinghat=None, json_projects_map=None,
-                 db_user='', db_password='', db_host='', db_path=None,
-                 db_port=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
+                 db_user='', db_password='', db_host='', insecure=True, db_port=None,
+                 db_path=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
         super().__init__(db_sortinghat=db_sortinghat, json_projects_map=json_projects_map,
-                         db_user=db_user, db_password=db_password, db_host=db_host,
+                         db_user=db_user, db_password=db_password, db_host=db_host, insecure=insecure,
                          db_port=db_port, db_path=db_path, db_ssl=db_ssl, db_verify_ssl=db_verify_ssl,
                          db_tenant=db_tenant)
 

--- a/grimoire_elk/enriched/remo.py
+++ b/grimoire_elk/enriched/remo.py
@@ -59,10 +59,10 @@ class ReMoEnrich(Enrich):
     mapping = Mapping
 
     def __init__(self, db_sortinghat=None, json_projects_map=None,
-                 db_user='', db_password='', db_host='', db_path=None,
-                 db_port=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
+                 db_user='', db_password='', db_host='', insecure=True, db_port=None,
+                 db_path=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
         super().__init__(db_sortinghat=db_sortinghat, json_projects_map=json_projects_map,
-                         db_user=db_user, db_password=db_password, db_host=db_host,
+                         db_user=db_user, db_password=db_password, db_host=db_host, insecure=insecure,
                          db_port=db_port, db_path=db_path, db_ssl=db_ssl, db_verify_ssl=db_verify_ssl,
                          db_tenant=db_tenant)
         self.author = "user"  # changes if we are generating events

--- a/grimoire_elk/enriched/weblate.py
+++ b/grimoire_elk/enriched/weblate.py
@@ -60,10 +60,10 @@ class WeblateEnrich(Enrich):
     mapping = Mapping
 
     def __init__(self, db_sortinghat=None, json_projects_map=None,
-                 db_user='', db_password='', db_host='', db_path=None,
-                 db_port=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
+                 db_user='', db_password='', db_host='', insecure=True, db_port=None,
+                 db_path=None, db_ssl=False, db_verify_ssl=True, db_tenant=None):
         super().__init__(db_sortinghat=db_sortinghat, json_projects_map=json_projects_map,
-                         db_user=db_user, db_password=db_password, db_host=db_host,
+                         db_user=db_user, db_password=db_password, db_host=db_host, insecure=insecure,
                          db_port=db_port, db_path=db_path, db_ssl=db_ssl, db_verify_ssl=db_verify_ssl,
                          db_tenant=db_tenant)
 

--- a/releases/unreleased/argument-order-in-enrich-backends.yml
+++ b/releases/unreleased/argument-order-in-enrich-backends.yml
@@ -1,0 +1,8 @@
+---
+title: Argument order in enrich backends
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Resolves a bug where the arguments in some enrich
+  backends were defined in the wrong order.


### PR DESCRIPTION
This PR resolves a bug where the arguments in the `__init__` method of certain enrich backends were incorrectly ordered, or missing.

The original signature of the Enrich backend is:
```
def __init__(self, db_sortinghat=None, json_projects_map=None, db_user='',
             db_password='', db_host='', insecure=True, db_port=None, db_path=None,
             db_ssl=False, db_verify_ssl=True, db_tenant=None):
```

But the backends that overwrite that method had this signature:
```
def __init__(self, db_sortinghat=None, json_projects_map=None, db_user='',
             db_password='', db_host='', db_path=None, db_port=None,
             db_ssl=False, db_verify_ssl=True, db_tenant=None):
```

This change requires another change in sirmordred.