### PR TITLE
[enrich] Avoid "-- UNDEFINED --" values

### DIFF
--- a/grimoire_elk/enriched/sortinghat_gelk.py
+++ b/grimoire_elk/enriched/sortinghat_gelk.py
@@ -143,8 +143,11 @@ class SortingHat(object):
         except SortingHatClientError as ex:
             for error in ex.errors:
                 msg = error['message']
+                status = error.get('status', None)
                 if 'already exists' in msg:
                     logger.debug("[sortinghat] {}".format(msg))
+                elif status and status == 502:
+                    raise SortingHatClientError(ex)
                 else:
                     logger.warning("[sortinghat] {}".format(msg))
 
@@ -361,6 +364,7 @@ class SortingHat(object):
                 entity = result['data']['individuals']['entities'][0]
         except SortingHatClientError as e:
             logger.error("[sortinghat] Error get entities {}: {}".format(id, e.errors[0]['message']))
+            raise SortingHatClientError(e)
         return entity
 
     @classmethod

--- a/releases/unreleased/avoid-undefined-values-in-author-fields.yml
+++ b/releases/unreleased/avoid-undefined-values-in-author-fields.yml
@@ -1,0 +1,10 @@
+---
+title: Avoid UNDEFINED values in author fields
+category: fixed
+author: Quan Zhou <quan@bitergia.com>
+issue: null
+notes: >
+    Avoid `-- UNDEFINED --` values for all SortingHat fields when
+    Mordred loses connection to the SortingHat server during the
+    enrichment or autorefresh execution. It will keep the values
+    of the `name`, `email`, `id` and `uuid` fields.

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -493,7 +493,7 @@ class TestGit(TestBaseBackend):
         url = self.es_con + "/test_git_onion/_search?size=50"
         response = requests.get(url, verify=False).json()
         hits = response['hits']['hits']
-        self.assertEqual(len(hits), 16)
+        self.assertEqual(len(hits), 28)
         for hit in hits:
             source = hit['_source']
             self.assertIn('timeframe', source)

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -405,7 +405,7 @@ class TestGitHub(TestBaseBackend):
         url = self.es_con + "/test_github_issues_onion/_search?size=20"
         response = requests.get(url, verify=False).json()
         hits = response['hits']['hits']
-        self.assertEqual(len(hits), 10)
+        self.assertEqual(len(hits), 12)
         for hit in hits:
             source = hit['_source']
             self.assertIn('timeframe', source)
@@ -426,7 +426,7 @@ class TestGitHub(TestBaseBackend):
         url = self.es_con + "/test_github_prs_onion/_search?size=20"
         response = requests.get(url, verify=False).json()
         hits = response['hits']['hits']
-        self.assertEqual(len(hits), 10)
+        self.assertEqual(len(hits), 12)
         for hit in hits:
             source = hit['_source']
             self.assertIn('timeframe', source)

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -314,7 +314,7 @@ class TestGitLab(TestBaseBackend):
         url = self.es_con + "/test_gitlab_onion/_search?size=50"
         response = requests.get(url, verify=False).json()
         hits = response['hits']['hits']
-        self.assertEqual(len(hits), 10)
+        self.assertEqual(len(hits), 22)
         for hit in hits:
             source = hit['_source']
             self.assertIn('timeframe', source)


### PR DESCRIPTION
Avoid `-- UNDEFINED --` values for all SortingHat fields when
Mordred loses connection to the SortingHat server during the
enrichment or autorefresh execution. It will keep the values
​of the `name`, `email`, `id` and `uuid` fields.