### PR TITLE
[enrich] Fix 'roles' attribute error

### DIFF
--- a/grimoire_elk/enriched/enrich.py
+++ b/grimoire_elk/enriched/enrich.py
@@ -101,6 +101,7 @@ class Enrich(ElasticItems):
     analyzer = Analyzer
     sh_db = None
     kibiter_version = None
+    roles = []
     RAW_FIELDS_COPY = ["metadata__updated_on", "metadata__timestamp",
                        "offset", "origin", "tag", "uuid"]
     KEYWORD_MAX_LENGTH = 1000  # this control allows to avoid max_bytes_length_exceeded_exception

--- a/releases/unreleased/roles-attribute-not-available-on-some-enrichers.yml
+++ b/releases/unreleased/roles-attribute-not-available-on-some-enrichers.yml
@@ -1,0 +1,10 @@
+---
+title: Roles attribute not available on some enrichers
+category: fixed
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: null
+notes: >
+  The 'roles' attribute wasn't available for all the
+  enrichers. The attribute has been added to the
+  main class 'Enrich' so subclasses will have it
+  available even when they don't use it.


### PR DESCRIPTION
The 'roles' attribute wasn't available for all the enrichers. The attribute has been added to the main class 'Enrich' so subclasses will have it available even when they don't use it.