### PR TITLE
[MBOX] Remove credentials from origin and tag

### DIFF
--- a/grimoire_elk/raw/mbox.py
+++ b/grimoire_elk/raw/mbox.py
@@ -23,6 +23,7 @@ import logging
 
 from .elastic import ElasticOcean
 from ..elastic_mapping import Mapping as BaseMapping
+from ..enriched.utils import anonymize_url
 
 
 logger = logging.getLogger(__name__)
@@ -79,3 +80,7 @@ class MBoxOcean(ElasticOcean):
         for field in fields:
             if field.lower().startswith("x-"):
                 item["data"].pop(field)
+
+        # Remove credentials from URL
+        item['origin'] = anonymize_url(item['origin'])
+        item['tag'] = anonymize_url(item['tag'])

--- a/releases/unreleased/mbox-origin-url-anonymized.yml
+++ b/releases/unreleased/mbox-origin-url-anonymized.yml
@@ -1,0 +1,7 @@
+---
+title: MBOX origin URL anonymized
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Remove credentials from MBOX origin URL and tag fields.


### PR DESCRIPTION
This code redefines the method `_fix_item` for the MBOX raw data to remove credentials that may appear in the origin.