### PR TITLE
[kitsune] Include new fields for Kitsune backend

### DIFF
--- a/releases/unreleased/kitsune-fields-updated.yml
+++ b/releases/unreleased/kitsune-fields-updated.yml
@@ -1,0 +1,10 @@
+---
+title: Kitsune fields updated
+category: added
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Include new fields in Kitsune backend enriched index.
+  Include `product` and `url` fields in answers, and
+  `is_kitsune_question_solved`, `time_to_first_reply` and 
+  `url` in questions.


### PR DESCRIPTION
Include new fields in Kitsune backend enriched index. Include `product` and `url` fields in answers, and 
 `is_kitsune_question_solved`, `time_to_first_reply` and `url` in questions.

Closes https://github.com/chaoss/grimoirelab-elk/issues/1144, https://github.com/chaoss/grimoirelab-elk/issues/1145, https://github.com/chaoss/grimoirelab-elk/issues/1146, https://github.com/chaoss/grimoirelab-elk/issues/1147