### PR TITLE
Update Kitsune raw mapping

### DIFF
--- a/grimoire_elk/raw/kitsune.py
+++ b/grimoire_elk/raw/kitsune.py
@@ -38,7 +38,6 @@ class Mapping(BaseMapping):
             "dynamic":true,
             "properties": {
                 "data": {
-                    "dynamic":false,
                     "properties": {
                         "metadata": {
                             "dynamic":false,

--- a/releases/unreleased/kitsune-mapping-updated.yml
+++ b/releases/unreleased/kitsune-mapping-updated.yml
@@ -1,0 +1,8 @@
+---
+title: Kitsune mapping updated
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Kitsune raw mapping was incorrectly defined with
+  `dynamic: false` in the data attribute.


### PR DESCRIPTION
This PR updates the mapping for the raw index of Kitsune. It was not including all the fields because dynamic was set to false in the data attribute.