### PR TITLE
[bug] Incorrect date type in identity enrollment retrieval

### DIFF
--- a/grimoire_elk/enriched/jira.py
+++ b/grimoire_elk/enriched/jira.py
@@ -114,12 +114,10 @@ class JiraEnrich(Enrich):
         if not self.sortinghat:
             return eitem_sh
 
-        created = str_to_datetime(date_field)
-
         for rol in roles:
             identity = self.get_sh_identity(item, rol)
 
-            eitem_sh.update(self.get_item_sh_fields(identity, created, rol=rol))
+            eitem_sh.update(self.get_item_sh_fields(identity, date_field, rol=rol))
 
             if not eitem_sh[rol + '_org_name']:
                 eitem_sh[rol + '_org_name'] = SH_UNKNOWN_VALUE

--- a/grimoire_elk/enriched/mediawiki.py
+++ b/grimoire_elk/enriched/mediawiki.py
@@ -115,7 +115,7 @@ class MediaWikiEnrich(Enrich):
         """ Add sorting hat enrichment fields for the author of the revision """
 
         identity = self.get_sh_identity(revision)
-        update = str_to_datetime(item[self.get_field_date()])
+        update = item[self.get_field_date()]
         erevision = self.get_item_sh_fields(identity, update)
 
         return erevision

--- a/grimoire_elk/enriched/meetup.py
+++ b/grimoire_elk/enriched/meetup.py
@@ -277,7 +277,7 @@ class MeetupEnrich(Enrich):
         else:
             return sh_fields
 
-        created = unixtime_to_datetime(item['created'] / 1000)
+        created = unixtime_to_datetime(item['created'] / 1000).isoformat()
         if self.sortinghat:
             sh_fields = self.get_item_sh_fields(identity, created)
         else:

--- a/releases/unreleased/bug-on-some-backends-enrichment.yml
+++ b/releases/unreleased/bug-on-some-backends-enrichment.yml
@@ -1,0 +1,8 @@
+---
+title: Bug on some backends enrichment
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Mediawiki, Meetup are Jira were failing to retrieve
+  the enrollment for an identity.


### PR DESCRIPTION
Mediawiki, Meetup are Jira were failing to retrieve the enrollment for an identity. Because the date was not a string.