### PR TITLE
[kitsune] Handle immense terms for Kitsune

### DIFF
--- a/grimoire_elk/raw/kitsune.py
+++ b/grimoire_elk/raw/kitsune.py
@@ -38,6 +38,7 @@ class Mapping(BaseMapping):
             "dynamic":true,
             "properties": {
                 "data": {
+                    "dynamic":false,
                     "properties": {
                         "metadata": {
                             "dynamic":false,
@@ -47,6 +48,19 @@ class Mapping(BaseMapping):
                                     "index": true
                                 }
                             }
+                        },
+                        "answers_data": {
+                            "dynamic":false,
+                            "properties": {
+                                "content": {
+                                    "type": "text",
+                                    "index": true
+                                }
+                            }
+                        },
+                        "content": {
+                            "type": "text",
+                            "index": true
                         }
                     }
                 }

--- a/releases/unreleased/kitsune-inmerse-terms-error.yml
+++ b/releases/unreleased/kitsune-inmerse-terms-error.yml
@@ -1,0 +1,8 @@
+---
+title: Kitsune inmerse terms error
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Update raw mapping of Kitsune indexes to handle immense terms
+  found in `data.answers_data.content`, and `data.content`.


### PR DESCRIPTION
This code modifies the raw mapping of Kitsune indexes to handle immense terms found in `data.answers_data.content`, and `data.content`. Thus, the corresponding field is converted to text.