### PR TITLE
[kitsune] Update enriched fields

### DIFF
--- a/grimoire_elk/enriched/kitsune.py
+++ b/grimoire_elk/enriched/kitsune.py
@@ -60,7 +60,13 @@ class Mapping(BaseMapping):
 
 class KitsuneEnrich(Enrich):
 
-    mappping = Mapping
+    mapping = Mapping
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.studies = []
+        self.studies.append(self.enrich_demography)
 
     def get_field_author(self):
         return "creator"

--- a/releases/unreleased/kitsune-demography-study.yml
+++ b/releases/unreleased/kitsune-demography-study.yml
@@ -4,4 +4,7 @@ category: added
 author: Jose Javier Merchante <jjmerchante@bitergia.com>
 issue: null
 notes: >
-  Include demography study in Kitsune (SUMO).
+  Include demography study in Kitsune (SUMO). And update
+  the index to include standard fields such as a unique
+  identifier (`id`) and some missing fields like `origin`
+  or `uuid`.

--- a/releases/unreleased/kitsune-demography-study.yml
+++ b/releases/unreleased/kitsune-demography-study.yml
@@ -1,0 +1,7 @@
+---
+title: Kitsune demography study
+category: added
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Include demography study in Kitsune (SUMO).


### PR DESCRIPTION
This PR allows to execute the demography study for Kitsune backend.

The enriched index now includes a unique identifier for questions and answers (`id`), this was causing an error when trying to autorefresh because `uuid` was missing.

Include the default raw fields in `answers` items that were missing: `metadata__updated_on` , `metadata__timestamp`, `offset`, `origin`, `tag`, and `uuid`.
