### PR TITLE
Individual id incorrectly assigned to identity id

### DIFF
--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -721,6 +721,7 @@ class Enrich(ElasticItems):
     def get_item_sh_fields(self, identity=None, item_date=None, sh_id=None,
                            rol='author'):
         """ Get standard SH fields from a SH identity """
+
         eitem_sh = self.__get_item_sh_fields_empty(rol)
 
         if identity:
@@ -849,8 +850,8 @@ class Enrich(ElasticItems):
             return sh_item
 
         # Fill the information needed with the identity, individual and profile
-        sh_item['id'] = individual['mk']
-        sh_item['uuid'] = identity_sh['uuid']
+        sh_item['id'] = identity_sh['uuid']
+        sh_item['uuid'] = individual['mk']
         sh_item['name'] = identity_sh['name']
         sh_item['username'] = identity_sh['username']
         sh_item['email'] = identity_sh['email']

--- a/releases/unreleased/field-author_uuid-incorrectly-assigned.yml
+++ b/releases/unreleased/field-author_uuid-incorrectly-assigned.yml
@@ -1,0 +1,8 @@
+---
+title: Individual `id` incorrectly assigned
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Correct a bug that results in enriched items using the individual ID
+  as the identity ID, and vice versa.


### PR DESCRIPTION
Correct a bug that results in enriched items using the individual ID as the identity ID, and vice versa.

This way:
- `author_uuid` = `individual.mk`
- `author_id` = `indentity.uuid`