### PR TITLE
Define the backend name for SortingHat identities

### DIFF
--- a/grimoire_elk/elk.py
+++ b/grimoire_elk/elk.py
@@ -375,14 +375,14 @@ def load_identities(ocean_backend, enrich_backend):
             if len(new_identities) >= 100:
                 SortingHat.add_identities(enrich_backend.sh_db,
                                           new_identities,
-                                          enrich_backend.get_connector_name())
+                                          enrich_backend.get_sh_backend_name())
                 identities_count += len(new_identities)
                 new_identities = []
 
     if new_identities:
         SortingHat.add_identities(enrich_backend.sh_db,
                                   new_identities,
-                                  enrich_backend.get_connector_name())
+                                  enrich_backend.get_sh_backend_name())
         identities_count += len(new_identities)
 
     return identities_count

--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -395,6 +395,11 @@ class Enrich(ElasticItems):
             self._connector_name = get_connector_name(type(self))
         return self._connector_name
 
+    def get_sh_backend_name(self):
+        """Retrieve the backend name for SortingHat identities."""
+
+        return self.get_connector_name()
+
     def get_field_author(self):
         """ Field with the author information """
         raise NotImplementedError
@@ -674,7 +679,7 @@ class Enrich(ElasticItems):
         username = identity.get('username', '')
         email = identity.get('email', '')
         name = identity.get('name', '')
-        backend_name = self.get_connector_name()
+        backend_name = self.get_sh_backend_name()
 
         if not (username or email or name):
             return self.__get_item_sh_fields_empty(rol)
@@ -725,7 +730,7 @@ class Enrich(ElasticItems):
         eitem_sh = self.__get_item_sh_fields_empty(rol)
 
         if identity:
-            sh_item = self.get_sh_item_from_identity(identity, self.get_connector_name())
+            sh_item = self.get_sh_item_from_identity(identity, self.get_sh_backend_name())
             eitem_sh[rol + "_id"] = sh_item.get('id', '')
             eitem_sh[rol + "_uuid"] = sh_item.get('uuid', '')
             eitem_sh[rol + "_name"] = identity.get('name', '')
@@ -1118,7 +1123,7 @@ class Enrich(ElasticItems):
 
     def add_sh_identities(self, identities):
         SortingHat.add_identities(self.sh_db, identities,
-                                  self.get_connector_name())
+                                  self.get_sh_backend_name())
 
     @lru_cache(4096)
     def add_sh_identity_cache(self, identity_tuple):
@@ -1129,7 +1134,7 @@ class Enrich(ElasticItems):
 
     def add_sh_identity(self, identity):
         SortingHat.add_identity(self.sh_db, identity,
-                                self.get_connector_name())
+                                self.get_sh_backend_name())
 
     def copy_raw_fields(self, copy_fields, source, target):
         """Copy fields from item to enriched item."""

--- a/grimoire_elk/enriched/git.py
+++ b/grimoire_elk/enriched/git.py
@@ -382,7 +382,7 @@ class GitEnrich(Enrich):
 
             if self.sortinghat:
                 # Create SH identity if it does not exist
-                backend_name = self.get_connector_name()
+                backend_name = self.get_sh_backend_name()
                 identity_id = self.generate_uuid(backend_name,
                                                  email=identity['email'],
                                                  name=identity['name'],

--- a/grimoire_elk/enriched/github2.py
+++ b/grimoire_elk/enriched/github2.py
@@ -122,6 +122,11 @@ class GitHubEnrich2(Enrich):
     def set_elastic(self, elastic):
         self.elastic = elastic
 
+    def get_sh_backend_name(self):
+        """Retrieve the backend name for SortingHat identities."""
+
+        return "github"
+
     def get_field_author(self):
         return "user_data"
 

--- a/releases/unreleased/sortinghat-backend-name-per-data-source.yml
+++ b/releases/unreleased/sortinghat-backend-name-per-data-source.yml
@@ -1,0 +1,9 @@
+---
+title: SortingHat backend name per data source
+category: added
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Allow to define the name of the backend for the identities
+  stored in SortingHat. From now on github2 is renamed as github
+  in SortingHat identities.

--- a/tests/test_load_identities.py
+++ b/tests/test_load_identities.py
@@ -95,7 +95,7 @@ class TestLoadIdentities(unittest.TestCase):
                 inserted_identities = self.load_bulk_identities(items_count,
                                                                 new_identities,
                                                                 self.enrich_backend.sh_db,
-                                                                self.enrich_backend.get_connector_name())
+                                                                self.enrich_backend.get_sh_backend_name())
                 identities_count += inserted_identities
                 new_identities = []
 
@@ -103,7 +103,7 @@ class TestLoadIdentities(unittest.TestCase):
             inserted_identities = self.load_bulk_identities(items_count,
                                                             new_identities,
                                                             self.enrich_backend.sh_db,
-                                                            self.enrich_backend.get_connector_name())
+                                                            self.enrich_backend.get_sh_backend_name())
             identities_count += inserted_identities
 
         stop = datetime.datetime.now().timestamp()


### PR DESCRIPTION
This PR allows to change the backend name for SortingHat identities. The GitHub2 backend is updated from 'github2' to 'github'. This way GitHub2 and GitHub share the same identity in SortingHat.

This change could break existing dashboards because the new github comments ids will be different from the old ones.