### PR TITLE
Sync AOC and Git raw indexes error

### DIFF
--- a/grimoire_elk/enriched/git.py
+++ b/grimoire_elk/enriched/git.py
@@ -677,7 +677,7 @@ class GitEnrich(Enrich):
             if until_date:
                 fltr.append({
                     "range": {
-                        "metadata__updated_on": {
+                        "grimoire_creation_date": {
                             "gte": until_date
                         }
                     }

--- a/releases/unreleased/sync-aoc-and-git-raw-indexes-error.yml
+++ b/releases/unreleased/sync-aoc-and-git-raw-indexes-error.yml
@@ -1,0 +1,9 @@
+---
+title: Sync AOC and Git raw indexes error
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  An error occurred in the Areas of Code study, where syncing
+  the AOC and the Git raw index caused an infinite loop due
+  to using different dates for filtering


### PR DESCRIPTION
An error occurred in the Areas of Code study, where syncing the AOC and the Git raw index caused an infinite loop due to using different dates for filtering