### PR TITLE
Migrate files for branch rename from master to main

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,4 +9,4 @@ jobs:
   check-changelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: bitergia/release-tools-check-changelog@master
+      - uses: bitergia/release-tools-check-changelog@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Build package using Poetry and store result.
-        uses: chaoss/grimoirelab-github-actions/build@master
+        uses: chaoss/grimoirelab-github-actions/build@main
         with:
           artifact-name: grimoire-elk-dist
           artifact-path: dist
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create a new release for the repository.
-        uses: chaoss/grimoirelab-github-actions/release@master
+        uses: chaoss/grimoirelab-github-actions/release@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Publish the package in PyPI.
-        uses: chaoss/grimoirelab-github-actions/publish@master
+        uses: chaoss/grimoirelab-github-actions/publish@main
         with:
           artifact-name: grimoire-elk-dist
           artifact-path: dist

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Welcome to GrimoireELK [![Build Status](https://github.com/chaoss/grimoirelab-elk/workflows/tests/badge.svg)](https://github.com/chaoss/grimoirelab-elk/actions?query=workflow:tests+branch:master+event:push) [![Coverage Status](https://coveralls.io/repos/github/chaoss/grimoirelab-elk/badge.svg?branch=master)](https://coveralls.io/github/chaoss/grimoirelab-elk?branch=master) [![PyPI version](https://badge.fury.io/py/grimoire-elk.svg)](https://badge.fury.io/py/grimoire-elk) 
+# Welcome to GrimoireELK [![Build Status](https://github.com/chaoss/grimoirelab-elk/workflows/tests/badge.svg)](https://github.com/chaoss/grimoirelab-elk/actions?query=workflow:tests+branch:main+event:push) [![Coverage Status](https://coveralls.io/repos/github/chaoss/grimoirelab-elk/badge.svg?branch=main)](https://coveralls.io/github/chaoss/grimoirelab-elk?branch=main) [![PyPI version](https://badge.fury.io/py/grimoire-elk.svg)](https://badge.fury.io/py/grimoire-elk) 
 
 GrimoireELK is the component of [GrimoireLab](https://github.com/chaoss/grimoirelab) that interacts with the ElasticSearch database. Its goal is two-fold, first it aims at offering a convenient
 way to store the data coming from Perceval, second it processes and enriches the data in a format that can be consumed by Kibiter.
@@ -115,7 +115,7 @@ profile information (i.e., identity fields) or (iv) to the project listed in the
 - **extra_** (anything): Extra fields added using the `enrich_extra_data` study.
 
 #### Data source specific fields
-Details of the fields of each data source is available in the [Schema](https://github.com/chaoss/grimoirelab-elk/tree/master/schema) folder.
+Details of the fields of each data source is available in the [Schema](https://github.com/chaoss/grimoirelab-elk/tree/main/schema) folder.
 
 ## Installation
 
@@ -165,18 +165,18 @@ $ poetry shell
 
 ## Running tests
 
-Tests are located in the folder [tests](https://github.com/chaoss/grimoirelab-elk/tree/master/tests). 
+Tests are located in the folder [tests](https://github.com/chaoss/grimoirelab-elk/tree/main/tests). 
 In order to run them, you need to have in your machine instances (or Docker containers) of ElasticSearch and MySQL
 
 Then you need to:
-- update the file [tests.conf](https://github.com/chaoss/grimoirelab-elk/blob/master/tests/tests.conf) file:
+- update the file [tests.conf](https://github.com/chaoss/grimoirelab-elk/blob/main/tests/tests.conf) file:
   - in case your ElasticSearch instance isn't available at `http://localhost:9200`. For example, if you are using the secure edition of elasticsearch, it will be located at `https://admin:admin@localhost:9200`
   - in case you are using non-default credentials for your SortingHat database, you will need to include the `[Database]` section of the file with both `user` and `password` parameters
 - create the databases `test_sh` and `test_projects` in your MySQL instance (e.g., `mysql -u root -e "create database test_sh"`, if you are running mysql in a container use `docker exec -i <container id> mysql -u root -e "create database test_sh"`)
-- populate the database `test_projects` with the SQL file [test_projects.sql](https://github.com/chaoss/grimoirelab-elk/blob/master/tests/test_projects.sql) (e.g., `mysql -u root test_projects < tests/test_projects.sql`)
+- populate the database `test_projects` with the SQL file [test_projects.sql](https://github.com/chaoss/grimoirelab-elk/blob/main/tests/test_projects.sql) (e.g., `mysql -u root test_projects < tests/test_projects.sql`)
 
-The full battery of tests can be executed with [run_tests.py](https://github.com/chaoss/grimoirelab-elk/blob/master/tests/run_tests.py). However, it is also possible to execute
-a sub-set of tests by running the single test files (`test_*` files in the [tests folder](https://github.com/chaoss/grimoirelab-elk/tree/master/tests))
+The full battery of tests can be executed with [run_tests.py](https://github.com/chaoss/grimoirelab-elk/blob/main/tests/run_tests.py). However, it is also possible to execute
+a sub-set of tests by running the single test files (`test_*` files in the [tests folder](https://github.com/chaoss/grimoirelab-elk/tree/main/tests))
 
 The tests can be run in combination with the Python package `coverage`. The steps below show how to do it:
 ```buildoutcfg

--- a/doc/studies.md
+++ b/doc/studies.md
@@ -17,7 +17,7 @@ It expects to find an input index named `git_aoc-raw`, a git raw index containin
 data to apply this study on.
 
 ### Results
-As output, you will get an index following our [areas of code index fields convention](https://github.com/chaoss/grimoirelab-elk/blob/master/schema/areas_of_code.csv). This index will be named `git_aoc-enriched`.
+As output, you will get an index following our [areas of code index fields convention](https://github.com/chaoss/grimoirelab-elk/blob/main/schema/areas_of_code.csv). This index will be named `git_aoc-enriched`.
 
 Additionally, an alias named `git_areas_of_code` pointing to above's index is created if it doesn't exist.
 
@@ -104,7 +104,7 @@ filter out, for instance, **bots** and **empty commits** in Git.
 
 ### Results: 
 
-As output, you will get an index following our [onion index fields convention](https://github.com/chaoss/grimoirelab-elk/blob/master/schema/onion.csv).
+As output, you will get an index following our [onion index fields convention](https://github.com/chaoss/grimoirelab-elk/blob/main/schema/onion.csv).
 This index will be named:
 * **Git**: `git_onion-enriched`.
 * **GitHub Issues**: `github_issues_onion-enriched`.


### PR DESCRIPTION
Update files to support the migration of GrimoireLab repositories as part of the default branch transition from master to main.