### PR TITLE
Fix incorrect from-date enriching behavior

### DIFF
--- a/releases/unreleased/incorrect-from-date-behavior-for-enrich-tasks.yml
+++ b/releases/unreleased/incorrect-from-date-behavior-for-enrich-tasks.yml
@@ -1,0 +1,9 @@
+---
+title: Incorrect `from-date` behavior for enrich tasks
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Enriching no longer uses the `from-date` parameter, which is only
+  intended for collection.
+  This fixes an issue causing all GitHub items to be enriched.


### PR DESCRIPTION
Remove enriching behavior using `from-date` parameter because it should only apply to collection, not enriching.

There was a bug where `from-date` was being compared against `1970-01-01`, which is incorrect since each backend has its own default `from-date`. This caused enrich tasks to enrich all items based on a shared default value instead of their backend-specific value.

Additionally, using `from-date` value from configuration was causing items collected after that date to be enriched, rather than enriching only the items that were updated in the origin data source since that date.

Removing that code fixes an issue that was causing all items from GitHub to be enriched instead of enriching only those items that are inserted after `metadata__timestamp`.