### PR TITLE
[enriched/github] Fix assignee fields

### DIFF
--- a/grimoire_elk/enriched/github.py
+++ b/grimoire_elk/enriched/github.py
@@ -581,9 +581,10 @@ class GitHubEnrich(Enrich):
             assignee = issue['assignee_data']
             rich_issue['assignee_login'] = assignee['login']
             rich_issue['assignee_name'] = assignee['name']
-            rich_issue["assignee_domain"] = self.get_email_domain(assignee['email']) if assignee['email'] else None
-            rich_issue['assignee_org'] = assignee['company']
-            rich_issue['assignee_location'] = assignee['location']
+            rich_issue["assignee_domain"] = self.get_email_domain(assignee['email']) if ('email' in assignee
+                                                                                         and assignee['email']) else None
+            rich_issue['assignee_org'] = assignee['company'] if 'company' in assignee else None
+            rich_issue['assignee_location'] = assignee['location'] if 'location' in assignee else None
             rich_issue['assignee_geolocation'] = None
         else:
             rich_issue['assignee_name'] = None

--- a/releases/unreleased/github-assignee-keyerror-in-enriched-index.yml
+++ b/releases/unreleased/github-assignee-keyerror-in-enriched-index.yml
@@ -1,0 +1,8 @@
+---
+title: GitHub assignee KeyError in enriched index
+category: fixed
+author: Quan Zhou
+issue: null
+notes: >
+    Fix the `KeyError` when the issue was assigned to a deleted user.
+    A deleted user don't have `email`, `company`, and `location` fields.


### PR DESCRIPTION
This commit fixes the `KeyError` when the issue was assigned to a deleted user.

A deleted user does not have these fields:
- email
- company
- location