### PR TITLE
[raw/kitsune] Include mapping for data.metadata.value too big

### DIFF
--- a/grimoire_elk/raw/kitsune.py
+++ b/grimoire_elk/raw/kitsune.py
@@ -20,9 +20,44 @@
 #
 
 from .elastic import ElasticOcean
+from grimoire_elk.elastic_mapping import Mapping as BaseMapping
+
+
+class Mapping(BaseMapping):
+
+    @staticmethod
+    def get_elastic_mappings(es_major):
+        """Get Elasticsearch mapping.
+
+        :param es_major: major version of Elasticsearch, as string
+        :returns: dictionary with a key, 'items', with the mapping
+        """
+
+        mapping = '''
+         {
+            "dynamic":true,
+            "properties": {
+                "data": {
+                    "properties": {
+                        "metadata": {
+                            "dynamic":false,
+                            "properties": {
+                                "value": {
+                                    "type": "text",
+                                    "index": true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        '''
+
+        return {"items": mapping}
 
 
 class KitsuneOcean(ElasticOcean):
     """Kitsune Ocean feeder"""
 
-    pass
+    mapping = Mapping

--- a/releases/unreleased/kitsune-raw-mapping-updated.yml
+++ b/releases/unreleased/kitsune-raw-mapping-updated.yml
@@ -1,0 +1,9 @@
+---
+title: Kitsune raw mapping updated
+category: added
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Update the mapping for Kitsune backend to fix an error
+  inserting Perceval items in the raw index when the field
+  'data.metadata.value' is too big.


### PR DESCRIPTION
This PR includes the mapping for Kitsune to fix an error in inserting Perceval items when the field 'data.metadata.value' is too big.