### PR TITLE
Add reponse times for bugzilla indices

### DIFF
--- a/grimoire_elk/enriched/bugzilla.py
+++ b/grimoire_elk/enriched/bugzilla.py
@@ -195,10 +195,21 @@ class BugzillaEnrich(Enrich):
 
         # Add extra JSON fields used in Kibana (enriched fields)
         eitem['comments'] = 0
+        eitem['last_comment_date'] = None
         eitem['url'] = None
 
         if 'long_desc' in issue:
             eitem['comments'] = len(issue['long_desc'])
+
+            last_comment_date = None
+
+            if eitem['comments'] > 1:
+                last_comment = issue['long_desc'][-1]
+                last_comment_date = str_to_datetime(last_comment['bug_when'][0]['__text__'])
+                last_comment_date = last_comment_date.isoformat()
+
+            eitem['last_comment_date'] = last_comment_date
+
         eitem['url'] = item['origin'] + "/show_bug.cgi?id=" + issue['bug_id'][0]['__text__']
         eitem['resolution_days'] = \
             get_time_diff_days(eitem['creation_date'], eitem['delta_ts'])

--- a/grimoire_elk/enriched/bugzillarest.py
+++ b/grimoire_elk/enriched/bugzillarest.py
@@ -136,6 +136,7 @@ class BugzillaRESTEnrich(Enrich):
 
         # Add extra JSON fields used in Kibana (enriched fields)
         eitem['comments'] = 0
+        eitem['last_comment_date'] = None
         eitem['number_of_comments'] = 0
         eitem['time_to_last_update_days'] = None
         eitem['time_to_first_attention'] = None
@@ -146,8 +147,18 @@ class BugzillaRESTEnrich(Enrich):
 
         if 'long_desc' in issue:
             eitem['number_of_comments'] = len(issue['long_desc'])
+
         if 'comments' in issue:
             eitem['comments'] = len(issue['comments'])
+
+            last_comment_date = None
+
+            if eitem['comments'] > 1:
+                last_comment_date = str_to_datetime(issue['comments'][-1]['time'])
+                last_comment_date = last_comment_date.isoformat()
+
+            eitem['last_comment_date'] = last_comment_date
+
         eitem['url'] = item['origin'] + "/show_bug.cgi?id=" + str(issue['id'])
         eitem['time_to_last_update_days'] = \
             get_time_diff_days(eitem['creation_ts'], eitem['delta_ts'])

--- a/grimoire_elk/enriched/bugzillarest.py
+++ b/grimoire_elk/enriched/bugzillarest.py
@@ -138,6 +138,7 @@ class BugzillaRESTEnrich(Enrich):
         eitem['comments'] = 0
         eitem['number_of_comments'] = 0
         eitem['time_to_last_update_days'] = None
+        eitem['time_to_first_attention'] = None
         eitem['url'] = None
 
         # Add the field to know if the ticket is open
@@ -154,6 +155,9 @@ class BugzillaRESTEnrich(Enrich):
         eitem['timeopen_days'] = get_time_diff_days(eitem['creation_ts'], datetime_utcnow().replace(tzinfo=None))
         if 'is_open' in issue and not issue['is_open']:
             eitem['timeopen_days'] = eitem['time_to_last_update_days']
+
+        eitem['time_to_first_attention'] = \
+            get_time_diff_days(eitem['creation_ts'], self.get_time_to_first_attention(issue))
 
         eitem['changes'] = 0
         for history in issue['history']:
@@ -177,3 +181,28 @@ class BugzillaRESTEnrich(Enrich):
         self.add_repository_labels(eitem)
         self.add_metadata_filter_raw(eitem)
         return eitem
+
+    def get_time_to_first_attention(self, item):
+        """Set the time to first attention.
+
+        This date is defined as the first date at which a comment by someone
+        other than the user who created the issue.
+        """
+        if 'comments' not in item:
+            return None
+
+        comment_dates = []
+        creator = item['creator']
+
+        # First comment is the description of the issue
+        # Real comments start at the second position (index 1)
+        for comment in item['comments'][1:]:
+            user = comment['creator']
+            if user == creator:
+                continue
+            comment_dates.append(str_to_datetime(comment['time']).replace(tzinfo=None))
+
+        if comment_dates:
+            return min(comment_dates)
+        else:
+            return None

--- a/releases/unreleased/new-reponse-times-on-bugzilla-items.yml
+++ b/releases/unreleased/new-reponse-times-on-bugzilla-items.yml
@@ -1,0 +1,15 @@
+---
+title: New reponse times on bugzilla items
+category: added
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: null
+notes: >
+  The Bugzilla enriched items include two new
+  fields to track response times on these type
+  of repositories.
+  The field `time_to_first_attention` is the
+  the time expressed in days between the ticket
+  creation and the first comment from a contributor
+  different from the author creating the bug.
+  The field `last_comment_date` is the date of
+  the last comment posted in the bug.

--- a/schema/bugzilla.csv
+++ b/schema/bugzilla.csv
@@ -58,6 +58,7 @@ is_bugzillarest_bugrest,long
 is_open,boolean
 keywords,keyword
 labels,list
+last_comment_date,date
 main_description,keyword
 main_description_analyzed,string,false
 metadata__enriched_on,date

--- a/schema/bugzilla.csv
+++ b/schema/bugzilla.csv
@@ -110,6 +110,7 @@ severity,keyword
 status,keyword
 tag,keyword
 timeopen_days,float
+time_to_first_attention,float
 url,keyword
 uuid,keyword
 whiteboard,keyword

--- a/tests/data/bugzilla.json
+++ b/tests/data/bugzilla.json
@@ -181,8 +181,8 @@
         ],
         "reporter": [
             {
-                "__text__": "rocapal@example.org",
-                "name": "Roberto Calvo"
+                "__text__": "sduenas@example.org",
+                "name": "Santiago Due\u00f1as"
             }
         ],
         "reporter_accessible": [
@@ -507,8 +507,8 @@
         ],
         "reporter": [
             {
-                "__text__": "rocapal@example.org",
-                "name": "Roberto Calvo"
+                "__text__": "sduenas@example.org",
+                "name": "Santiago Due\u00f1as"
             }
         ],
         "reporter_accessible": [
@@ -668,8 +668,8 @@
                 ],
                 "who": [
                     {
-                        "__text__": "sduenas@example.org",
-                        "name": "Santiago Due\u00f1as"
+                        "__text__": "dizquierdo@example.org",
+                        "name": "Daniel Izquierdo Cortazar"
                     }
                 ]
             }
@@ -1026,8 +1026,8 @@
         ],
         "reporter": [
             {
-                "__text__": "rocapal@example.com",
-                "name": "Roberto Calvo"
+                "__text__": "sduenas@example.org",
+                "name": "Santiago Due\u00f1as"
             }
         ],
         "reporter_accessible": [
@@ -1251,8 +1251,8 @@
         ],
         "reporter": [
             {
-                "__text__": "rocapal@example.org",
-                "name": "Roberto Calvo"
+                "__text__": "sduenas@example.org",
+                "name": "Santiago Due\u00f1as"
             }
         ],
         "reporter_accessible": [
@@ -1446,8 +1446,8 @@
         ],
         "reporter": [
             {
-                "__text__": "dizquierdo@example.org",
-                "name": "Daniel Izquierdo Cortazar"
+                "__text__": "sduenas@example.org",
+                "name": "Santiago Due\u00f1as"
             }
         ],
         "reporter_accessible": [
@@ -1661,7 +1661,7 @@
         ],
         "creation_ts": [
             {
-                "__text__": "2015-05-23 06:06:06 +0200"
+                "__text__": "2013-06-25 11:49:36 +0200"
             }
         ],
         "delta_ts": [
@@ -1720,7 +1720,7 @@
                 ],
                 "bug_when": [
                     {
-                        "__text__": "2013-06-25 11:55:46 +0200"
+                        "__text__": "2013-07-01 12:00:00 +0200"
                     }
                 ],
                 "commentid": [
@@ -1732,6 +1732,96 @@
                 "thetext": [
                     {
                         "__text__": "A mock patch for this bug"
+                    }
+                ],
+                "who": [
+                    {
+                        "__text__": "sduenas@example.org",
+                        "name": "Santiago Due\u00f1as"
+                    }
+                ]
+            },
+            {
+                "__text__": "\n            ",
+                "attachid": [
+                    {
+                        "__text__": "172"
+                    }
+                ],
+                "bug_when": [
+                    {
+                        "__text__": "2014-06-25 11:55:46 +0200"
+                    }
+                ],
+                "commentid": [
+                    {
+                        "__text__": "1086"
+                    }
+                ],
+                "isprivate": "0",
+                "thetext": [
+                    {
+                        "__text__": "This patch is great"
+                    }
+                ],
+                "who": [
+                    {
+                        "__text__": "lcanas@example.org",
+                        "name": "Luis Ca\u00f1as"
+                    }
+                ]
+            },
+            {
+                "__text__": "\n            ",
+                "attachid": [
+                    {
+                        "__text__": "172"
+                    }
+                ],
+                "bug_when": [
+                    {
+                        "__text__": "2014-06-25 11:55:46 +0200"
+                    }
+                ],
+                "commentid": [
+                    {
+                        "__text__": "1086"
+                    }
+                ],
+                "isprivate": "0",
+                "thetext": [
+                    {
+                        "__text__": "Thanks!"
+                    }
+                ],
+                "who": [
+                    {
+                        "__text__": "sduenas@example.org",
+                        "name": "Santiago Due\u00f1as"
+                    }
+                ]
+            },
+            {
+                "__text__": "\n            ",
+                "attachid": [
+                    {
+                        "__text__": "172"
+                    }
+                ],
+                "bug_when": [
+                    {
+                        "__text__": "2014-08-01 11:55:46 +0200"
+                    }
+                ],
+                "commentid": [
+                    {
+                        "__text__": "1086"
+                    }
+                ],
+                "isprivate": "0",
+                "thetext": [
+                    {
+                        "__text__": "Applied"
                     }
                 ],
                 "who": [
@@ -1770,8 +1860,8 @@
         ],
         "reporter": [
             {
-                "__text__": "carlosgc@example.com",
-                "name": "Carlos Garcia Campos"
+                "__text__": "sduenas@example.org",
+                "name": "Santiago Due\u00f1as"
             }
         ],
         "reporter_accessible": [

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -19,6 +19,7 @@
 #     Alvaro del Castillo <acs@bitergia.com>
 #     Valerio Cosentino <valcos@bitergia.com>
 #
+
 import logging
 import unittest
 
@@ -104,6 +105,26 @@ class TestBugzilla(TestBaseBackend):
         for index in range(0, len(self.items)):
             eitem = enrich_backend.get_rich_item(self.items[index])
             self.assertEqual(eitem['time_to_first_attention'], expected[index])
+
+    def test_last_comment_date(self):
+        """Test whether last_comment_date is added to the enriched item"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        expected = [
+            "2013-06-25T11:55:46+02:00",
+            "2013-06-25T11:55:46+02:00",
+            None,
+            "2013-06-25T11:55:46+02:00",
+            "2013-06-25T11:55:46+02:00",
+            None,
+            "2014-08-01T11:55:46+02:00"
+        ]
+
+        for index in range(0, len(self.items)):
+            eitem = enrich_backend.get_rich_item(self.items[index])
+            self.assertEqual(eitem['last_comment_date'], expected[index])
 
     def test_raw_to_enrich_sorting_hat(self):
         """Test enrich with SortingHat"""

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -93,6 +93,18 @@ class TestBugzilla(TestBaseBackend):
             eitem = enrich_backend.get_rich_item(item)
             self.assertEqual(eitem['keywords'], [])
 
+    def test_time_to_first_attention(self):
+        """Test whether time_to_first_attention is calculated"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        expected = [None, None, None, None, None, None, 365]
+
+        for index in range(0, len(self.items)):
+            eitem = enrich_backend.get_rich_item(self.items[index])
+            self.assertEqual(eitem['time_to_first_attention'], expected[index])
+
     def test_raw_to_enrich_sorting_hat(self):
         """Test enrich with SortingHat"""
 

--- a/tests/test_bugzillarest.py
+++ b/tests/test_bugzillarest.py
@@ -103,6 +103,26 @@ class TestBugzillaRest(TestBaseBackend):
             eitem = enrich_backend.get_rich_item(self.items[index])
             self.assertEqual(eitem['time_to_first_attention'], expected[index])
 
+    def test_last_comment_date(self):
+        """Test whether last_comment_date is added to the enriched item"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        expected = [
+            "2016-07-27T07:35:45+00:00",
+            "2016-07-27T10:00:54+00:00",
+            "2016-07-27T10:02:00+00:00",
+            "2016-07-27T10:02:14+00:00",
+            "2016-06-07T00:01:29+00:00",
+            None,
+            None
+        ]
+
+        for index in range(0, len(self.items)):
+            eitem = enrich_backend.get_rich_item(self.items[index])
+            self.assertEqual(eitem['last_comment_date'], expected[index])
+
     def test_raw_to_enrich_sorting_hat(self):
         """Test enrich with SortingHat"""
 

--- a/tests/test_bugzillarest.py
+++ b/tests/test_bugzillarest.py
@@ -91,6 +91,18 @@ class TestBugzillaRest(TestBaseBackend):
         eitem = enrich_backend.get_rich_item(item)
         self.assertEqual(eitem['keywords'], ['crash', 'regression'])
 
+    def test_time_to_first_attention(self):
+        """Test whether time_to_first_attention is calculated"""
+
+        self._test_raw_to_enrich()
+        enrich_backend = self.connectors[self.connector][2]()
+
+        expected = [7.23, 0.03, 0.2, 2.31, 9.88, None, None]
+
+        for index in range(0, len(self.items)):
+            eitem = enrich_backend.get_rich_item(self.items[index])
+            self.assertEqual(eitem['time_to_first_attention'], expected[index])
+
     def test_raw_to_enrich_sorting_hat(self):
         """Test enrich with SortingHat"""
 


### PR DESCRIPTION
The Bugzilla enriched items include two new fields to track response times on these type of repositories:

- `time_to_first_attention` is the the time expressed in days between the ticket creation and the first comment from a contributor different from the author creating the bug.
- `last_comment_date` is the date of the last comment posted in the bug.