### PR TITLE
[enriched/githubql] Fix enrich_reference_analysis study

### DIFF
--- a/releases/unreleased/the-enrich_reference_analysis-study-process-all-references.yml
+++ b/releases/unreleased/the-enrich_reference_analysis-study-process-all-references.yml
@@ -1,0 +1,11 @@
+---
+title: All references processed for the reference analysis study
+category: fixed
+author: Quan Zhou <quan@bitergia.com>
+issue: null
+notes: >
+    The `enrich_reference_analysis` study analyzes the cross-references
+    between "issues" and "pull request". When we use an aggregations query,
+    it returns only the first 10 items (ElasticSearch/OpenSearch by default).
+    By using 'composite aggregations', we can paginate the result and thus,
+    obtain all the references.


### PR DESCRIPTION
This code fixes the `enrich_reference_analysis` study that only processed the first 10 references instead of all of them. By default, the ElasticSearch/OpenSearch `aggregations` query only returns the first 10 documents. Using `composite aggregations` we can paginate the result to get all the references.

Fixes #1172