### PR TITLE
Reduce the number of jobs in workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12"]
         opensearch-version: [ "2", "3" ]
     services:
       mysql:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12"]
         opensearch-version: ["2", "3"]
     services:
       mysql:


### PR DESCRIPTION
This PR removes Python 3.13 from the tests and release workflows to prevent creating a large number of jobs for each test.