### PR TITLE
[github] Fix GitHub failing with URL ending with a slash

### DIFF
--- a/grimoire_elk/raw/github.py
+++ b/grimoire_elk/raw/github.py
@@ -95,6 +95,7 @@ class GitHubOcean(ElasticOcean):
         """ Get the perceval params given a URL for the data source """
         params = []
 
+        url = url.rstrip('/')
         owner = url.split('/')[-2]
         repository = url.split('/')[-1]
         params.append(owner)

--- a/releases/unreleased/github-url-ending-with-slash-failed.yml
+++ b/releases/unreleased/github-url-ending-with-slash-failed.yml
@@ -1,0 +1,7 @@
+---
+title: GitHub URL ending with slash failed
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: 1159
+notes: >
+  GrimoireLab failed to run with GitHub URLs ending in a slash

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -218,6 +218,12 @@ class TestGitHub(TestBaseBackend):
         ]
         self.assertListEqual(GitHubOcean.get_perceval_params_from_url(url), expected_params)
 
+        url = "https://github.com/chaoss/grimoirelab-perceval/"
+        expected_params = [
+            'chaoss', 'grimoirelab-perceval'
+        ]
+        self.assertListEqual(GitHubOcean.get_perceval_params_from_url(url), expected_params)
+
     def test_demography_study(self):
         """ Test that the demography study works correctly """
 


### PR DESCRIPTION
This commit fixes a bug that causes GrimoireLab to fail running GitHub URLs ending in a slash.

Fixes https://github.com/chaoss/grimoirelab-elk/issues/1159