### PR TITLE
Update the author's filter in autorefresh process

### DIFF
--- a/grimoire_elk/elk.py
+++ b/grimoire_elk/elk.py
@@ -262,7 +262,7 @@ def refresh_identities(enrich_backend, author_fields=None, individuals=None):
     def create_filter_authors(authors, to_refresh):
         filter_authors = []
         for author in authors:
-            author_name = author if author == 'author_uuid' else author + '_uuids'
+            author_name = author if author.endswith('_uuid') else author + '_uuids'
             field_author = {
                 "name": author_name,
                 "value": to_refresh

--- a/releases/unreleased/identity-refresh-bug-for-some-items.yml
+++ b/releases/unreleased/identity-refresh-bug-for-some-items.yml
@@ -1,0 +1,9 @@
+---
+title: Identity refresh bug for some items
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: 1161
+notes: >
+  Update the filter construction to correctly match UUIDs in
+  OpenSearch, addressing a bug in Mordred that prevented role
+  identities from being refreshed.


### PR DESCRIPTION
This PR updates the filter construction to correctly match UUIDs in OpenSearch, addressing a bug in Mordred that prevented role identities from being refreshed.


This PR with https://github.com/chaoss/grimoirelab-sirmordred/pull/626 fixes https://github.com/chaoss/grimoirelab-elk/issues/1161 