### PR TITLE
[git] Fix branches study that assigns wrong branches to commits

### DIFF
--- a/grimoire_elk/enriched/git.py
+++ b/grimoire_elk/enriched/git.py
@@ -1027,12 +1027,13 @@ class GitEnrich(Enrich):
         :param git_repo: GitRepository object
         :param enrich_backend: the enrich backend
         """
-        to_process = []
         for hash, refname in git_repo._discover_refs(remote=True):
 
             if not refname.startswith('refs/heads/'):
                 continue
 
+            # reset the counter
+            to_process = []
             commit_count = 0
             branch_name = refname.replace('refs/heads/', '')
 

--- a/releases/unreleased/git-branches-study-fixed.yml
+++ b/releases/unreleased/git-branches-study-fixed.yml
@@ -1,0 +1,8 @@
+---
+title: Git branches study fixed
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Git branches study was assigning branches to wrong
+  commits.


### PR DESCRIPTION
This PR fixes the Git branches study. There was a bug that didn't reset the list of commits assigned to branches, causing commits to be assigned to the wrong branches.