### PR TITLE
[git] Improve branches study for consistency

### DIFF
--- a/releases/unreleased/git-branches-study-improved.yml
+++ b/releases/unreleased/git-branches-study-improved.yml
@@ -1,0 +1,12 @@
+---
+title: Git branches study improved
+category: fixed
+author: null
+issue: null
+notes: >
+    Previously, while the branches study was running,
+    the `branches` field remained empty or partially filled
+    until the study was completed, leading to incorrect data
+    being displayed on the dashboard.
+    With this change, the branches field is updated only
+    after the study has finished.


### PR DESCRIPTION
Previously, while the branches study was running, the `branches` field remained empty or partially filled until the study was completed, leading to incorrect data being displayed on the dashboard.
With this change, the study is first created in an auxiliary field `branches_aux`, and once complete, the results are moved to the `branches` field.